### PR TITLE
Add maximum complexity of all methods as a metric

### DIFF
--- a/src/main/java/edu/hm/hafner/coverage/Metric.java
+++ b/src/main/java/edu/hm/hafner/coverage/Metric.java
@@ -35,6 +35,7 @@ public enum Metric {
     MUTATION(new ValuesAggregator()),
     COMPLEXITY(new ValuesAggregator()),
     COMPLEXITY_DENSITY(new DensityEvaluator()),
+    COMPLEXITY_MAXIMUM(new MethodMaxComplexityFinder()),
     LOC(new LocEvaluator());
 
     /**
@@ -171,6 +172,24 @@ public enum Metric {
                 }
             }
             return Optional.empty();
+        }
+    }
+
+    private static class MethodMaxComplexityFinder extends MetricEvaluator {
+        @Override
+        public boolean isAggregatingChildren() {
+            return false;
+        }
+
+        @Override
+        Optional<Value> compute(final Node node, final Metric searchMetric) {
+            if (node.getMetric() == Metric.METHOD) {
+                return COMPLEXITY.getValueFor(node);
+            }
+            return node.getChildren().stream()
+                    .map(c -> compute(c, searchMetric))
+                    .flatMap(Optional::stream)
+                    .reduce(Value::max);
         }
     }
 

--- a/src/main/java/edu/hm/hafner/coverage/Node.java
+++ b/src/main/java/edu/hm/hafner/coverage/Node.java
@@ -110,6 +110,9 @@ public abstract class Node implements Serializable {
                 elements.add(Metric.COMPLEXITY_DENSITY);
             }
         }
+        if (elements.contains(Metric.COMPLEXITY)) {
+            elements.add(Metric.COMPLEXITY_MAXIMUM);
+        }
         return elements;
     }
 

--- a/src/main/java/edu/hm/hafner/coverage/Value.java
+++ b/src/main/java/edu/hm/hafner/coverage/Value.java
@@ -93,6 +93,7 @@ public abstract class Value implements Serializable {
                     case COMPLEXITY_DENSITY:
                         return new FractionValue(metric, Fraction.getFraction(value));
                     case COMPLEXITY:
+                    case COMPLEXITY_MAXIMUM:
                         return new CyclomaticComplexity(Integer.parseInt(value));
                     case LOC:
                         return new LinesOfCode(Integer.parseInt(value));

--- a/src/test/java/edu/hm/hafner/coverage/parser/CoberturaParserTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/parser/CoberturaParserTest.java
@@ -113,7 +113,7 @@ class CoberturaParserTest extends AbstractParserTest {
         var builder = new CoverageBuilder();
 
         assertThat(tree).hasOnlyMetrics(MODULE, PACKAGE, FILE, CLASS, METHOD, LINE, BRANCH, COMPLEXITY,
-                COMPLEXITY_DENSITY, LOC);
+                COMPLEXITY_DENSITY, COMPLEXITY_MAXIMUM, LOC);
         assertThat(tree.aggregateValues()).containsExactly(
                 builder.setMetric(MODULE).setCovered(1).setMissed(0).build(),
                 builder.setMetric(PACKAGE).setCovered(1).setMissed(0).build(),
@@ -124,6 +124,7 @@ class CoberturaParserTest extends AbstractParserTest {
                 builder.setMetric(BRANCH).setCovered(3).setMissed(1).build(),
                 new CyclomaticComplexity(8),
                 new FractionValue(COMPLEXITY_DENSITY, 8, 42 + 9),
+                new CyclomaticComplexity(4),
                 new LinesOfCode(42 + 9));
     }
 
@@ -146,7 +147,7 @@ class CoberturaParserTest extends AbstractParserTest {
         var builder = new CoverageBuilder();
 
         assertThat(tree).hasOnlyMetrics(MODULE, PACKAGE, FILE, CLASS, METHOD, LINE, BRANCH, COMPLEXITY,
-                COMPLEXITY_DENSITY, LOC);
+                COMPLEXITY_DENSITY, COMPLEXITY_MAXIMUM, LOC);
         assertThat(tree.aggregateValues()).containsExactly(
                 builder.setMetric(MODULE).setCovered(1).setMissed(0).build(),
                 builder.setMetric(PACKAGE).setCovered(1).setMissed(0).build(),
@@ -157,6 +158,7 @@ class CoberturaParserTest extends AbstractParserTest {
                 builder.setMetric(BRANCH).setCovered(6).setMissed(0).build(),
                 new CyclomaticComplexity(0),
                 new FractionValue(COMPLEXITY_DENSITY, 0, 9),
+                new CyclomaticComplexity(0),
                 new LinesOfCode(9));
     }
 
@@ -173,7 +175,7 @@ class CoberturaParserTest extends AbstractParserTest {
         var builder = new CoverageBuilder();
 
         assertThat(root).hasOnlyMetrics(MODULE, PACKAGE, FILE, CLASS, METHOD, LINE, BRANCH, COMPLEXITY,
-                COMPLEXITY_DENSITY, LOC);
+                COMPLEXITY_DENSITY, COMPLEXITY_MAXIMUM, LOC);
         assertThat(root.aggregateValues()).containsExactly(
                 builder.setMetric(MODULE).setCovered(1).setMissed(0).build(),
                 builder.setMetric(PACKAGE).setCovered(1).setMissed(0).build(),
@@ -184,6 +186,7 @@ class CoberturaParserTest extends AbstractParserTest {
                 builder.setMetric(BRANCH).setCovered(2).setMissed(2).build(),
                 new CyclomaticComplexity(22),
                 new FractionValue(COMPLEXITY_DENSITY, 22, 61 + 19),
+                new CyclomaticComplexity(7),
                 new LinesOfCode(61 + 19));
 
         assertThat(root.getChildren()).extracting(Node::getName)
@@ -286,7 +289,7 @@ class CoberturaParserTest extends AbstractParserTest {
         assertThat(result.getValue(BRANCH)).isPresent().get().isInstanceOfSatisfying(Coverage.class,
                 coverage -> assertThat(coverage).hasCovered(4).hasMissed(0));
         assertThat(result).hasOnlyMetrics(MODULE, PACKAGE, FILE, CLASS, LINE, BRANCH, LOC, COMPLEXITY,
-                COMPLEXITY_DENSITY);
+                COMPLEXITY_DENSITY, COMPLEXITY_MAXIMUM);
 
         var fileNode = result.getAllFileNodes().get(0);
         assertThat(fileNode.getLinesWithCoverage())

--- a/src/test/java/edu/hm/hafner/coverage/parser/JacocoParserTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/parser/JacocoParserTest.java
@@ -49,7 +49,7 @@ class JacocoParserTest extends AbstractParserTest {
         assertThat(tree.getAll(METHOD)).hasSize(102);
 
         assertThat(tree).hasOnlyMetrics(MODULE, PACKAGE, FILE, CLASS, METHOD, LINE, INSTRUCTION, BRANCH,
-                COMPLEXITY, COMPLEXITY_DENSITY, LOC);
+                COMPLEXITY, COMPLEXITY_DENSITY, COMPLEXITY_MAXIMUM, LOC);
 
         var builder = new CoverageBuilder();
 
@@ -64,6 +64,7 @@ class JacocoParserTest extends AbstractParserTest {
                 builder.setMetric(INSTRUCTION).setCovered(1260).setMissed(90).build(),
                 new CyclomaticComplexity(160),
                 new FractionValue(COMPLEXITY_DENSITY, 160, 294 + 29),
+                new CyclomaticComplexity(6),
                 new LinesOfCode(294 + 29));
 
         assertThat(tree.getChildren()).hasSize(1)


### PR DESCRIPTION
Summing up the complexities of all methods might be not a good metric for a project. It makes more sense to look at the maximum complexity of all methods.