### PR TITLE
Add a metric tendency

### DIFF
--- a/src/main/java/edu/hm/hafner/coverage/Coverage.java
+++ b/src/main/java/edu/hm/hafner/coverage/Coverage.java
@@ -145,8 +145,8 @@ public final class Coverage extends Value {
     }
 
     /**
-     * Returns whether this coverage is below the given threshold. The threshold must be a percentage in the range of
-     * [0, 100].
+     * Returns whether this coverage percentage is below the given threshold. The threshold must be a percentage in the
+     * range of [0, 100].
      *
      * @param threshold
      *         the threshold in the range of [0, 100]
@@ -154,7 +154,7 @@ public final class Coverage extends Value {
      * @return {@code true}, if this value is below the specified threshold
      */
     @Override
-    public boolean isBelowThreshold(final double threshold) {
+    public boolean isOutOfValidRange(final double threshold) {
         return getCoveredPercentage().toDouble() < threshold;
     }
 
@@ -233,7 +233,8 @@ public final class Coverage extends Value {
                 for (int missed = 0; missed < CACHE_SIZE; missed++) {
                     LINE_CACHE[getCacheIndex(covered, missed)] = new Coverage(Metric.LINE, covered, missed);
                     BRANCH_CACHE[getCacheIndex(covered, missed)] = new Coverage(Metric.BRANCH, covered, missed);
-                    INSTRUCTION_CACHE[getCacheIndex(covered, missed)] = new Coverage(Metric.INSTRUCTION, covered, missed);
+                    INSTRUCTION_CACHE[getCacheIndex(covered, missed)] = new Coverage(Metric.INSTRUCTION, covered,
+                            missed);
                     MUTATION_CACHE[getCacheIndex(covered, missed)] = new Coverage(Metric.MUTATION, covered, missed);
                 }
             }

--- a/src/main/java/edu/hm/hafner/coverage/CyclomaticComplexity.java
+++ b/src/main/java/edu/hm/hafner/coverage/CyclomaticComplexity.java
@@ -10,12 +10,25 @@ public final class CyclomaticComplexity extends IntegerValue {
 
     /**
      * Creates a new {@link CyclomaticComplexity} instance with the specified complexity.
+     * The metric is set to {@link Metric#COMPLEXITY}.
      *
      * @param complexity
      *         the cyclomatic complexity
      */
     public CyclomaticComplexity(final int complexity) {
-        super(Metric.COMPLEXITY, complexity);
+        this(complexity, Metric.COMPLEXITY);
+    }
+
+    /**
+     * Creates a new {@link CyclomaticComplexity} instance with the specified complexity.
+     *
+     * @param complexity
+     *         the cyclomatic complexity
+     * @param metric
+     *         the metric of this value
+     */
+    public CyclomaticComplexity(final int complexity, final Metric metric) {
+        super(metric, complexity);
     }
 
     @Override

--- a/src/main/java/edu/hm/hafner/coverage/FractionValue.java
+++ b/src/main/java/edu/hm/hafner/coverage/FractionValue.java
@@ -4,6 +4,8 @@ import java.util.Objects;
 
 import org.apache.commons.lang3.math.Fraction;
 
+import edu.hm.hafner.coverage.Metric.MetricTendency;
+
 /**
  * Represents the value of a rational number based metric. Internally the rational number is stored using a
  * {@link Fraction} instance.
@@ -74,9 +76,23 @@ public final class FractionValue extends Value {
         throw new IllegalArgumentException(String.format("Cannot cast incompatible types: %s and %s", this, other));
     }
 
+    /**
+     * Returns whether this fraction is out of the valid range. For values that have a metric that is getting better
+     * when values are increasing (e.g., coverage), the method will return {@code true} if the fraction value is
+     * smaller than the threshold. For values that have a metric that is getting better when values are decreasing
+     * (e.g., complexity), the method will return {@code true} if the fraction value is larger than the threshold.
+     *
+     * @param threshold
+     *         the threshold to compare with
+     *
+     * @return {@code true}, if this value is larger or smaller than specified threshold (see {@link MetricTendency})
+     */
     @Override
-    public boolean isBelowThreshold(final double threshold) {
-        return fraction.doubleValue() < threshold;
+    public boolean isOutOfValidRange(final double threshold) {
+        if (getMetric().getTendency() == MetricTendency.LARGER_IS_BETTER) {
+            return fraction.doubleValue() < threshold;
+        }
+        return fraction.doubleValue() > threshold;
     }
 
     private SafeFraction asSafeFraction() {

--- a/src/main/java/edu/hm/hafner/coverage/IntegerValue.java
+++ b/src/main/java/edu/hm/hafner/coverage/IntegerValue.java
@@ -74,16 +74,16 @@ public abstract class IntegerValue extends Value {
     }
 
     /**
-     * Returns whether this integer value is below the given threshold.
+     * Returns whether this integer value is larger than the given threshold.
      *
      * @param threshold
      *         the threshold
      *
-     * @return {@code true}, if this value is below the specified threshold
+     * @return {@code true}, if this value is larger than the specified threshold
      */
     @Override
-    public boolean isBelowThreshold(final double threshold) {
-        return getValue() < threshold;
+    public boolean isOutOfValidRange(final double threshold) {
+        return getValue() > threshold;
     }
 
     @Override

--- a/src/main/java/edu/hm/hafner/coverage/Value.java
+++ b/src/main/java/edu/hm/hafner/coverage/Value.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.Fraction;
 
+import edu.hm.hafner.coverage.Metric.MetricTendency;
 import edu.umd.cs.findbugs.annotations.CheckReturnValue;
 
 /**
@@ -93,8 +94,9 @@ public abstract class Value implements Serializable {
                     case COMPLEXITY_DENSITY:
                         return new FractionValue(metric, Fraction.getFraction(value));
                     case COMPLEXITY:
-                    case COMPLEXITY_MAXIMUM:
                         return new CyclomaticComplexity(Integer.parseInt(value));
+                    case COMPLEXITY_MAXIMUM:
+                        return new CyclomaticComplexity(Integer.parseInt(value), Metric.COMPLEXITY_MAXIMUM);
                     case LOC:
                         return new LinesOfCode(Integer.parseInt(value));
                 }
@@ -158,13 +160,17 @@ public abstract class Value implements Serializable {
     public abstract Value max(Value other);
 
     /**
-     * Returns whether this value if below the specified threshold (given as double value).
+     * Returns whether this value if within the specified threshold (given as double value). For metrics of type
+     * {@link MetricTendency#LARGER_IS_BETTER} (like coverage percentage) this value will be checked with greater or
+     * equal than the threshold. For metrics of type {@link MetricTendency#SMALLER_IS_BETTER} (like complexity) this
+     * value will be checked with less or equal than.
      *
      * @param threshold
      *         the threshold to check against
-     * @return {@code true} if this value is below the specified threshold, {@code false} otherwise
+     *
+     * @return {@code true} if this value is within the specified threshold, {@code false} otherwise
      */
-    public abstract boolean isBelowThreshold(double threshold);
+    public abstract boolean isOutOfValidRange(double threshold);
 
     /**
      * Serializes this instance into a String.

--- a/src/test/java/edu/hm/hafner/coverage/CoverageTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/CoverageTest.java
@@ -48,12 +48,12 @@ class CoverageTest {
         Coverage fifty = builder.setCovered(2).setMissed(2).build();
         Coverage hundred = builder.setCovered(2).setMissed(0).build();
 
-        assertThat(zero.isBelowThreshold(0)).isFalse();
-        assertThat(zero.isBelowThreshold(0.1)).isTrue();
-        assertThat(fifty.isBelowThreshold(50)).isFalse();
-        assertThat(fifty.isBelowThreshold(50.1)).isTrue();
-        assertThat(hundred.isBelowThreshold(100)).isFalse();
-        assertThat(hundred.isBelowThreshold(100.1)).isTrue();
+        assertThat(zero.isOutOfValidRange(0)).isFalse();
+        assertThat(zero.isOutOfValidRange(0.1)).isTrue();
+        assertThat(fifty.isOutOfValidRange(50)).isFalse();
+        assertThat(fifty.isOutOfValidRange(50.1)).isTrue();
+        assertThat(hundred.isOutOfValidRange(100)).isFalse();
+        assertThat(hundred.isOutOfValidRange(100.1)).isTrue();
     }
 
     private double getDelta(final String value) {

--- a/src/test/java/edu/hm/hafner/coverage/CyclomaticComplexityTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/CyclomaticComplexityTest.java
@@ -27,9 +27,9 @@ class CyclomaticComplexityTest {
 
     @Test
     void shouldCompareWithThreshold() {
-        assertThat(new CyclomaticComplexity(125).isBelowThreshold(0)).isFalse();
-        assertThat(new CyclomaticComplexity(125).isBelowThreshold(125)).isFalse();
-        assertThat(new CyclomaticComplexity(125).isBelowThreshold(125.1)).isTrue();
+        assertThat(new CyclomaticComplexity(125).isOutOfValidRange(200)).isFalse();
+        assertThat(new CyclomaticComplexity(125).isOutOfValidRange(125)).isFalse();
+        assertThat(new CyclomaticComplexity(125).isOutOfValidRange(124.9)).isTrue();
     }
 
     @Test

--- a/src/test/java/edu/hm/hafner/coverage/FractionValueTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/FractionValueTest.java
@@ -20,8 +20,8 @@ class FractionValueTest {
         var fiftyAgain = new FractionValue(Metric.LINE, 50, 1);
         var hundred = new FractionValue(Metric.LINE, Fraction.getFraction(100, 1));
 
-        assertThat(fifty.isBelowThreshold(50.1)).isTrue();
-        assertThat(fifty.isBelowThreshold(50)).isFalse();
+        assertThat(fifty.isOutOfValidRange(50.1)).isTrue();
+        assertThat(fifty.isOutOfValidRange(50)).isFalse();
 
         assertThat(fifty.add(fifty)).isEqualTo(hundred);
         assertThat(fifty.max(hundred)).isEqualTo(hundred);
@@ -55,8 +55,8 @@ class FractionValueTest {
         var fifty = new FractionValue(Metric.LINE, Fraction.getFraction(50, 1));
         var hundred = new FractionValue(Metric.LINE, Fraction.getFraction(100, 1));
 
-        assertThat(fifty.isBelowThreshold(50.1)).isTrue();
-        assertThat(fifty.isBelowThreshold(50)).isFalse();
+        assertThat(fifty.isOutOfValidRange(50.1)).isTrue();
+        assertThat(fifty.isOutOfValidRange(50)).isFalse();
 
         assertThat(hundred.delta(fifty)).isEqualTo(Fraction.getFraction(50, 1));
     }

--- a/src/test/java/edu/hm/hafner/coverage/LinesOfCodeTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/LinesOfCodeTest.java
@@ -28,9 +28,9 @@ class LinesOfCodeTest {
 
     @Test
     void shouldCompareWithThreshold() {
-        assertThat(new LinesOfCode(125).isBelowThreshold(0)).isFalse();
-        assertThat(new LinesOfCode(125).isBelowThreshold(125)).isFalse();
-        assertThat(new LinesOfCode(125).isBelowThreshold(125.1)).isTrue();
+        assertThat(new LinesOfCode(125).isOutOfValidRange(200)).isFalse();
+        assertThat(new LinesOfCode(125).isOutOfValidRange(125)).isFalse();
+        assertThat(new LinesOfCode(125).isOutOfValidRange(124.9)).isTrue();
     }
 
     @Test

--- a/src/test/java/edu/hm/hafner/coverage/parser/CoberturaParserTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/parser/CoberturaParserTest.java
@@ -121,7 +121,7 @@ class CoberturaParserTest extends AbstractParserTest {
                 builder.setMetric(BRANCH).setCovered(3).setMissed(1).build(),
                 new CyclomaticComplexity(8),
                 new FractionValue(COMPLEXITY_DENSITY, 8, 42 + 9),
-                new CyclomaticComplexity(4),
+                new CyclomaticComplexity(4, COMPLEXITY_MAXIMUM),
                 new LinesOfCode(42 + 9));
     }
 
@@ -155,7 +155,7 @@ class CoberturaParserTest extends AbstractParserTest {
                 builder.setMetric(BRANCH).setCovered(6).setMissed(0).build(),
                 new CyclomaticComplexity(0),
                 new FractionValue(COMPLEXITY_DENSITY, 0, 9),
-                new CyclomaticComplexity(0),
+                new CyclomaticComplexity(0, COMPLEXITY_MAXIMUM),
                 new LinesOfCode(9));
     }
 
@@ -183,7 +183,7 @@ class CoberturaParserTest extends AbstractParserTest {
                 builder.setMetric(BRANCH).setCovered(2).setMissed(2).build(),
                 new CyclomaticComplexity(22),
                 new FractionValue(COMPLEXITY_DENSITY, 22, 61 + 19),
-                new CyclomaticComplexity(7),
+                new CyclomaticComplexity(7, COMPLEXITY_MAXIMUM),
                 new LinesOfCode(61 + 19));
 
         assertThat(root.getChildren()).extracting(Node::getName)

--- a/src/test/java/edu/hm/hafner/coverage/parser/JacocoParserTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/parser/JacocoParserTest.java
@@ -80,7 +80,7 @@ class JacocoParserTest extends AbstractParserTest {
                 builder.setMetric(INSTRUCTION).setCovered(1260).setMissed(90).build(),
                 new CyclomaticComplexity(160),
                 new FractionValue(COMPLEXITY_DENSITY, 160, 294 + 29),
-                new CyclomaticComplexity(6),
+                new CyclomaticComplexity(6, COMPLEXITY_MAXIMUM),
                 new LinesOfCode(294 + 29));
 
         assertThat(tree.getChildren()).hasSize(1)


### PR DESCRIPTION
When validating quality gates the algorithm needs to know if a threshold is an upper or lower limit. Some metrics are better when the value is smaller (e.g., complexity) and other metrics are better when the value is larger (e.g. coverage percentage). The same information is required to render the delta values in green (good) or red (bad).