### PR TITLE
Add relative path for file nodes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -281,19 +281,6 @@ def params = [
                   if (failFast && currentBuild.result == 'UNSTABLE') {
                     error 'Static analysis quality gates not passed; halting early'
                   }
-                  /*
-                   * If the current build was successful, we send the commits to Launchable so that
-                   * the result can be consumed by a Launchable build in the future. We do not
-                   * attempt to record commits for non-incrementalified plugins because such
-                   * plugins' PR builds could not be consumed by anything else anyway, and all
-                   * plugins currently in the BOM are incrementalified. We do not attempt to record
-                   * commits on Windows because our Windows agents do not have Python installed.
-                   */
-                  if (incrementals && platform != 'windows' && currentBuild.currentResult == 'SUCCESS') {
-                    launchable.install()
-                    launchable('verify')
-                    launchable('record commit')
-                  }
                 } else {
                   echo "Skipping static analysis results for ${stageIdentifier}"
                 }

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,8 @@
     <changelist>-SNAPSHOT</changelist>
 
     <module.name>edu.hm.hafner.coverage</module.name>
+
+    <incrementals-plugin.version>1.6</incrementals-plugin.version>
   </properties>
 
   <build>
@@ -61,6 +63,19 @@
             <package>edu.hm.hafner.coverage</package>
           </packages>
           <entryPointClassPackage>edu.hm.hafner.coverage.assertions</entryPointClassPackage>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>io.jenkins.tools.incrementals</groupId>
+        <artifactId>incrementals-maven-plugin</artifactId>
+        <version>${incrementals-plugin.version}</version>
+        <configuration>
+          <includes>
+            <include>org.jenkins-ci.*</include>
+            <include>io.jenkins.*</include>
+          </includes>
+          <generateBackupPoms>false</generateBackupPoms>
+          <updateNonincremental>false</updateNonincremental>
         </configuration>
       </plugin>
       <plugin>
@@ -88,6 +103,134 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>might-produce-incrementals</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>flatten-maven-plugin</artifactId>
+            <version>1.4.1</version>
+            <configuration>
+              <updatePomFile>true</updatePomFile>
+            </configuration>
+            <executions>
+              <execution>
+                <id>flatten</id>
+                <phase>process-resources</phase>
+                <goals>
+                  <goal>flatten</goal>
+                </goals>
+                <configuration>
+                  <flattenMode>oss</flattenMode>
+                  <outputDirectory>${project.build.directory}</outputDirectory>
+                  <flattenedPomFilename>${project.artifactId}-${project.version}.pom</flattenedPomFilename>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-enforcer-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>display-info</id>
+                <configuration>
+                  <rules>
+                    <requireMavenVersion>
+                      <version>[3.5.0,)</version>
+                      <message>3.5.0+ required to use Incrementals.</message>
+                    </requireMavenVersion>
+                    <rule implementation="io.jenkins.tools.incrementals.enforcer.RequireExtensionVersion">
+                      <version>[1.0-beta-4,)</version>
+                    </rule>
+                  </rules>
+                </configuration>
+              </execution>
+            </executions>
+            <dependencies>
+              <dependency>
+                <groupId>io.jenkins.tools.incrementals</groupId>
+                <artifactId>incrementals-enforcer-rules</artifactId>
+                <version>1.6</version>
+              </dependency>
+            </dependencies>
+          </plugin>
+          <plugin>
+            <artifactId>maven-release-plugin</artifactId>
+            <configuration>
+              <completionGoals>incrementals:reincrementalify</completionGoals>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>produce-incrementals</id>
+      <activation>
+        <property>
+          <name>set.changelist</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <distributionManagement>
+        <repository>
+          <id>incrementals</id>
+          <url>https://repo.jenkins-ci.org/incrementals/</url>
+        </repository>
+      </distributionManagement>
+      <build>
+        <plugins>
+          <!-- Copied from jenkins-release: -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>${maven-source-plugin.version}</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>benchmark</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <excludes>
+                <exclude>**/*Test.java</exclude>
+              </excludes>
+              <includes>
+                <include>**/*Benchmark.java</include>
+              </includes>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
   <distributionManagement>
     <snapshotRepository>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   </parent>
 
   <artifactId>coverage-model</artifactId>
-  <version>0.22.0-SNAPSHOT</version>
+  <version>${revision}${changelist}</version>
 
   <packaging>jar</packaging>
 
@@ -45,7 +45,7 @@
 
   <properties>
     <scmTag>HEAD</scmTag>
-    <revision>0.19.1</revision>
+    <revision>0.22.0</revision>
     <changelist>-SNAPSHOT</changelist>
 
     <module.name>edu.hm.hafner.coverage</module.name>

--- a/src/main/java/edu/hm/hafner/coverage/FileNode.java
+++ b/src/main/java/edu/hm/hafner/coverage/FileNode.java
@@ -40,7 +40,7 @@ public final class FileNode extends Node {
     private final NavigableMap<Integer, Integer> indirectCoverageChanges = new TreeMap<>();
     private final NavigableMap<Metric, Fraction> coverageDelta = new TreeMap<>();
 
-    private final TreeString relativePath;
+    private TreeString relativePath;
 
     /**
      * Creates a new {@link FileNode} with the given name.
@@ -99,6 +99,10 @@ public final class FileNode extends Node {
             return true;
         }
         return getRelativePath().hashCode() == searchNameHashCode;
+    }
+
+    public void setRelativePath(final String relativePath) {
+        this.relativePath = TreeString.valueOf(relativePath);
     }
 
     public SortedSet<Integer> getModifiedLines() {

--- a/src/main/java/edu/hm/hafner/coverage/FileNode.java
+++ b/src/main/java/edu/hm/hafner/coverage/FileNode.java
@@ -41,7 +41,6 @@ public final class FileNode extends Node {
     private final NavigableMap<Metric, Fraction> coverageDelta = new TreeMap<>();
 
     private final TreeString relativePath;
-    private TreeString absolutePath = TreeString.valueOf(StringUtils.EMPTY);
 
     /**
      * Creates a new {@link FileNode} with the given name.
@@ -82,8 +81,6 @@ public final class FileNode extends Node {
 
         file.indirectCoverageChanges.putAll(indirectCoverageChanges);
         file.coverageDelta.putAll(coverageDelta);
-
-        file.absolutePath = absolutePath;
 
         return file;
     }
@@ -532,14 +529,6 @@ public final class FileNode extends Node {
         return StringUtils.defaultString(relativePath.toString(), getName());
     }
 
-    void setAbsolutePath(final TreeString absolutePath) {
-        this.absolutePath = absolutePath;
-    }
-
-    public String getAbsolutePath() {
-        return StringUtils.defaultString(absolutePath.toString(), getRelativePath());
-    }
-
     @Override
     public boolean equals(final Object o) {
         if (this == o) {
@@ -552,17 +541,18 @@ public final class FileNode extends Node {
             return false;
         }
         FileNode fileNode = (FileNode) o;
-        return Objects.equals(coveredPerLine, fileNode.coveredPerLine) && Objects.equals(missedPerLine,
-                fileNode.missedPerLine) && Objects.equals(mutations, fileNode.mutations)
-                && Objects.equals(modifiedLines, fileNode.modifiedLines) && Objects.equals(
-                indirectCoverageChanges, fileNode.indirectCoverageChanges) && Objects.equals(coverageDelta,
-                fileNode.coverageDelta) && Objects.equals(relativePath, fileNode.relativePath)
-                && Objects.equals(absolutePath, fileNode.absolutePath);
+        return Objects.equals(coveredPerLine, fileNode.coveredPerLine)
+                && Objects.equals(missedPerLine, fileNode.missedPerLine)
+                && Objects.equals(mutations, fileNode.mutations)
+                && Objects.equals(modifiedLines, fileNode.modifiedLines)
+                && Objects.equals(indirectCoverageChanges, fileNode.indirectCoverageChanges)
+                && Objects.equals(coverageDelta, fileNode.coverageDelta)
+                && Objects.equals(relativePath, fileNode.relativePath);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(super.hashCode(), coveredPerLine, missedPerLine, mutations, modifiedLines,
-                indirectCoverageChanges, coverageDelta, relativePath, absolutePath);
+                indirectCoverageChanges, coverageDelta, relativePath);
     }
 }

--- a/src/main/java/edu/hm/hafner/coverage/FileNode.java
+++ b/src/main/java/edu/hm/hafner/coverage/FileNode.java
@@ -540,8 +540,8 @@ public final class FileNode extends Node {
      * @param relativePath
      *         the relative path
      */
-    public void setRelativePath(final String relativePath) {
-        this.relativePath = TreeString.valueOf(relativePath);
+    public void setRelativePath(final TreeString relativePath) {
+        this.relativePath = relativePath;
     }
 
     @Override

--- a/src/main/java/edu/hm/hafner/coverage/FileNode.java
+++ b/src/main/java/edu/hm/hafner/coverage/FileNode.java
@@ -101,10 +101,6 @@ public final class FileNode extends Node {
         return getRelativePath().hashCode() == searchNameHashCode;
     }
 
-    public void setRelativePath(final String relativePath) {
-        this.relativePath = TreeString.valueOf(relativePath);
-    }
-
     public SortedSet<Integer> getModifiedLines() {
         return modifiedLines;
     }
@@ -529,8 +525,23 @@ public final class FileNode extends Node {
         return findClass(className).orElseGet(() -> createClassNode(className));
     }
 
+    /**
+     * Returns the relative path of the file. If no relative path is set then the name of this node is returned.
+     *
+     * @return the relative path of the file
+     */
     public String getRelativePath() {
         return StringUtils.defaultString(relativePath.toString(), getName());
+    }
+
+    /**
+     * Sets the relative path of the file.
+     *
+     * @param relativePath
+     *         the relative path
+     */
+    public void setRelativePath(final String relativePath) {
+        this.relativePath = TreeString.valueOf(relativePath);
     }
 
     @Override

--- a/src/main/java/edu/hm/hafner/coverage/ModuleNode.java
+++ b/src/main/java/edu/hm/hafner/coverage/ModuleNode.java
@@ -146,7 +146,8 @@ public final class ModuleNode extends Node {
      * @see #createPackageNode(String)
      */
     public PackageNode findOrCreatePackageNode(final String packageName) {
-        return findPackage(packageName).orElseGet(() -> createPackageNode(packageName));
+        var normalizedPackageName = PackageNode.normalizePackageName(packageName);
+        return findPackage(normalizedPackageName).orElseGet(() -> createPackageNode(normalizedPackageName));
     }
 
     @Override

--- a/src/main/java/edu/hm/hafner/coverage/Mutation.java
+++ b/src/main/java/edu/hm/hafner/coverage/Mutation.java
@@ -244,9 +244,9 @@ public final class Mutation implements Serializable {
         public void buildAndAddToModule(final ModuleNode root) {
             String packageName = StringUtils.substringBeforeLast(mutatedClass, ".");
             String className = StringUtils.substringAfterLast(mutatedClass, ".");
-            var packageNode = root.findPackage(packageName).orElseGet(() -> root.createPackageNode(packageName));
-            var fileNode = packageNode.findFile(sourceFile).orElseGet(() -> packageNode.createFileNode(sourceFile));
-            var classNode = fileNode.findClass(className).orElseGet(() -> fileNode.createClassNode(className));
+            var packageNode = root.findOrCreatePackageNode(packageName);
+            var fileNode = packageNode.findOrCreateFileNode(sourceFile, packageName.replace('.', '/') + '/' + sourceFile);
+            var classNode = fileNode.findOrCreateClassNode(className);
             var methodNode = classNode.findMethod(mutatedMethod, mutatedMethodSignature)
                     .orElseGet(() -> classNode.createMethodNode(mutatedMethod, mutatedMethodSignature));
 

--- a/src/main/java/edu/hm/hafner/coverage/Mutation.java
+++ b/src/main/java/edu/hm/hafner/coverage/Mutation.java
@@ -8,6 +8,7 @@ import org.apache.commons.lang3.StringUtils;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 
 import edu.hm.hafner.coverage.Coverage.CoverageBuilder;
+import edu.hm.hafner.util.TreeStringBuilder;
 
 /**
  * Class which represents a mutation of the PIT Mutation Testing tool.
@@ -240,13 +241,15 @@ public final class Mutation implements Serializable {
          *
          * @param root
          *         the module root to add the mutations to
+         * @param treeStringBuilder
+         *         the tree string builder to create the file names
          */
-        public void buildAndAddToModule(final ModuleNode root) {
+        public void buildAndAddToModule(final ModuleNode root, final TreeStringBuilder treeStringBuilder) {
             String packageName = StringUtils.substringBeforeLast(mutatedClass, ".");
             String className = StringUtils.substringAfterLast(mutatedClass, ".");
             var packageNode = root.findOrCreatePackageNode(packageName);
             var relativePath = packageName.replace('.', '/') + '/' + sourceFile;
-            var fileNode = packageNode.findOrCreateFileNode(sourceFile, relativePath);
+            var fileNode = packageNode.findOrCreateFileNode(sourceFile, treeStringBuilder.intern(relativePath));
             var classNode = fileNode.findOrCreateClassNode(className);
             var methodNode = classNode.findMethod(mutatedMethod, mutatedMethodSignature)
                     .orElseGet(() -> classNode.createMethodNode(mutatedMethod, mutatedMethodSignature));

--- a/src/main/java/edu/hm/hafner/coverage/Mutation.java
+++ b/src/main/java/edu/hm/hafner/coverage/Mutation.java
@@ -245,7 +245,8 @@ public final class Mutation implements Serializable {
             String packageName = StringUtils.substringBeforeLast(mutatedClass, ".");
             String className = StringUtils.substringAfterLast(mutatedClass, ".");
             var packageNode = root.findOrCreatePackageNode(packageName);
-            var fileNode = packageNode.findOrCreateFileNode(sourceFile, packageName.replace('.', '/') + '/' + sourceFile);
+            var relativePath = packageName.replace('.', '/') + '/' + sourceFile;
+            var fileNode = packageNode.findOrCreateFileNode(sourceFile, relativePath);
             var classNode = fileNode.findOrCreateClassNode(className);
             var methodNode = classNode.findMethod(mutatedMethod, mutatedMethodSignature)
                     .orElseGet(() -> classNode.createMethodNode(mutatedMethod, mutatedMethodSignature));

--- a/src/main/java/edu/hm/hafner/coverage/Node.java
+++ b/src/main/java/edu/hm/hafner/coverage/Node.java
@@ -762,10 +762,11 @@ public abstract class Node implements Serializable {
     }
 
     /**
-     * Resolves the absolute paths of all files in this tree. The mapping is used to map the relative file names
-     * to the absolute file names.
+     * Resolves the absolute paths of all files in this tree. The mapping is used to map the relative file names to the
+     * absolute file names.
      *
-     * @param pathMapping the mapping from relative to absolute file names
+     * @param pathMapping
+     *         the mapping from relative to absolute file names
      */
     public void resolvePaths(final Map<String, String> pathMapping) {
         var builder = new TreeStringBuilder();

--- a/src/main/java/edu/hm/hafner/coverage/Node.java
+++ b/src/main/java/edu/hm/hafner/coverage/Node.java
@@ -4,7 +4,6 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
 import java.util.NavigableMap;
 import java.util.NavigableSet;
@@ -21,7 +20,6 @@ import java.util.stream.Stream;
 import org.apache.commons.lang3.math.Fraction;
 
 import edu.hm.hafner.util.Ensure;
-import edu.hm.hafner.util.TreeStringBuilder;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -759,22 +757,5 @@ public abstract class Node implements Serializable {
         var copy = copy();
         copy.addAllChildren(prunedChildren);
         return Optional.of(copy);
-    }
-
-    /**
-     * Resolves the absolute paths of all files in this tree. The mapping is used to map the relative file names to the
-     * absolute file names.
-     *
-     * @param pathMapping
-     *         the mapping from relative to absolute file names
-     */
-    public void resolvePaths(final Map<String, String> pathMapping) {
-        var builder = new TreeStringBuilder();
-        for (FileNode fileNode : getAllFileNodes()) {
-            if (pathMapping.containsKey(fileNode.getName())) {
-                fileNode.setAbsolutePath(builder.intern(pathMapping.get(fileNode.getName())));
-            }
-        }
-        builder.dedup();
     }
 }

--- a/src/main/java/edu/hm/hafner/coverage/PackageNode.java
+++ b/src/main/java/edu/hm/hafner/coverage/PackageNode.java
@@ -1,7 +1,5 @@
 package edu.hm.hafner.coverage;
 
-import java.util.Collection;
-
 import org.apache.commons.lang3.StringUtils;
 
 import edu.hm.hafner.util.PathUtil;
@@ -44,23 +42,6 @@ public final class PackageNode extends Node {
      */
     public PackageNode(@CheckForNull final String name) {
         super(Metric.PACKAGE, normalizePackageName(name));
-    }
-
-    /**
-     * Creates a new coverage item node with the given name. / and \ in the name are replaced with a .
-     *
-     * @param name
-     *         the human-readable name of the node, see {@link #normalizePackageName(String)}
-     * @param values
-     *         the values to add
-     *
-     * @see #addValue(Value)
-     * @see #addAllValues(Collection)
-     */
-    public PackageNode(@CheckForNull final String name, final Collection<Value> values) {
-        this(name);
-
-        addAllValues(values);
     }
 
     static PackageNode appendPackage(final PackageNode localChild, final PackageNode localParent) {

--- a/src/main/java/edu/hm/hafner/coverage/PackageNode.java
+++ b/src/main/java/edu/hm/hafner/coverage/PackageNode.java
@@ -2,7 +2,6 @@ package edu.hm.hafner.coverage;
 
 import org.apache.commons.lang3.StringUtils;
 
-import edu.hm.hafner.util.PathUtil;
 import edu.hm.hafner.util.TreeString;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 
@@ -13,8 +12,6 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
  */
 public final class PackageNode extends Node {
     private static final long serialVersionUID = 8236436628673022634L;
-
-    private static final PathUtil PATH_UTIL = new PathUtil();
 
     /**
      * Replace slashes and backslashes with a dot so that package names use the typical format of packages or
@@ -64,8 +61,8 @@ public final class PackageNode extends Node {
      *
      * @return the created and linked file node
      */
-    public FileNode createFileNode(final String fileName, final String relativePath) {
-        var fileNode = new FileNode(fileName, TreeString.valueOf(relativePath));
+    public FileNode createFileNode(final String fileName, final TreeString relativePath) {
+        var fileNode = new FileNode(fileName, relativePath);
         addChild(fileNode);
         return fileNode;
     }
@@ -80,10 +77,10 @@ public final class PackageNode extends Node {
      *         the relative path of the file
      *
      * @return the existing or created file node
-     * @see #createFileNode(String, String)
+     * @see #createFileNode(String, TreeString)
      */
-    public FileNode findOrCreateFileNode(final String fileName, final String relativePath) {
-        return findFile(fileName).orElseGet(() -> createFileNode(fileName, PATH_UTIL.getAbsolutePath(relativePath)));
+    public FileNode findOrCreateFileNode(final String fileName, final TreeString relativePath) {
+        return findFile(fileName).orElseGet(() -> createFileNode(fileName, relativePath));
     }
 
     /**

--- a/src/main/java/edu/hm/hafner/coverage/parser/CoberturaParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/parser/CoberturaParser.java
@@ -64,13 +64,13 @@ public class CoberturaParser extends CoverageParser {
      *         the reader to read the report from
      */
     @Override
-    public ModuleNode parse(final Reader reader, final FilteredLog log) {
+    protected ModuleNode parseReport(final Reader reader, final FilteredLog log) {
         try {
-            var factory = new SecureXmlParserFactory();
-            var eventReader = factory.createXmlEventReader(reader);
+            var eventReader = new SecureXmlParserFactory().createXmlEventReader(reader);
 
             var root = new ModuleNode("-");
             boolean isEmpty = true;
+
             while (eventReader.hasNext()) {
                 XMLEvent event = eventReader.nextEvent();
 
@@ -106,8 +106,10 @@ public class CoberturaParser extends CoverageParser {
             if (event.isStartElement()) {
                 var nextElement = event.asStartElement();
                 if (CLASS.equals(nextElement.getName())) {
-                    var relativePath = getValueOf(nextElement, FILE_NAME);
-                    var fileNode = packageNode.findOrCreateFileNode(getFileName(relativePath), relativePath);
+                    var fileName = getValueOf(nextElement, FILE_NAME);
+                    var relativePath = PATH_UTIL.getRelativePath(fileName);
+                    var fileNode = packageNode.findOrCreateFileNode(getFileName(fileName),
+                            getTreeStringBuilder().intern(relativePath));
                     readClassOrMethod(reader, fileNode, nextElement);
                 }
             }

--- a/src/main/java/edu/hm/hafner/coverage/parser/CoberturaParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/parser/CoberturaParser.java
@@ -10,8 +10,6 @@ import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.events.StartElement;
 import javax.xml.stream.events.XMLEvent;
 
-import org.apache.commons.lang3.StringUtils;
-
 import edu.hm.hafner.coverage.Coverage;
 import edu.hm.hafner.coverage.Coverage.CoverageBuilder;
 import edu.hm.hafner.coverage.CoverageParser;
@@ -119,7 +117,11 @@ public class CoberturaParser extends CoverageParser {
     }
 
     private String getFileName(final String relativePath) {
-        return StringUtils.defaultString(Paths.get(relativePath).getFileName().toString(), relativePath);
+        var path = Paths.get(relativePath).getFileName();
+        if (path == null) {
+            return relativePath;
+        }
+        return path.toString();
     }
 
     @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.CognitiveComplexity"})

--- a/src/main/java/edu/hm/hafner/coverage/parser/CoberturaParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/parser/CoberturaParser.java
@@ -34,6 +34,7 @@ import edu.hm.hafner.util.SecureXmlParserFactory.ParsingException;
 public class CoberturaParser extends CoverageParser {
     private static final long serialVersionUID = -3625341318291829577L;
 
+    private static final PathUtil PATH_UTIL = new PathUtil();
     private static final QName SOURCE = new QName("source");
     private static final QName PACKAGE = new QName("package");
     private static final QName CLASS = new QName("class");
@@ -117,7 +118,7 @@ public class CoberturaParser extends CoverageParser {
     }
 
     private String getFileName(final String relativePath) {
-        var path = Paths.get(relativePath).getFileName();
+        var path = Paths.get(PATH_UTIL.getAbsolutePath(relativePath)).getFileName();
         if (path == null) {
             return relativePath;
         }

--- a/src/main/java/edu/hm/hafner/coverage/parser/CoberturaParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/parser/CoberturaParser.java
@@ -1,6 +1,7 @@
 package edu.hm.hafner.coverage.parser;
 
 import java.io.Reader;
+import java.nio.file.Paths;
 import java.util.NoSuchElementException;
 import java.util.regex.Pattern;
 import javax.xml.namespace.QName;
@@ -8,6 +9,8 @@ import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.events.StartElement;
 import javax.xml.stream.events.XMLEvent;
+
+import org.apache.commons.lang3.StringUtils;
 
 import edu.hm.hafner.coverage.Coverage;
 import edu.hm.hafner.coverage.Coverage.CoverageBuilder;
@@ -104,8 +107,8 @@ public class CoberturaParser extends CoverageParser {
             if (event.isStartElement()) {
                 var nextElement = event.asStartElement();
                 if (CLASS.equals(nextElement.getName())) {
-                    var fileNode = packageNode.findOrCreateFileNode(getValueOf(nextElement, FILE_NAME));
-
+                    var relativePath = getValueOf(nextElement, FILE_NAME);
+                    var fileNode = packageNode.findOrCreateFileNode(getFileName(relativePath), relativePath);
                     readClassOrMethod(reader, fileNode, nextElement);
                 }
             }
@@ -113,6 +116,10 @@ public class CoberturaParser extends CoverageParser {
                 return; // finish processing of package
             }
         }
+    }
+
+    private String getFileName(final String relativePath) {
+        return StringUtils.defaultString(Paths.get(relativePath).getFileName().toString(), relativePath);
     }
 
     @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.CognitiveComplexity"})

--- a/src/main/java/edu/hm/hafner/coverage/parser/JacocoParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/parser/JacocoParser.java
@@ -114,18 +114,18 @@ public class JacocoParser extends CoverageParser {
 
     private PackageNode readPackage(final XMLEventReader reader,
             final ModuleNode root, final StartElement startElement) throws XMLStreamException {
-        var packageNode = root.findOrCreatePackageNode(getValueOf(startElement, NAME));
-
+        var packageName = getValueOf(startElement, NAME);
+        var packageNode = root.findOrCreatePackageNode(packageName);
         while (reader.hasNext()) {
             XMLEvent event = reader.nextEvent();
 
             if (event.isStartElement()) {
                 var nextElement = event.asStartElement();
                 if (CLASS.equals(nextElement.getName())) {
-                    readClass(reader, packageNode, nextElement);
+                    readClass(reader, packageNode, packageName, nextElement);
                 }
                 else if (SOURCE_FILE.equals(nextElement.getName())) {
-                    readSourceFile(reader, packageNode, nextElement);
+                    readSourceFile(reader, packageNode, packageName, nextElement);
                 }
                 else if (COUNTER.equals(startElement.getName())) {
                     readValueCounter(packageNode, startElement);
@@ -142,11 +142,12 @@ public class JacocoParser extends CoverageParser {
     }
 
     private Node readClass(final XMLEventReader reader, final PackageNode packageNode,
-            final StartElement startElement) throws XMLStreamException {
-        Optional<String> fileName = getOptionalValueOf(startElement, SOURCE_FILE_NAME);
+            final String packageName, final StartElement startElement) throws XMLStreamException {
+        Optional<String> possibleFileName = getOptionalValueOf(startElement, SOURCE_FILE_NAME);
         ClassNode classNode;
-        if (fileName.isPresent()) {
-            var fileNode = packageNode.findOrCreateFileNode(fileName.get());
+        if (possibleFileName.isPresent()) {
+            var fileName = possibleFileName.get();
+            var fileNode = packageNode.findOrCreateFileNode(fileName, packageName + '/' + fileName);
 
             classNode = fileNode.findOrCreateClassNode(getValueOf(startElement, NAME));
         }
@@ -176,9 +177,9 @@ public class JacocoParser extends CoverageParser {
     }
 
     private Node readSourceFile(final XMLEventReader reader, final PackageNode packageNode,
-            final StartElement startElement) throws XMLStreamException {
+            final String packageName, final StartElement startElement) throws XMLStreamException {
         String fileName = getValueOf(startElement, NAME);
-        var fileNode = packageNode.findOrCreateFileNode(fileName);
+        var fileNode = packageNode.findOrCreateFileNode(fileName, packageName + '/' + fileName);
 
         while (reader.hasNext()) {
             XMLEvent event = reader.nextEvent();

--- a/src/main/java/edu/hm/hafner/coverage/parser/PitestParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/parser/PitestParser.java
@@ -54,7 +54,7 @@ public class PitestParser extends CoverageParser {
      *         the reader to read the report from
      */
     @Override
-    public ModuleNode parse(final Reader reader, final FilteredLog log) {
+    protected ModuleNode parseReport(final Reader reader, final FilteredLog log) {
         try {
             var factory = new SecureXmlParserFactory();
             var eventReader = factory.createXmlEventReader(reader);
@@ -118,7 +118,7 @@ public class PitestParser extends CoverageParser {
                 readProperty(reader, builder);
             }
             else if (event.isEndElement()) {
-                builder.buildAndAddToModule(root);
+                builder.buildAndAddToModule(root, getTreeStringBuilder());
                 return;
             }
         }

--- a/src/test/java/edu/hm/hafner/coverage/AbstractNodeTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/AbstractNodeTest.java
@@ -8,7 +8,6 @@ import edu.hm.hafner.coverage.Coverage.CoverageBuilder;
 import edu.hm.hafner.util.TreeString;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
-import nl.jqno.equalsverifier.Warning;
 
 import static edu.hm.hafner.coverage.assertions.Assertions.*;
 
@@ -95,7 +94,6 @@ abstract class AbstractNodeTest {
                 .withPrefabValues(TreeString.class, TreeString.valueOf("src"), TreeString.valueOf("test"))
                 .withIgnoredFields("parent")
                 .withRedefinedSuperclass()
-                .suppress(Warning.NONFINAL_FIELDS)
                 .verify();
     }
 }

--- a/src/test/java/edu/hm/hafner/coverage/AbstractNodeTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/AbstractNodeTest.java
@@ -5,8 +5,10 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import edu.hm.hafner.coverage.Coverage.CoverageBuilder;
+import edu.hm.hafner.util.TreeString;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 
 import static edu.hm.hafner.coverage.assertions.Assertions.*;
 
@@ -88,10 +90,12 @@ abstract class AbstractNodeTest {
 
     @Test
     void shouldAdhereToEquals() {
-        EqualsVerifier.forClass(createNode(NAME).getClass()).withPrefabValues(
-                Node.class,
-                new PackageNode("src"),
-                new PackageNode("test")
-        ).withIgnoredFields("parent").withRedefinedSuperclass().verify();
+        EqualsVerifier.forClass(createNode(NAME).getClass())
+                .withPrefabValues(Node.class, new PackageNode("src"), new PackageNode("test"))
+                .withPrefabValues(TreeString.class, TreeString.valueOf("src"), TreeString.valueOf("test"))
+                .withIgnoredFields("parent")
+                .withRedefinedSuperclass()
+                .suppress(Warning.NONFINAL_FIELDS)
+                .verify();
     }
 }

--- a/src/test/java/edu/hm/hafner/coverage/AbstractNodeTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/AbstractNodeTest.java
@@ -5,9 +5,10 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import edu.hm.hafner.coverage.Coverage.CoverageBuilder;
-import edu.hm.hafner.util.TreeString;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.api.EqualsVerifierApi;
+import nl.jqno.equalsverifier.api.SingleTypeEqualsVerifierApi;
 
 import static edu.hm.hafner.coverage.assertions.Assertions.*;
 
@@ -89,11 +90,16 @@ abstract class AbstractNodeTest {
 
     @Test
     void shouldAdhereToEquals() {
-        EqualsVerifier.forClass(createNode(NAME).getClass())
+        SingleTypeEqualsVerifierApi<? extends Node> equalsVerifier = EqualsVerifier.forClass(
+                        createNode(NAME).getClass())
                 .withPrefabValues(Node.class, new PackageNode("src"), new PackageNode("test"))
-                .withPrefabValues(TreeString.class, TreeString.valueOf("src"), TreeString.valueOf("test"))
                 .withIgnoredFields("parent")
-                .withRedefinedSuperclass()
-                .verify();
+                .withRedefinedSuperclass();
+        configureEqualsVerifier(equalsVerifier);
+        equalsVerifier.verify();
+    }
+
+    void configureEqualsVerifier(final EqualsVerifierApi<? extends Node> verifier) {
+        // no additional configuration
     }
 }

--- a/src/test/java/edu/hm/hafner/coverage/ContainerNodeTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/ContainerNodeTest.java
@@ -1,5 +1,9 @@
 package edu.hm.hafner.coverage;
 
+import org.junit.jupiter.api.Test;
+
+import static edu.hm.hafner.coverage.assertions.Assertions.*;
+
 class ContainerNodeTest extends AbstractNodeTest {
     @Override
     Metric getMetric() {
@@ -9,5 +13,21 @@ class ContainerNodeTest extends AbstractNodeTest {
     @Override
     Node createNode(final String name) {
         return new ContainerNode(name);
+    }
+
+    @Test
+    void shouldAggregateSourceFolders() {
+        var root = new ContainerNode("root");
+        var left = new ModuleNode("left");
+        root.addChild(left);
+        var right = new ModuleNode("right");
+        root.addChild(right);
+
+        assertThat(root.getSourceFolders()).isEmpty();
+        assertThat(root.getChildren()).containsExactly(left, right);
+
+        left.addSource("left/path");
+        right.addSource("right/path");
+        assertThat(root.getSourceFolders()).containsExactly("left/path", "right/path");
     }
 }

--- a/src/test/java/edu/hm/hafner/coverage/FileNodeTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/FileNodeTest.java
@@ -2,12 +2,24 @@ package edu.hm.hafner.coverage;
 
 import org.junit.jupiter.api.Test;
 
+import edu.hm.hafner.util.TreeString;
+
+import nl.jqno.equalsverifier.Warning;
+import nl.jqno.equalsverifier.api.EqualsVerifierApi;
+
 import static edu.hm.hafner.coverage.assertions.Assertions.*;
 
 class FileNodeTest extends AbstractNodeTest {
     @Override
     Metric getMetric() {
         return Metric.FILE;
+    }
+
+    @Override
+    void configureEqualsVerifier(final EqualsVerifierApi<? extends Node> verifier) {
+        verifier.withPrefabValues(TreeString.class, TreeString.valueOf("src"), TreeString.valueOf("test"))
+                .suppress(Warning.NONFINAL_FIELDS);
+
     }
 
     @Override

--- a/src/test/java/edu/hm/hafner/coverage/FileNodeTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/FileNodeTest.java
@@ -12,12 +12,12 @@ class FileNodeTest extends AbstractNodeTest {
 
     @Override
     FileNode createNode(final String name) {
-        var fileNode = new FileNode(name);
+        var fileNode = new FileNode(name, "path");
         fileNode.addCounters(10, 1, 0);
         fileNode.addCounters(11, 2, 2);
         fileNode.addModifiedLines(10);
         fileNode.addIndirectCoverageChange(15, 123);
-        var empty = new FileNode("empty");
+        var empty = new FileNode("empty", "path");
         fileNode.computeDelta(empty);
         return fileNode;
     }
@@ -26,17 +26,17 @@ class FileNodeTest extends AbstractNodeTest {
     void shouldGetFilePath() {
         var module = new ModuleNode("top-level"); // just for testing
         var folder = new PackageNode("folder"); // just for testing
-        var file = new FileNode("Coverage.java");
-
+        var fileName = "Coverage.java";
+        var relativePath = "relative/path/to/file";
+        var file = new FileNode(fileName, relativePath);
         folder.addChild(file);
         module.addChild(folder);
 
-        var absolutePath = "folder/Coverage.java";
+        assertThat(file.getRelativePath()).isEqualTo(relativePath);
 
-        assertThat(file.getPath()).isEqualTo(absolutePath);
-        assertThat(file.getFiles()).containsExactly(absolutePath);
-        assertThat(folder.getFiles()).containsExactly(absolutePath);
-        assertThat(module.getFiles()).containsExactly(absolutePath);
+        assertThat(file.getFiles()).containsExactly(relativePath);
+        assertThat(folder.getFiles()).containsExactly(relativePath);
+        assertThat(module.getFiles()).containsExactly(relativePath);
 
         assertThat(module.getAll(Metric.FILE)).containsExactly(file);
         assertThat(folder.getAll(Metric.FILE)).containsExactly(file);

--- a/src/test/java/edu/hm/hafner/coverage/FileNodeTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/FileNodeTest.java
@@ -55,7 +55,7 @@ class FileNodeTest extends AbstractNodeTest {
         assertThat(folder.getAll(Metric.FILE)).containsExactly(file);
         assertThat(file.getAll(Metric.FILE)).containsExactly(file);
 
-        file.setRelativePath(otherPath);
+        file.setRelativePath(TreeString.valueOf(otherPath));
         assertThat(file.getRelativePath()).isEqualTo(otherPath);
 
         assertThat(file.matches(Metric.FILE, fileName)).isTrue();

--- a/src/test/java/edu/hm/hafner/coverage/FileNodeTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/FileNodeTest.java
@@ -45,6 +45,7 @@ class FileNodeTest extends AbstractNodeTest {
         module.addChild(folder);
 
         assertThat(file.getRelativePath()).isEqualTo(relativePath);
+        var otherPath = "other";
 
         assertThat(file.getFiles()).containsExactly(relativePath);
         assertThat(folder.getFiles()).containsExactly(relativePath);
@@ -53,5 +54,16 @@ class FileNodeTest extends AbstractNodeTest {
         assertThat(module.getAll(Metric.FILE)).containsExactly(file);
         assertThat(folder.getAll(Metric.FILE)).containsExactly(file);
         assertThat(file.getAll(Metric.FILE)).containsExactly(file);
+
+        file.setRelativePath(otherPath);
+        assertThat(file.getRelativePath()).isEqualTo(otherPath);
+
+        assertThat(file.matches(Metric.FILE, fileName)).isTrue();
+        assertThat(file.matches(Metric.FILE, otherPath)).isTrue();
+        assertThat(file.matches(Metric.FILE, "wrong")).isFalse();
+
+        assertThat(file.matches(Metric.FILE, fileName.hashCode())).isTrue();
+        assertThat(file.matches(Metric.FILE, otherPath.hashCode())).isTrue();
+        assertThat(file.matches(Metric.FILE, "wrong".hashCode())).isFalse();
     }
 }

--- a/src/test/java/edu/hm/hafner/coverage/ModuleNodeTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/ModuleNodeTest.java
@@ -28,7 +28,7 @@ class ModuleNodeTest extends AbstractNodeTest {
         root.splitPackages();
         assertThat(root.getAll(PACKAGE)).isEmpty();
 
-        root.addChild(new FileNode("file.c"));
+        root.addChild(new FileNode("file.c", "path"));
         root.splitPackages();
         assertThat(root.getAll(PACKAGE)).isEmpty();
     }
@@ -75,7 +75,7 @@ class ModuleNodeTest extends AbstractNodeTest {
         root.addChild(differentPackage);
         root.addChild(eduPackage);
 
-        eduPackage.addChild(new FileNode("edu/File.c"));
+        eduPackage.addChild(new FileNode("File.c", "edu/File.c"));
 
         var builder = new CoverageBuilder().setMetric(LINE);
         eduPackage.addValue(builder.setCovered(10).setMissed(0).build());
@@ -86,7 +86,7 @@ class ModuleNodeTest extends AbstractNodeTest {
         var subPackage = new PackageNode("edu.hm.hafner");
         root.addChild(subPackage);
         subPackage.addValue(builder.setMissed(10).build());
-        subPackage.addChild(new FileNode("edu.hm.hafner/OtherFile.c"));
+        subPackage.addChild(new FileNode("OtherFile.c", "edu.hm.hafner/OtherFile.c"));
         assertThat(root.getValue(LINE)).contains(builder.setCovered(20).setMissed(10).build());
 
         root.splitPackages();
@@ -103,7 +103,7 @@ class ModuleNodeTest extends AbstractNodeTest {
     void shouldKeepNodesAfterSplitting() {
         var root = new ModuleNode("Root");
         Node pkg = new PackageNode("edu.hm.hafner");
-        Node file = new FileNode("HelloWorld.java");
+        Node file = new FileNode("HelloWorld.java", "path");
 
         root.addChild(pkg);
         pkg.addChild(file);
@@ -117,7 +117,7 @@ class ModuleNodeTest extends AbstractNodeTest {
     void shouldNotMergeWhenDifferentMetric() {
         var root = new ModuleNode("Root");
         Node pkg = new PackageNode("edu.hm.hafner");
-        Node file = new FileNode("Helicopter.java");
+        Node file = new FileNode("Helicopter.java", "path");
 
         root.addChild(pkg);
         root.addChild(file);

--- a/src/test/java/edu/hm/hafner/coverage/NodeTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/NodeTest.java
@@ -76,26 +76,11 @@ class NodeTest {
     }
 
     @Test
-    void shouldReturnCorrectPathInBaseClass() {
-        var root = new ModuleNode("Root");
-        var child = new FileNode("Child");
-        var childOfChild = new ClassNode("ChildOfChild");
-
-        root.addChild(child);
-        child.addChild(childOfChild);
-
-        assertThat(root).hasPath("");
-        assertThat(root.mergePath("-")).isEmpty();
-        assertThat(child.mergePath("/local/path")).isEqualTo("/local/path");
-        assertThat(childOfChild.mergePath("")).isEqualTo("Child");
-    }
-
-    @Test
     void shouldPrintAllMetricsForNodeAndChildNodes() {
         var parent = new ModuleNode("Parent");
         var child1 = new PackageNode("ChildOne");
         var child2 = new PackageNode("ChildTwo");
-        var childOfChildOne = new FileNode("ChildOfChildOne");
+        var childOfChildOne = new FileNode("ChildOfChildOne", "path");
 
         parent.addChild(child1);
         parent.addChild(child2);
@@ -150,8 +135,8 @@ class NodeTest {
         Node parent = new ModuleNode("Parent");
         Node child1 = new PackageNode("ChildOne");
         Node child2 = new PackageNode("ChildTwo");
-        Node childOfChildOne = new FileNode("ChildOfChildOne");
-        Node childOfChildTwo = new FileNode("ChildOfChildTwo");
+        Node childOfChildOne = new FileNode("ChildOfChildOne", "path");
+        Node childOfChildTwo = new FileNode("ChildOfChildTwo", "path");
 
         parent.addChild(child1);
         parent.addChild(child2);
@@ -181,8 +166,8 @@ class NodeTest {
     @Test
     void shouldCalculateCorrectCoverageWithNestedStructure() {
         var node = new ModuleNode("Node");
-        var missedFile = new FileNode("fileMissed");
-        var coveredFile = new FileNode("fileCovered");
+        var missedFile = new FileNode("fileMissed", "path");
+        var coveredFile = new FileNode("fileCovered", "path");
         var valueOne = new CoverageBuilder().setMetric(LINE).setCovered(1).setMissed(0).build();
         var valueTwo = new CoverageBuilder().setMetric(LINE).setCovered(0).setMissed(1).build();
 
@@ -199,7 +184,7 @@ class NodeTest {
     @Test
     void shouldDeepCopyNodeTree() {
         var node = new ModuleNode("Node");
-        var childNode = new FileNode("childNode");
+        var childNode = new FileNode("childNode", "path");
         var valueOne = new CoverageBuilder().setMetric(LINE).setCovered(1).setMissed(0).build();
         var valueTwo = new CoverageBuilder().setMetric(LINE).setCovered(0).setMissed(1).build();
 
@@ -215,7 +200,7 @@ class NodeTest {
     @Test
     void shouldDeepCopyNodeTreeWithSpecifiedNodeAsParent() {
         var node = new ModuleNode("Node");
-        var childNode = new FileNode("childNode");
+        var childNode = new FileNode("childNode", "path");
         var valueOne = new CoverageBuilder().setMetric(LINE).setCovered(1).setMissed(0).build();
         var valueTwo = new CoverageBuilder().setMetric(LINE).setCovered(0).setMissed(1).build();
         var newParent = new ModuleNode("parent");
@@ -238,13 +223,12 @@ class NodeTest {
 
         assertThat(node.matches(MODULE, node.getName().hashCode())).isTrue();
         assertThat(node.matches(MODULE, "WrongName".hashCode())).isFalse();
-        assertThat(node.matches(MODULE, node.getPath().hashCode())).isTrue();
     }
 
     @Test
     void shouldFindNodeByNameOrHashCode() {
         var node = new ModuleNode("Node");
-        var childNode = new FileNode("childNode");
+        var childNode = new FileNode("childNode", "path");
         node.addChild(childNode);
 
         assertThat(node.find(BRANCH, "NotExisting")).isNotPresent();
@@ -327,8 +311,8 @@ class NodeTest {
         Node pkg = new PackageNode("coverage");
         Node samePackage = new PackageNode("coverage");
 
-        Node fileToKeep = new FileNode("KeepMe");
-        Node otherFileToKeep = new FileNode("KeepMeToo");
+        Node fileToKeep = new FileNode("KeepMe", "path");
+        Node otherFileToKeep = new FileNode("KeepMeToo", "path");
 
         pkg.addChild(fileToKeep);
         module.addChild(pkg);
@@ -346,8 +330,8 @@ class NodeTest {
         Node sameModule = new ModuleNode("edu.hm.hafner.module1");
         Node pkg = new PackageNode("coverage");
         Node samePackage = new PackageNode("coverage");
-        Node fileToKeep = new FileNode("KeepMe");
-        Node sameFileToKeep = new FileNode("KeepMe");
+        Node fileToKeep = new FileNode("KeepMe", "path");
+        Node sameFileToKeep = new FileNode("KeepMe", "path");
         Node classA = new ClassNode("ClassA");
         Node classB = new ClassNode("ClassB");
 
@@ -372,7 +356,7 @@ class NodeTest {
     private static Node setUpNodeTree() {
         Node module = new ModuleNode("edu.hm.hafner.module1");
         Node pkg = new PackageNode("coverage");
-        Node file = new FileNode("Node.java");
+        Node file = new FileNode("Node.java", "path");
         Node covNodeClass = new ClassNode("Node.class");
         Node combineWithMethod = new MethodNode("combineWith", "(Ljava/util/Map;)V", 10);
 
@@ -388,7 +372,7 @@ class NodeTest {
     void shouldComputeCorrectCoverageAfterCombiningMethods() {
         Node module = new ModuleNode("edu.hm.hafner.module");
         Node pkg = new PackageNode("edu.hm.hafner.package");
-        Node file = new FileNode("Node.java");
+        Node file = new FileNode("Node.java", "path");
         Node covNodeClass = new ClassNode("Node.class");
         Node combineWithMethod = new MethodNode("combineWith", "(Ljava/util/Map;)V", 10);
 
@@ -468,7 +452,7 @@ class NodeTest {
 
         // Difference on package level
         var autograding = new PackageNode("autograding");
-        var file = new FileNode("Main.java");
+        var file = new FileNode("Main.java", "path");
         var mainClass = new ClassNode("Main.class");
         var mainMethod = new MethodNode("main", "(Ljava/util/Map;)V", 10);
 
@@ -479,8 +463,8 @@ class NodeTest {
         mainMethod.addValue(new CoverageBuilder().setMetric(LINE).setCovered(8).setMissed(2).build());
 
         // Difference on file level
-        var leaf = new FileNode("Leaf");
-        var pkgCovFile = new FileNode("HelloWorld");
+        var leaf = new FileNode("Leaf", "path");
+        var pkgCovFile = new FileNode("HelloWorld", "path");
         leaf.addChild(mainClass.copyTree());
 
         report.getAll(PACKAGE).get(0).addChild(pkgCovFile);
@@ -515,7 +499,7 @@ class NodeTest {
     void shouldAlsoHandleReportsThatStopAtHigherLevelThanMethod() {
         Node report = new ModuleNode("edu.hm.hafner.module1");
         Node pkg = new PackageNode("coverage");
-        Node file = new FileNode("Node.java");
+        Node file = new FileNode("Node.java", "path");
 
         report.addChild(pkg);
         pkg.addChild(file);
@@ -534,7 +518,7 @@ class NodeTest {
     void shouldAlsoHandleReportsThatStopAtHigherLevelAndOtherReportHasHigherCoverage() {
         Node report = new ModuleNode("edu.hm.hafner.module1");
         Node pkg = new PackageNode("coverage");
-        Node file = new FileNode("Node.java");
+        Node file = new FileNode("Node.java", "path");
 
         report.addChild(pkg);
         pkg.addChild(file);
@@ -572,9 +556,8 @@ class NodeTest {
         assertThat(filteredTree)
                 .isNotSameAs(tree)
                 .hasName(tree.getName())
-                .hasPath(tree.getPath())
                 .hasMetric(tree.getMetric())
-                .hasOnlyFiles("coverage/" + COVERED_FILE)
+                .hasOnlyFiles("path/to/" + COVERED_FILE)
                 .hasModifiedLines()
                 .satisfies(treeVerification);
     }
@@ -622,7 +605,6 @@ class NodeTest {
         assertThat(filteredTree)
                 .isNotSameAs(tree)
                 .hasName(tree.getName())
-                .hasPath(tree.getPath())
                 .hasMetric(tree.getMetric())
                 .hasNoChildren()
                 .hasNoValues();
@@ -682,9 +664,8 @@ class NodeTest {
         assertThat(tree.filterByIndirectChanges())
                 .isNotSameAs(tree)
                 .hasName(tree.getName())
-                .hasPath(tree.getPath())
                 .hasMetric(tree.getMetric())
-                .hasFiles("coverage/" + COVERED_FILE)
+                .hasFiles("path/to/" + COVERED_FILE)
                 .satisfies(this::verifyIndirectChanges);
     }
 
@@ -754,8 +735,8 @@ class NodeTest {
     private Node createTreeWithoutCoverage() {
         Node moduleNode = new ModuleNode("edu.hm.hafner.module1");
         Node packageNode = new PackageNode("coverage");
-        Node coveredFileNode = new FileNode(COVERED_FILE);
-        Node missedFileNode = new FileNode(MISSED_FILE);
+        Node coveredFileNode = new FileNode(COVERED_FILE, "path/to/" + COVERED_FILE);
+        Node missedFileNode = new FileNode(MISSED_FILE, "path/to/" + MISSED_FILE);
 
         moduleNode.addChild(packageNode);
 

--- a/src/test/java/edu/hm/hafner/coverage/PackageNodeTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/PackageNodeTest.java
@@ -17,30 +17,6 @@ class PackageNodeTest extends AbstractNodeTest {
     }
 
     /**
-     * Tests if correct package path is returned.
-     */
-    @Test
-    void shouldGetPath() {
-        String pkgName = "ui.home.model";
-        var pkg = new PackageNode(pkgName);
-
-        assertThat(pkg.getPath()).isEqualTo("ui/home/model");
-    }
-
-    @Test
-    void shouldMergePathWithChild() {
-        // Given
-        String parentName = "ui";
-        var parent = new PackageNode(parentName);
-        var child = new PackageNode("model");
-        parent.addChild(child);
-
-        // When & Then
-        assertThat(child.mergePath("Update.java")).isEqualTo(parentName + "/Update.java");
-        assertThat(child.mergePath("")).isEqualTo(parentName);
-    }
-
-    /**
      * Tests the copy functionality with a child.
      */
     @Test
@@ -71,8 +47,8 @@ class PackageNodeTest extends AbstractNodeTest {
         var pkg = new PackageNode(pkgName);
 
         // When & Then
-        assertThat(pkg.matches(PACKAGE, "ui/home/model".hashCode())).isTrue();
-        assertThat(pkg.matches(PACKAGE, "test/path".hashCode())).isFalse();
+        assertThat(pkg.matches(PACKAGE, "ui.home.model".hashCode())).isTrue();
+        assertThat(pkg.matches(PACKAGE, "test.path".hashCode())).isFalse();
     }
 
     @Test

--- a/src/test/java/edu/hm/hafner/coverage/parser/CoberturaParserTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/parser/CoberturaParserTest.java
@@ -142,9 +142,12 @@ class CoberturaParserTest extends AbstractParserTest {
 
         assertThat(tree.getAll(MODULE)).hasSize(1).extracting(Node::getName).containsOnly("-");
         assertThat(tree.getAll(PACKAGE)).hasSize(1).extracting(Node::getName).containsOnly("Numbers");
-        assertThat(tree.getAll(FILE)).hasSize(1)
+        assertThat(tree.getAllFileNodes()).hasSize(1)
                 .extracting(Node::getName)
-                .containsOnly("D:\\Build\\workspace\\esignPlugins_test-jenkins-plugin\\Numbers\\PrimeService.cs");
+                .containsOnly("PrimeService.cs");
+        assertThat(tree.getAllFileNodes()).hasSize(1)
+                .extracting(FileNode::getRelativePath)
+                .containsOnly("D:/Build/workspace/esignPlugins_test-jenkins-plugin/Numbers/PrimeService.cs");
         assertThat(tree.getAll(CLASS)).hasSize(1)
                 .extracting(Node::getName)
                 .containsOnly("Numbers.PrimeService");

--- a/src/test/java/edu/hm/hafner/coverage/parser/CoberturaParserTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/parser/CoberturaParserTest.java
@@ -29,6 +29,17 @@ class CoberturaParserTest extends AbstractParserTest {
     }
 
     @Test
+    void shouldReadCoberturaIssue610() {
+        Node tree = readReport("coverage-missing-sources.xml");
+
+        assertThat(tree.getAll(MODULE)).hasSize(1).extracting(Node::getName).containsExactly("-");
+        assertThat(tree.getAll(FILE)).extracting(Node::getName).containsExactly(
+                "args.ts", "badge-result.ts", "colors.ts", "index.ts");
+        assertThat(tree.getAllFileNodes()).extracting(FileNode::getRelativePath).containsExactly(
+                "src/args.ts", "src/badge-result.ts", "src/colors.ts", "src/index.ts");
+    }
+
+    @Test
     void shouldReadCoberturaIssue599() {
         Node tree = readReport("cobertura-ts.xml");
 
@@ -42,18 +53,18 @@ class CoberturaParserTest extends AbstractParserTest {
                 "services.ui.libs.client.libs.env.src",
                 "services.ui.libs.client.src.util",
                 "services.ui.src");
-        assertThat(tree.getAll(FILE)).extracting(Node::getName).containsExactly("libs/env/src/env.ts",
-                "services/api/src/api.ts",
-                "services/api/src/app-info.ts",
-                "services/api/src/env.ts",
-                "services/api/src/database/movie-store.ts",
-                "services/api/src/database/store.ts",
-                "services/api/src/graphql/resolver.ts",
-                "services/api/src/graphql/schema.ts",
-                "services/ui/libs/client/libs/env/src/env.ts",
-                "services/ui/libs/client/src/util/error-util.ts",
-                "services/ui/src/env.ts",
-                "services/ui/src/server.ts");
+        assertThat(tree.getAll(FILE)).extracting(Node::getName).containsExactly("env.ts",
+                "api.ts",
+                "app-info.ts",
+                "env.ts",
+                "movie-store.ts",
+                "store.ts",
+                "resolver.ts",
+                "schema.ts",
+                "env.ts",
+                "error-util.ts",
+                "env.ts",
+                "server.ts");
         assertThat(tree.getAll(CLASS))
                 .extracting(Node::getName)
                 .containsExactly("env.ts",
@@ -81,15 +92,15 @@ class CoberturaParserTest extends AbstractParserTest {
 
         assertThat(tree.findPackage("libs.env.src")).isNotEmpty().get().satisfies(
                 p -> {
+                    assertThat(p.getAllFileNodes()).extracting(FileNode::getRelativePath).containsExactly("libs/env/src/env.ts");
                     assertThat(p).hasFiles("libs/env/src/env.ts");
-                    assertThat(p.getAllFileNodes()).extracting(Node::getPath).containsExactly("libs/env/src/env.ts");
                     assertThat(p.getAll(CLASS)).extracting(Node::getName).containsExactly("env.ts");
                 }
         );
         assertThat(tree.findPackage("services.api.src")).isNotEmpty().get().satisfies(
                 p -> {
                     assertThat(p).hasFiles("services/api/src/env.ts");
-                    assertThat(p.getAllFileNodes()).extracting(Node::getPath).contains("services/api/src/env.ts");
+                    assertThat(p.getAllFileNodes()).extracting(FileNode::getRelativePath).contains("services/api/src/env.ts");
                     assertThat(p.getAll(CLASS)).extracting(Node::getName).contains("env.ts");
                 }
         );
@@ -138,7 +149,7 @@ class CoberturaParserTest extends AbstractParserTest {
                 .extracting(Node::getName)
                 .containsOnly("Numbers.PrimeService");
 
-        assertThat(tree.getAllFileNodes()).hasSize(1).extracting(Node::getPath)
+        assertThat(tree.getAllFileNodes()).hasSize(1).extracting(FileNode::getRelativePath)
                 .containsOnly("D:/Build/workspace/esignPlugins_test-jenkins-plugin/Numbers/PrimeService.cs");
 
         var builder = new CoverageBuilder();
@@ -252,7 +263,7 @@ class CoberturaParserTest extends AbstractParserTest {
         Node result = readReport("cobertura-lots-of-data.xml");
         assertThat(result.getAllFileNodes())
                 .hasSize(19)
-                .extracting(FileNode::getPath)
+                .extracting(FileNode::getRelativePath)
                 .containsOnly("org/apache/commons/cli/AlreadySelectedException.java",
                         "org/apache/commons/cli/BasicParser.java",
                         "org/apache/commons/cli/CommandLine.java",
@@ -279,7 +290,7 @@ class CoberturaParserTest extends AbstractParserTest {
         Node result = readReport("cobertura-python.xml");
         assertThat(result.getAllFileNodes())
                 .hasSize(1)
-                .extracting(FileNode::getPath)
+                .extracting(FileNode::getRelativePath)
                 .containsOnly("__init__.py");
 
         assertThat(result.getValue(LINE)).isPresent().get().isInstanceOfSatisfying(Coverage.class,

--- a/src/test/resources/edu/hm/hafner/coverage/parser/coverage-missing-sources.xml
+++ b/src/test/resources/edu/hm/hafner/coverage/parser/coverage-missing-sources.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" ?>
+<!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">
+<coverage lines-valid="29" lines-covered="27" line-rate="0.9309999999999999" branches-valid="2" branches-covered="2" branch-rate="1" timestamp="1680392774613" complexity="0" version="0.1">
+  <sources>
+    <source>/var/jenkins_home/workspace/ts_shields.io-badge-results_PR-5/PR-5-1</source>
+  </sources>
+  <packages>
+    <package name="main" line-rate="0.9309999999999999" branch-rate="1">
+      <classes>
+        <class name="args.ts" filename="src/args.ts" line-rate="1" branch-rate="1">
+          <methods>
+            <method name="(anonymous_8)" hits="8" signature="()V">
+              <lines>
+                <line number="15" hits="8"/>
+              </lines>
+            </method>
+          </methods>
+          <lines>
+            <line number="1" hits="3" branch="false"/>
+            <line number="2" hits="3" branch="false"/>
+            <line number="4" hits="3" branch="false"/>
+            <line number="14" hits="3" branch="false"/>
+            <line number="16" hits="8" branch="false"/>
+            <line number="53" hits="8" branch="false"/>
+          </lines>
+        </class>
+        <class name="badge-result.ts" filename="src/badge-result.ts" line-rate="1" branch-rate="1">
+          <methods>
+            <method name="(anonymous_8)" hits="1" signature="()V">
+              <lines>
+                <line number="7" hits="1"/>
+              </lines>
+            </method>
+          </methods>
+          <lines>
+            <line number="1" hits="2" branch="false"/>
+            <line number="2" hits="2" branch="false"/>
+            <line number="6" hits="2" branch="false"/>
+            <line number="8" hits="1" branch="false"/>
+            <line number="9" hits="1" branch="false"/>
+            <line number="10" hits="1" branch="false"/>
+          </lines>
+        </class>
+        <class name="colors.ts" filename="src/colors.ts" line-rate="1" branch-rate="1">
+          <methods>
+            <method name="(anonymous_0)" hits="3" signature="()V">
+              <lines>
+                <line number="1" hits="3"/>
+              </lines>
+            </method>
+          </methods>
+          <lines>
+            <line number="1" hits="3" branch="true" condition-coverage="100% (2/2)"/>
+            <line number="2" hits="3" branch="false"/>
+            <line number="3" hits="3" branch="false"/>
+            <line number="4" hits="3" branch="false"/>
+            <line number="5" hits="3" branch="false"/>
+            <line number="6" hits="3" branch="false"/>
+            <line number="7" hits="3" branch="false"/>
+            <line number="8" hits="3" branch="false"/>
+            <line number="9" hits="3" branch="false"/>
+            <line number="12" hits="3" branch="false"/>
+          </lines>
+        </class>
+        <class name="index.ts" filename="src/index.ts" line-rate="0.7142000000000001" branch-rate="1">
+          <methods>
+            <method name="(anonymous_8)" hits="1" signature="()V">
+              <lines>
+                <line number="5" hits="1"/>
+              </lines>
+            </method>
+            <method name="(anonymous_9)" hits="1" signature="()V">
+              <lines>
+                <line number="5" hits="1"/>
+              </lines>
+            </method>
+          </methods>
+          <lines>
+            <line number="1" hits="1" branch="false"/>
+            <line number="2" hits="1" branch="false"/>
+            <line number="5" hits="1" branch="false"/>
+            <line number="6" hits="1" branch="false"/>
+            <line number="7" hits="1" branch="false"/>
+            <line number="9" hits="0" branch="false"/>
+            <line number="10" hits="0" branch="false"/>
+          </lines>
+        </class>
+      </classes>
+    </package>
+  </packages>
+</coverage>


### PR DESCRIPTION
Replaces the path computation based on packages.

Fixes https://github.com/jenkinsci/code-coverage-api-plugin/issues/610

Tasks:
- [x] Optimize `TreeString` creation