### PR TITLE
Add support for groups in JaCoCo files

### DIFF
--- a/src/main/java/edu/hm/hafner/coverage/parser/JacocoParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/parser/JacocoParser.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.events.EndElement;
 import javax.xml.stream.events.StartElement;
 import javax.xml.stream.events.XMLEvent;
 
@@ -115,13 +116,16 @@ public class JacocoParser extends CoverageParser {
             }
             else if (event.isEndElement()) {
                 var endElement = event.asEndElement();
-                if (REPORT.equals(endElement.getName())
-                        || GROUP.equals(endElement.getName())) {
+                if (isModuleEnd(endElement)) {
                     return module;
                 }
             }
         }
         throw createEofException();
+    }
+
+    private boolean isModuleEnd(final EndElement endElement) {
+        return REPORT.equals(endElement.getName()) || GROUP.equals(endElement.getName());
     }
 
     private PackageNode readPackage(final XMLEventReader reader,

--- a/src/main/java/edu/hm/hafner/coverage/parser/JacocoParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/parser/JacocoParser.java
@@ -40,6 +40,7 @@ public class JacocoParser extends CoverageParser {
 
     private static final QName REPORT = new QName("report");
     private static final QName PACKAGE = new QName("package");
+    private static final QName GROUP = new QName("group");
     private static final QName CLASS = new QName("class");
     private static final QName METHOD = new QName("method");
     private static final QName COUNTER = new QName("counter");
@@ -81,7 +82,7 @@ public class JacocoParser extends CoverageParser {
                     var tagName = startElement.getName();
                     if (REPORT.equals(tagName)) {
                         var root = new ModuleNode(getValueOf(startElement, NAME));
-                        readReport(eventReader, root);
+                        readModule(eventReader, root);
                         return root;
                     }
                 }
@@ -93,7 +94,7 @@ public class JacocoParser extends CoverageParser {
         }
     }
 
-    private ModuleNode readReport(final XMLEventReader reader, final ModuleNode root)
+    private ModuleNode readModule(final XMLEventReader reader, final ModuleNode module)
             throws XMLStreamException {
         while (reader.hasNext()) {
             XMLEvent event = reader.nextEvent();
@@ -101,16 +102,22 @@ public class JacocoParser extends CoverageParser {
             if (event.isStartElement()) {
                 var startElement = event.asStartElement();
                 if (PACKAGE.equals(startElement.getName())) {
-                    readPackage(reader, root, startElement);
+                    readPackage(reader, module, startElement);
+                }
+                else if (GROUP.equals(startElement.getName())) {
+                    var subModule = new ModuleNode(getValueOf(startElement, NAME));
+                    readModule(reader, subModule);
+                    module.addChild(subModule);
                 }
                 else if (COUNTER.equals(startElement.getName())) {
-                    readValueCounter(root, startElement);
+                    readValueCounter(module, startElement);
                 }
             }
             else if (event.isEndElement()) {
                 var endElement = event.asEndElement();
-                if (REPORT.equals(endElement.getName())) {
-                    return root;
+                if (REPORT.equals(endElement.getName())
+                        || GROUP.equals(endElement.getName())) {
+                    return module;
                 }
             }
         }

--- a/src/test/java/edu/hm/hafner/coverage/parser/JacocoParserTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/parser/JacocoParserTest.java
@@ -50,11 +50,11 @@ class JacocoParserTest extends AbstractParserTest {
 
         var builder = new CoverageBuilder().setMetric(LINE);
         assertThat(jenkinsRoot.getValue(LINE))
-                .contains(builder.setCovered(35611).setMissed(18100).build());
+                .contains(builder.setCovered(35_611).setMissed(18_100).build());
         assertThat(jenkinsRoot.find(MODULE, "cli").get().getValue(LINE))
                 .contains(builder.setCovered(337).setMissed(558).build());
         assertThat(jenkinsRoot.find(MODULE, "jenkins-core").get().getValue(LINE))
-                .contains(builder.setCovered(35274).setMissed(17542).build());
+                .contains(builder.setCovered(35_274).setMissed(17_542).build());
     }
 
     @Test

--- a/src/test/java/edu/hm/hafner/coverage/parser/JacocoParserTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/parser/JacocoParserTest.java
@@ -38,6 +38,26 @@ class JacocoParserTest extends AbstractParserTest {
     }
 
     @Test
+    void shouldReadAggregationWithGroups() {
+        ModuleNode jenkinsRoot = readReport("jacoco-jenkins.xml");
+
+        assertThat(jenkinsRoot.getChildren()).hasSize(2)
+                .extracting(Node::getName)
+                .containsExactly("cli", "jenkins-core");
+        assertThat(jenkinsRoot.getAll(PACKAGE)).hasSize(2)
+                .extracting(Node::getName)
+                .containsExactly("hudson.cli.client", "org.acegisecurity.context");
+
+        var builder = new CoverageBuilder().setMetric(LINE);
+        assertThat(jenkinsRoot.getValue(LINE))
+                .contains(builder.setCovered(35611).setMissed(18100).build());
+        assertThat(jenkinsRoot.find(MODULE, "cli").get().getValue(LINE))
+                .contains(builder.setCovered(337).setMissed(558).build());
+        assertThat(jenkinsRoot.find(MODULE, "jenkins-core").get().getValue(LINE))
+                .contains(builder.setCovered(35274).setMissed(17542).build());
+    }
+
+    @Test
     void shouldDetectMethodCoverage() {
         ModuleNode module = readReport("jacocoTestReport.xml");
 

--- a/src/test/resources/edu/hm/hafner/coverage/parser/jacoco-jenkins.xml
+++ b/src/test/resources/edu/hm/hafner/coverage/parser/jacoco-jenkins.xml
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE report PUBLIC "-//JACOCO//DTD Report 1.1//EN" "report.dtd">
+<report name="Jenkins coverage">
+  <group name="cli">
+    <package name="hudson/cli/client">
+      <class name="hudson/cli/client/Messages" sourcefilename="Messages.java">
+        <method name="&lt;init&gt;" desc="()V" line="20">
+          <counter type="INSTRUCTION" missed="3" covered="0"/>
+          <counter type="LINE" missed="1" covered="0"/>
+          <counter type="COMPLEXITY" missed="1" covered="0"/>
+          <counter type="METHOD" missed="1" covered="0"/>
+        </method>
+        <method name="CLI_NoSuchFileExists" desc="(Ljava/lang/Object;)Ljava/lang/String;" line="37">
+          <counter type="INSTRUCTION" missed="10" covered="0"/>
+          <counter type="LINE" missed="1" covered="0"/>
+          <counter type="COMPLEXITY" missed="1" covered="0"/>
+          <counter type="METHOD" missed="1" covered="0"/>
+        </method>
+        <method name="_CLI_NoSuchFileExists" desc="(Ljava/lang/Object;)Lorg/jvnet/localizer/Localizable;" line="49">
+          <counter type="INSTRUCTION" missed="12" covered="0"/>
+          <counter type="LINE" missed="1" covered="0"/>
+          <counter type="COMPLEXITY" missed="1" covered="0"/>
+          <counter type="METHOD" missed="1" covered="0"/>
+        </method>
+        <method name="CLI_NoURL" desc="()Ljava/lang/String;" line="60">
+          <counter type="INSTRUCTION" missed="6" covered="0"/>
+          <counter type="LINE" missed="1" covered="0"/>
+          <counter type="COMPLEXITY" missed="1" covered="0"/>
+          <counter type="METHOD" missed="1" covered="0"/>
+        </method>
+        <method name="_CLI_NoURL" desc="()Lorg/jvnet/localizer/Localizable;" line="71">
+          <counter type="INSTRUCTION" missed="8" covered="0"/>
+          <counter type="LINE" missed="1" covered="0"/>
+          <counter type="COMPLEXITY" missed="1" covered="0"/>
+          <counter type="METHOD" missed="1" covered="0"/>
+        </method>
+        <method name="CLI_Usage" desc="()Ljava/lang/String;" line="171">
+          <counter type="INSTRUCTION" missed="6" covered="0"/>
+          <counter type="LINE" missed="1" covered="0"/>
+          <counter type="COMPLEXITY" missed="1" covered="0"/>
+          <counter type="METHOD" missed="1" covered="0"/>
+        </method>
+        <method name="_CLI_Usage" desc="()Lorg/jvnet/localizer/Localizable;" line="271">
+          <counter type="INSTRUCTION" missed="8" covered="0"/>
+          <counter type="LINE" missed="1" covered="0"/>
+          <counter type="COMPLEXITY" missed="1" covered="0"/>
+          <counter type="METHOD" missed="1" covered="0"/>
+        </method>
+        <method name="CLI_BadAuth" desc="()Ljava/lang/String;" line="283">
+          <counter type="INSTRUCTION" missed="6" covered="0"/>
+          <counter type="LINE" missed="1" covered="0"/>
+          <counter type="COMPLEXITY" missed="1" covered="0"/>
+          <counter type="METHOD" missed="1" covered="0"/>
+        </method>
+        <method name="_CLI_BadAuth" desc="()Lorg/jvnet/localizer/Localizable;" line="295">
+          <counter type="INSTRUCTION" missed="8" covered="0"/>
+          <counter type="LINE" missed="1" covered="0"/>
+          <counter type="COMPLEXITY" missed="1" covered="0"/>
+          <counter type="METHOD" missed="1" covered="0"/>
+        </method>
+        <method name="&lt;clinit&gt;" desc="()V" line="26">
+          <counter type="INSTRUCTION" missed="4" covered="0"/>
+          <counter type="LINE" missed="1" covered="0"/>
+          <counter type="COMPLEXITY" missed="1" covered="0"/>
+          <counter type="METHOD" missed="1" covered="0"/>
+        </method>
+        <counter type="INSTRUCTION" missed="71" covered="0"/>
+        <counter type="LINE" missed="10" covered="0"/>
+        <counter type="COMPLEXITY" missed="10" covered="0"/>
+        <counter type="METHOD" missed="10" covered="0"/>
+        <counter type="CLASS" missed="1" covered="0"/>
+      </class>
+      <sourcefile name="Messages.java">
+        <line nr="20" mi="3" ci="0" mb="0" cb="0"/>
+        <line nr="26" mi="4" ci="0" mb="0" cb="0"/>
+        <line nr="37" mi="10" ci="0" mb="0" cb="0"/>
+        <line nr="49" mi="12" ci="0" mb="0" cb="0"/>
+        <line nr="60" mi="6" ci="0" mb="0" cb="0"/>
+        <line nr="71" mi="8" ci="0" mb="0" cb="0"/>
+        <line nr="171" mi="6" ci="0" mb="0" cb="0"/>
+        <line nr="271" mi="8" ci="0" mb="0" cb="0"/>
+        <line nr="283" mi="6" ci="0" mb="0" cb="0"/>
+        <line nr="295" mi="8" ci="0" mb="0" cb="0"/>
+        <counter type="INSTRUCTION" missed="71" covered="0"/>
+        <counter type="LINE" missed="10" covered="0"/>
+        <counter type="COMPLEXITY" missed="10" covered="0"/>
+        <counter type="METHOD" missed="10" covered="0"/>
+        <counter type="CLASS" missed="1" covered="0"/>
+      </sourcefile>
+      <counter type="INSTRUCTION" missed="71" covered="0"/>
+      <counter type="LINE" missed="10" covered="0"/>
+      <counter type="COMPLEXITY" missed="10" covered="0"/>
+      <counter type="METHOD" missed="10" covered="0"/>
+      <counter type="CLASS" missed="1" covered="0"/>
+    </package>
+    <counter type="INSTRUCTION" missed="2281" covered="1318"/>
+    <counter type="BRANCH" missed="273" covered="114"/>
+    <counter type="LINE" missed="558" covered="337"/>
+    <counter type="COMPLEXITY" missed="268" covered="103"/>
+    <counter type="METHOD" missed="101" covered="66"/>
+    <counter type="CLASS" missed="16" covered="16"/>
+  </group>
+  <group name="jenkins-core">
+    <package name="org/acegisecurity/context">
+      <class name="org/acegisecurity/context/SecurityContextHolder" sourcefilename="SecurityContextHolder.java">
+        <method name="&lt;init&gt;" desc="()V" line="34">
+          <counter type="INSTRUCTION" missed="3" covered="0"/>
+          <counter type="LINE" missed="1" covered="0"/>
+          <counter type="COMPLEXITY" missed="1" covered="0"/>
+          <counter type="METHOD" missed="1" covered="0"/>
+        </method>
+        <method name="getContext" desc="()Lorg/acegisecurity/context/SecurityContext;" line="37">
+          <counter type="INSTRUCTION" missed="3" covered="0"/>
+          <counter type="LINE" missed="1" covered="0"/>
+          <counter type="COMPLEXITY" missed="1" covered="0"/>
+          <counter type="METHOD" missed="1" covered="0"/>
+        </method>
+        <method name="setContext" desc="(Lorg/acegisecurity/context/SecurityContext;)V" line="41">
+          <counter type="INSTRUCTION" missed="4" covered="0"/>
+          <counter type="LINE" missed="2" covered="0"/>
+          <counter type="COMPLEXITY" missed="1" covered="0"/>
+          <counter type="METHOD" missed="1" covered="0"/>
+        </method>
+        <method name="clearContext" desc="()V" line="45">
+          <counter type="INSTRUCTION" missed="2" covered="0"/>
+          <counter type="LINE" missed="2" covered="0"/>
+          <counter type="COMPLEXITY" missed="1" covered="0"/>
+          <counter type="METHOD" missed="1" covered="0"/>
+        </method>
+        <counter type="INSTRUCTION" missed="12" covered="0"/>
+        <counter type="LINE" missed="6" covered="0"/>
+        <counter type="COMPLEXITY" missed="4" covered="0"/>
+        <counter type="METHOD" missed="4" covered="0"/>
+        <counter type="CLASS" missed="1" covered="0"/>
+      </class>
+              <counter type="INSTRUCTION" missed="1361" covered="4212"/>
+      <counter type="BRANCH" missed="141" covered="335"/>
+      <counter type="LINE" missed="324" covered="932"/>
+      <counter type="COMPLEXITY" missed="178" covered="391"/>
+      <counter type="METHOD" missed="71" covered="258"/>
+      <counter type="CLASS" missed="3" covered="52"/>
+    </package>
+    <counter type="INSTRUCTION" missed="80151" covered="159210"/>
+    <counter type="BRANCH" missed="8541" covered="12832"/>
+    <counter type="LINE" missed="17542" covered="35274"/>
+    <counter type="COMPLEXITY" missed="11119" covered="14879"/>
+    <counter type="METHOD" missed="5166" covered="10095"/>
+    <counter type="CLASS" missed="375" covered="1873"/>
+  </group>
+  <counter type="INSTRUCTION" missed="82432" covered="160528"/>
+  <counter type="BRANCH" missed="8814" covered="12946"/>
+  <counter type="LINE" missed="18100" covered="35611"/>
+  <counter type="COMPLEXITY" missed="11387" covered="14982"/>
+  <counter type="METHOD" missed="5267" covered="10161"/>
+  <counter type="CLASS" missed="391" covered="1889"/>
+</report>


### PR DESCRIPTION
See exception in https://github.com/jenkinsci/jenkins/pull/7831

JaCoCo reports can contain [groups](https://github.com/jacoco/jacoco/blob/31f16d834819526cf1e8ffbafed4b7e3fe5ed502/org.jacoco.report/src/org/jacoco/report/xml/report.dtd#L34-L37) as element below a report.
