### PR TITLE
Rewrite merging of nodes

### DIFF
--- a/src/main/java/edu/hm/hafner/coverage/Coverage.java
+++ b/src/main/java/edu/hm/hafner/coverage/Coverage.java
@@ -450,14 +450,34 @@ public final class Coverage extends Value {
          * Increments the number of covered items by 1.
          */
         public void incrementCovered() {
-            setCovered(covered + 1);
+            incrementCovered(1);
+        }
+
+        /**
+         * Increments the number of covered items by the specified amount.
+         *
+         * @param amount
+         *         the amount to increment
+         */
+        public void incrementCovered(final int amount) {
+            setCovered(covered + amount);
         }
 
         /**
          * Increments the number of missed items by 1.
          */
         public void incrementMissed() {
-            setMissed(missed + 1);
+            incrementMissed(1);
+        }
+
+        /**
+         * Increments the number of missed items by the specified amount.
+         *
+         * @param amount
+         *         the amount to increment
+         */
+        public void incrementMissed(final int amount) {
+            setMissed(missed + amount);
         }
     }
 }

--- a/src/main/java/edu/hm/hafner/coverage/MethodNode.java
+++ b/src/main/java/edu/hm/hafner/coverage/MethodNode.java
@@ -11,7 +11,7 @@ public final class MethodNode extends Node {
     private static final long serialVersionUID = -5765205034179396434L;
 
     private final String signature;
-    private String methodName;
+    private /* almost final */ String methodName; // @since 0.25.0
     /** The line number where the code of method begins (not including the method head). */
     private final int lineNumber;
 
@@ -52,7 +52,6 @@ public final class MethodNode extends Node {
         }
 
         return this;
-
     }
 
     @Override

--- a/src/main/java/edu/hm/hafner/coverage/parser/CoberturaParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/parser/CoberturaParser.java
@@ -143,15 +143,19 @@ public class CoberturaParser extends CoverageParser {
                 var nextElement = event.asStartElement();
                 if (LINE.equals(nextElement.getName())) {
                     Coverage coverage;
+                    Coverage currentLineCoverage;
                     if (isBranchCoverage(nextElement)) {
                         coverage = readBranchCoverage(nextElement);
+                        currentLineCoverage = computeLineCoverage(coverage.getCovered());
+
                         branchCoverage = branchCoverage.add(coverage);
                     }
                     else {
                         int lineHits = getIntegerValueOf(nextElement, HITS);
-                        coverage = lineHits > 0 ? LINE_COVERED : LINE_MISSED;
-                        lineCoverage = lineCoverage.add(coverage);
+                        currentLineCoverage = computeLineCoverage(lineHits);
+                        coverage = currentLineCoverage;
                     }
+                    lineCoverage = lineCoverage.add(currentLineCoverage);
 
                     if (CLASS.equals(parentElement.getName())) { // Counters are stored at file level
                         int lineNumber = getIntegerValueOf(nextElement, NUMBER);
@@ -175,6 +179,10 @@ public class CoberturaParser extends CoverageParser {
             }
         }
         throw createEofException();
+    }
+
+    private Coverage computeLineCoverage(final int coverage) {
+        return coverage > 0 ? LINE_COVERED : LINE_MISSED;
     }
 
     private Node createNode(final FileNode file, final StartElement parentElement) {


### PR DESCRIPTION
Merging is now based on the actual file counters. That means information below the files (classes and methods) needs to be stripped of. Additionally, the predefined counters of inner nodes (packages, etc.) will be removed as well since they might be inaccurate after a merge.

This works well for the line coverage but cannot work for the branch coverage as we cannot identify the branches during merge. 

Will (partly) fix https://github.com/jenkinsci/code-coverage-api-plugin/issues/729.

