### PR TITLE
Make `CoberturaParser` more robost on broken input files

### DIFF
--- a/src/main/java/edu/hm/hafner/coverage/CoverageParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/CoverageParser.java
@@ -18,8 +18,46 @@ import edu.hm.hafner.util.TreeStringBuilder;
  * @author Ullrich Hafner
  */
 public abstract class CoverageParser implements Serializable {
+    /**
+     * Defines how to handle fatal errors during parsing.
+     */
+    public enum ProcessingMode {
+        /** All fatal errors will be ignored and logged. */
+        IGNORE_ERRORS,
+        /** An exception will be thrown if a fatal error is detected. */
+        FAIL_FAST
+    }
+
     private static final long serialVersionUID = 3941742254762282096L;
     private transient TreeStringBuilder treeStringBuilder = new TreeStringBuilder();
+
+    private final ProcessingMode processingMode; // since 0.26.0
+
+    /**
+     * Creates a new instance of {@link CoverageParser}.
+     *
+     * @param processingMode
+     *         determines whether to ignore errors
+     */
+    protected CoverageParser(final ProcessingMode processingMode) {
+        this.processingMode = processingMode;
+    }
+
+    /**
+     * Creates a new instance of {@link CoverageParser} that will fail on all errors.
+     */
+    protected CoverageParser() {
+        this(ProcessingMode.FAIL_FAST);
+    }
+
+    /**
+     * Returns whether to ignore errors or to fail fast.
+     *
+     * @return true if errors should be ignored, false if an exception should be thrown on errors
+     */
+    protected boolean ignoreErrors() {
+        return processingMode == ProcessingMode.IGNORE_ERRORS;
+    }
 
     /**
      * Parses a report provided by the given reader.

--- a/src/main/java/edu/hm/hafner/coverage/Node.java
+++ b/src/main/java/edu/hm/hafner/coverage/Node.java
@@ -178,6 +178,17 @@ public abstract class Node implements Serializable {
     }
 
     /**
+     * Returns whether this node has a child with the specified name.
+     *
+     * @param childName
+     *         the name of the child to look for
+     * @return {@code true} if this node has a child with the specified name, {@code false} otherwise
+     */
+    public boolean hasChild(final String childName) {
+        return children.stream().map(Node::getName).anyMatch(childName::equals);
+    }
+
+    /**
      * Adds alls given nodes as children to the current node.
      *
      * @param nodes
@@ -186,7 +197,6 @@ public abstract class Node implements Serializable {
     public void addAllChildren(final Collection<? extends Node> nodes) {
         nodes.forEach(this::addChild);
     }
-
 
     /**
      * Returns the parent node.
@@ -779,4 +789,5 @@ public abstract class Node implements Serializable {
         copy.addAllChildren(prunedChildren);
         return Optional.of(copy);
     }
+
 }

--- a/src/main/java/edu/hm/hafner/coverage/parser/CoberturaParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/parser/CoberturaParser.java
@@ -63,25 +63,21 @@ public class CoberturaParser extends CoverageParser {
     private static final QName BRANCH = new QName("branch");
     private static final QName CONDITION_COVERAGE = new QName("condition-coverage");
 
-    private final boolean ignoreErrors; // since 0.26.0
-
     /**
      * Creates a new instance of {@link CoberturaParser}.
      */
     public CoberturaParser() {
-        this(false);
+        this(ProcessingMode.FAIL_FAST);
     }
 
     /**
      * Creates a new instance of {@link CoberturaParser}.
      *
-     * @param ignoreErrors
+     * @param processingMode
      *         determines whether to ignore errors
      */
-    public CoberturaParser(final boolean ignoreErrors) {
-        super();
-
-        this.ignoreErrors = ignoreErrors;
+    public CoberturaParser(final ProcessingMode processingMode) {
+        super(processingMode);
     }
 
     @Override
@@ -182,7 +178,7 @@ public class CoberturaParser extends CoverageParser {
                 }
                 else if (METHOD.equals(nextElement.getName())) {
                     Node methodNode = readClassOrMethod(reader, fileNode, nextElement, log);
-                    if (node.hasChild(methodNode.getName()) && ignoreErrors) {
+                    if (node.hasChild(methodNode.getName()) && ignoreErrors()) {
                         log.logError("Skipping duplicate method '%s' for class '%s'", node.getName(), methodNode.getName());
                     }
                     else {

--- a/src/test/java/edu/hm/hafner/coverage/parser/AbstractParserTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/parser/AbstractParserTest.java
@@ -26,9 +26,15 @@ abstract class AbstractParserTest {
     private final FilteredLog log = new FilteredLog("Errors");
 
     ModuleNode readReport(final String fileName) {
+        var parser = createParser();
+
+        return readReport(fileName, parser);
+    }
+
+    ModuleNode readReport(final String fileName, final CoverageParser parser) {
         try (InputStream stream = AbstractParserTest.class.getResourceAsStream(fileName);
                 Reader reader = new InputStreamReader(Objects.requireNonNull(stream), StandardCharsets.UTF_8)) {
-            return createParser().parse(reader, log);
+            return parser.parse(reader, log);
         }
         catch (IOException e) {
             throw new AssertionError(e);

--- a/src/test/java/edu/hm/hafner/coverage/parser/CoberturaParserTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/parser/CoberturaParserTest.java
@@ -32,14 +32,13 @@ class CoberturaParserTest extends AbstractParserTest {
     void shouldIgnoreMissingConditionAttribute() {
         Node duplicateMethods = readReport("cobertura-missing-condition-coverage.xml");
 
-        assertThat(duplicateMethods.getAll(FILE)).extracting(Node::getName)
-                .containsExactly("DataSourceProvider.cs");
-        assertThat(duplicateMethods.getAll(CLASS)).extracting(Node::getName)
-                .containsExactly("VisualOn.Data.DataSourceProvider");
-        assertThat(duplicateMethods.getAll(METHOD)).extracting(Node::getName)
-                .containsExactly("Enumerate()");
+        verifySmallTree(duplicateMethods);
         assertThat(getLog().hasErrors()).isFalse();
 
+        verifyBranchCoverageOfLine61(duplicateMethods);
+    }
+
+    private void verifyBranchCoverageOfLine61(final Node duplicateMethods) {
         var file = duplicateMethods.getAllFileNodes().get(0);
         assertThat(file.getCoveredOfLine(61)).isEqualTo(2);
         assertThat(file.getMissedOfLine(61)).isEqualTo(0);
@@ -49,19 +48,24 @@ class CoberturaParserTest extends AbstractParserTest {
     void shouldIgnoreDuplicateMethods() {
         Node duplicateMethods = readReport("cobertura-duplicate-methods.xml", new CoberturaParser(true));
 
+        verifySmallTree(duplicateMethods);
+        assertThat(getLog().hasErrors()).isTrue();
+        assertThat(getLog().getErrorMessages())
+                .contains("Skipping duplicate method 'VisualOn.Data.DataSourceProvider' for class 'Enumerate()'");
+
+        verifyBranchCoverageOfLine61(duplicateMethods);
+
+        assertThatIllegalArgumentException().isThrownBy(
+                () -> readReport("cobertura-duplicate-methods.xml", new CoberturaParser()));
+    }
+
+    private void verifySmallTree(final Node duplicateMethods) {
         assertThat(duplicateMethods.getAll(FILE)).extracting(Node::getName)
                 .containsExactly("DataSourceProvider.cs");
         assertThat(duplicateMethods.getAll(CLASS)).extracting(Node::getName)
                 .containsExactly("VisualOn.Data.DataSourceProvider");
         assertThat(duplicateMethods.getAll(METHOD)).extracting(Node::getName)
                 .containsExactly("Enumerate()");
-        assertThat(getLog().hasErrors()).isTrue();
-        assertThat(getLog().getErrorMessages())
-                .contains("Skipping duplicate method 'VisualOn.Data.DataSourceProvider' for class 'Enumerate()'");
-
-        var file = duplicateMethods.getAllFileNodes().get(0);
-        assertThat(file.getCoveredOfLine(61)).isEqualTo(2);
-        assertThat(file.getMissedOfLine(61)).isEqualTo(0);
     }
 
     @Test

--- a/src/test/java/edu/hm/hafner/coverage/parser/CoberturaParserTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/parser/CoberturaParserTest.java
@@ -29,6 +29,42 @@ class CoberturaParserTest extends AbstractParserTest {
     }
 
     @Test
+    void shouldIgnoreMissingConditionAttribute() {
+        Node duplicateMethods = readReport("cobertura-missing-condition-coverage.xml");
+
+        assertThat(duplicateMethods.getAll(FILE)).extracting(Node::getName)
+                .containsExactly("DataSourceProvider.cs");
+        assertThat(duplicateMethods.getAll(CLASS)).extracting(Node::getName)
+                .containsExactly("VisualOn.Data.DataSourceProvider");
+        assertThat(duplicateMethods.getAll(METHOD)).extracting(Node::getName)
+                .containsExactly("Enumerate()");
+        assertThat(getLog().hasErrors()).isFalse();
+
+        var file = duplicateMethods.getAllFileNodes().get(0);
+        assertThat(file.getCoveredOfLine(61)).isEqualTo(2);
+        assertThat(file.getMissedOfLine(61)).isEqualTo(0);
+    }
+
+    @Test
+    void shouldIgnoreDuplicateMethods() {
+        Node duplicateMethods = readReport("cobertura-duplicate-methods.xml", new CoberturaParser(true));
+
+        assertThat(duplicateMethods.getAll(FILE)).extracting(Node::getName)
+                .containsExactly("DataSourceProvider.cs");
+        assertThat(duplicateMethods.getAll(CLASS)).extracting(Node::getName)
+                .containsExactly("VisualOn.Data.DataSourceProvider");
+        assertThat(duplicateMethods.getAll(METHOD)).extracting(Node::getName)
+                .containsExactly("Enumerate()");
+        assertThat(getLog().hasErrors()).isTrue();
+        assertThat(getLog().getErrorMessages())
+                .contains("Skipping duplicate method 'VisualOn.Data.DataSourceProvider' for class 'Enumerate()'");
+
+        var file = duplicateMethods.getAllFileNodes().get(0);
+        assertThat(file.getCoveredOfLine(61)).isEqualTo(2);
+        assertThat(file.getMissedOfLine(61)).isEqualTo(0);
+    }
+
+    @Test
     void shouldMergeCorrectly729() {
         var builder = new CoverageBuilder();
 

--- a/src/test/java/edu/hm/hafner/coverage/parser/CoberturaParserTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/parser/CoberturaParserTest.java
@@ -7,6 +7,7 @@ import org.junitpioneer.jupiter.DefaultLocale;
 
 import edu.hm.hafner.coverage.Coverage;
 import edu.hm.hafner.coverage.Coverage.CoverageBuilder;
+import edu.hm.hafner.coverage.CoverageParser.ProcessingMode;
 import edu.hm.hafner.coverage.CyclomaticComplexity;
 import edu.hm.hafner.coverage.FileNode;
 import edu.hm.hafner.coverage.FractionValue;
@@ -46,7 +47,8 @@ class CoberturaParserTest extends AbstractParserTest {
 
     @Test
     void shouldIgnoreDuplicateMethods() {
-        Node duplicateMethods = readReport("cobertura-duplicate-methods.xml", new CoberturaParser(true));
+        Node duplicateMethods = readReport("cobertura-duplicate-methods.xml",
+                new CoberturaParser(ProcessingMode.IGNORE_ERRORS));
 
         verifySmallTree(duplicateMethods);
         assertThat(getLog().hasErrors()).isTrue();

--- a/src/test/resources/edu/hm/hafner/coverage/parser/cobertura-duplicate-methods.xml
+++ b/src/test/resources/edu/hm/hafner/coverage/parser/cobertura-duplicate-methods.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<coverage line-rate="0.8301000000000001" branch-rate="0.75" version="1.9" timestamp="1663310122" lines-covered="44"
+          lines-valid="53" branches-covered="3" branches-valid="4">
+  <sources>
+    <source>/CoverageTest.Service/</source>
+  </sources>
+  <packages>
+    <package name="CoverageTest.Service" line-rate="0.8301000000000001" branch-rate="0.75" complexity="8">
+      <classes>
+        <class name="VisualOn.Data.DataSourceProvider" filename="src/VisualOn.Core/Data/DataSourceProvider.cs"
+               line-rate="0.925" branch-rate="0.7692307692307693" complexity="18">
+          <methods>
+            <method name="Enumerate" signature="()" line-rate="1" branch-rate="1" complexity="2">
+              <lines>
+                <line number="61" hits="2" branch="true" condition-coverage="100% (2/2)"/>
+                <line number="63" hits="2" branch="false"/>
+                <line number="65" hits="1" branch="false"/>
+              </lines>
+            </method>
+            <method name="Enumerate" signature="()" line-rate="1" branch-rate="1" complexity="2">
+              <lines>
+                <line number="69" hits="1" branch="false"/>
+                <line number="71" hits="1" branch="true" condition-coverage="100% (2/2)"/>
+                <line number="73" hits="1" branch="false"/>
+                <line number="75" hits="1" branch="false"/>
+              </lines>
+            </method>
+          </methods>
+          <lines>
+            <line number="13" hits="2" branch="false"/>
+            <line number="15" hits="2" branch="false"/>
+            <line number="16" hits="2" branch="false"/>
+            <line number="17" hits="2" branch="false"/>
+            <line number="20" hits="2" branch="true" condition-coverage="50% (1/2)"/>
+            <line number="24" hits="2" branch="false"/>
+            <line number="25" hits="2" branch="true" condition-coverage="100% (4/4)"/>
+            <line number="26" hits="2" branch="false"/>
+            <line number="28" hits="2" branch="false"/>
+            <line number="30" hits="2" branch="true" condition-coverage="50% (1/2)"/>
+            <line number="33" hits="2" branch="false"/>
+            <line number="37" hits="2" branch="true" condition-coverage="50% (1/2)"/>
+            <line number="38" hits="1" branch="false"/>
+            <line number="40" hits="2" branch="false"/>
+            <line number="41" hits="2" branch="false"/>
+            <line number="46" hits="2" branch="true" condition-coverage="50% (1/2)"/>
+            <line number="47" hits="0" branch="false"/>
+            <line number="48" hits="2" branch="false"/>
+            <line number="53" hits="2" branch="true" condition-coverage="50% (1/2)"/>
+            <line number="54" hits="0" branch="false"/>
+            <line number="56" hits="2" branch="false"/>
+            <line number="61" hits="2" branch="true" condition-coverage="100% (2/2)"/>
+            <line number="63" hits="2" branch="false"/>
+            <line number="65" hits="1" branch="false"/>
+            <line number="69" hits="1" branch="false"/>
+            <line number="71" hits="1" branch="true" condition-coverage="100% (2/2)"/>
+            <line number="73" hits="1" branch="false"/>
+            <line number="75" hits="1" branch="false"/>
+            <line number="77" hits="1" branch="false"/>
+            <line number="81" hits="2" branch="true" condition-coverage="50% (1/2)"/>
+            <line number="82" hits="0" branch="false"/>
+            <line number="84" hits="2" branch="false"/>
+            <line number="85" hits="2" branch="false"/>
+            <line number="87" hits="2" branch="true" condition-coverage="100% (2/2)"/>
+            <line number="88" hits="2" branch="false"/>
+            <line number="90" hits="2" branch="true" condition-coverage="100% (2/2)"/>
+            <line number="91" hits="2" branch="false"/>
+            <line number="93" hits="2" branch="true" condition-coverage="100% (2/2)"/>
+            <line number="94" hits="2" branch="false"/>
+            <line number="96" hits="2" branch="false"/>
+          </lines>
+        </class>
+      </classes>
+    </package>
+  </packages>
+</coverage>

--- a/src/test/resources/edu/hm/hafner/coverage/parser/cobertura-missing-condition-coverage.xml
+++ b/src/test/resources/edu/hm/hafner/coverage/parser/cobertura-missing-condition-coverage.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<coverage line-rate="0.8301000000000001" branch-rate="0.75" version="1.9" timestamp="1663310122" lines-covered="44"
+          lines-valid="53" branches-covered="3" branches-valid="4">
+  <sources>
+    <source>/CoverageTest.Service/</source>
+  </sources>
+  <packages>
+    <package name="CoverageTest.Service" line-rate="0.8301000000000001" branch-rate="0.75" complexity="8">
+      <classes>
+        <class name="VisualOn.Data.DataSourceProvider" filename="src/VisualOn.Core/Data/DataSourceProvider.cs"
+               line-rate="0.925" branch-rate="0.7692307692307693" complexity="18">
+          <methods>
+            <method name="Enumerate" signature="()" line-rate="1" branch-rate="1" complexity="2">
+              <lines>
+                <line number="61" hits="2" branch="true"/>
+                <line number="63" hits="2" branch="false"/>
+                <line number="65" hits="1" branch="false"/>
+              </lines>
+            </method>
+          </methods>
+          <lines>
+            <line number="13" hits="2" branch="false"/>
+            <line number="15" hits="2" branch="false"/>
+            <line number="16" hits="2" branch="false"/>
+            <line number="17" hits="2" branch="false"/>
+            <line number="20" hits="2" branch="true" condition-coverage="50% (1/2)"/>
+            <line number="24" hits="2" branch="false"/>
+            <line number="25" hits="2" branch="true" condition-coverage="100% (4/4)"/>
+            <line number="26" hits="2" branch="false"/>
+            <line number="28" hits="2" branch="false"/>
+            <line number="30" hits="2" branch="true" condition-coverage="50% (1/2)"/>
+            <line number="33" hits="2" branch="false"/>
+            <line number="37" hits="2" branch="true" condition-coverage="50% (1/2)"/>
+            <line number="38" hits="1" branch="false"/>
+            <line number="40" hits="2" branch="false"/>
+            <line number="41" hits="2" branch="false"/>
+            <line number="46" hits="2" branch="true" condition-coverage="50% (1/2)"/>
+            <line number="47" hits="0" branch="false"/>
+            <line number="48" hits="2" branch="false"/>
+            <line number="53" hits="2" branch="true" condition-coverage="50% (1/2)"/>
+            <line number="54" hits="0" branch="false"/>
+            <line number="56" hits="2" branch="false"/>
+            <line number="61" hits="2" branch="true"/>
+            <line number="63" hits="2" branch="false"/>
+            <line number="65" hits="1" branch="false"/>
+            <line number="69" hits="1" branch="false"/>
+            <line number="71" hits="1" branch="true"/>
+            <line number="73" hits="1" branch="false"/>
+            <line number="75" hits="1" branch="false"/>
+            <line number="77" hits="1" branch="false"/>
+            <line number="81" hits="2" branch="true" condition-coverage="50% (1/2)"/>
+            <line number="82" hits="0" branch="false"/>
+            <line number="84" hits="2" branch="false"/>
+            <line number="85" hits="2" branch="false"/>
+            <line number="87" hits="2" branch="true"/>
+            <line number="88" hits="2" branch="false"/>
+            <line number="90" hits="2" branch="true"/>
+            <line number="91" hits="2" branch="false"/>
+            <line number="93" hits="2" branch="true"/>
+            <line number="94" hits="2" branch="false"/>
+            <line number="96" hits="2" branch="false"/>
+          </lines>
+        </class>
+      </classes>
+    </package>
+  </packages>
+</coverage>


### PR DESCRIPTION
Add a new optional property to the parser to ignore all errors. Additionally, use a default value of 2/2 when branch coverage is missing the details attribute `condition-coverage`.

See https://github.com/jenkinsci/code-coverage-api-plugin/issues/785
