### PR TITLE
Make `ProcessingMode` a parameter in the registry

### DIFF
--- a/src/main/java/edu/hm/hafner/coverage/parser/CoberturaParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/parser/CoberturaParser.java
@@ -33,7 +33,7 @@ import edu.hm.hafner.util.SecureXmlParserFactory.ParsingException;
  * @author Melissa Bauer
  * @author Ullrich Hafner
  */
-@SuppressWarnings("checkstyle:ClassDataAbstractionCoupling")
+@SuppressWarnings({"checkstyle:ClassDataAbstractionCoupling", "PMD.GodClass"})
 public class CoberturaParser extends CoverageParser {
     private static final long serialVersionUID = -3625341318291829577L;
 

--- a/src/main/java/edu/hm/hafner/coverage/registry/ParserRegistry.java
+++ b/src/main/java/edu/hm/hafner/coverage/registry/ParserRegistry.java
@@ -1,6 +1,7 @@
 package edu.hm.hafner.coverage.registry;
 
 import edu.hm.hafner.coverage.CoverageParser;
+import edu.hm.hafner.coverage.CoverageParser.ProcessingMode;
 import edu.hm.hafner.coverage.parser.CoberturaParser;
 import edu.hm.hafner.coverage.parser.JacocoParser;
 import edu.hm.hafner.coverage.parser.PitestParser;
@@ -22,12 +23,19 @@ public class ParserRegistry {
      * Returns the parser for the specified name.
      *
      * @param parserName
-     *         the name of the parser
+     *         the unique name of the parser
+     * @param processingMode
+     *         determines whether to ignore errors
      *
      * @return the created parser
      */
-    public CoverageParser getParser(final String parserName) {
-        return getParser(CoverageParserType.valueOf(parserName));
+    public CoverageParser getParser(final String parserName, final ProcessingMode processingMode) {
+        try {
+            return getParser(CoverageParserType.valueOf(parserName), processingMode);
+        }
+        catch (IllegalArgumentException exception) {
+            throw new IllegalArgumentException("Unknown parser name: " + parserName, exception);
+        }
     }
 
     /**
@@ -35,13 +43,15 @@ public class ParserRegistry {
      *
      * @param parser
      *         the parser
+     * @param processingMode
+     *         determines whether to ignore errors
      *
      * @return the created parser
      */
-    public CoverageParser getParser(final CoverageParserType parser) {
+    public CoverageParser getParser(final CoverageParserType parser, final ProcessingMode processingMode) {
         switch (parser) {
             case COBERTURA:
-                return new CoberturaParser();
+                return new CoberturaParser(processingMode);
             case JACOCO:
                 return new JacocoParser();
             case PIT:

--- a/src/test/java/edu/hm/hafner/coverage/registry/ParserRegistryTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/registry/ParserRegistryTest.java
@@ -1,0 +1,27 @@
+package edu.hm.hafner.coverage.registry;
+
+import org.junit.jupiter.api.Test;
+
+import edu.hm.hafner.coverage.CoverageParser.ProcessingMode;
+import edu.hm.hafner.coverage.parser.CoberturaParser;
+import edu.hm.hafner.coverage.parser.JacocoParser;
+import edu.hm.hafner.coverage.registry.ParserRegistry.CoverageParserType;
+
+import static org.assertj.core.api.Assertions.*;
+
+class ParserRegistryTest {
+    @Test
+    void shouldCreateSomeParsers() {
+        var registry = new ParserRegistry();
+
+        assertThat(registry.getParser(CoverageParserType.COBERTURA.name(), ProcessingMode.FAIL_FAST)).isInstanceOf(CoberturaParser.class);
+        assertThat(registry.getParser(CoverageParserType.JACOCO, ProcessingMode.IGNORE_ERRORS)).isInstanceOf(JacocoParser.class);
+    }
+
+    @Test
+    void shouldThrowExceptionForNotSupportedTypes() {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> new ParserRegistry().getParser("UNKNOWN", ProcessingMode.FAIL_FAST))
+                .withMessageContaining("Unknown parser name: UNKNOWN");
+    }
+}


### PR DESCRIPTION
Otherwise the coverage API cannot use the property.

Followup for https://github.com/jenkinsci/code-coverage-api-plugin/issues/785