### PR TITLE
Ignore duplicate classes in Cobertura reports

### DIFF
--- a/src/main/java/edu/hm/hafner/coverage/ClassNode.java
+++ b/src/main/java/edu/hm/hafner/coverage/ClassNode.java
@@ -36,4 +36,19 @@ public final class ClassNode extends Node {
         addChild(fileNode);
         return fileNode;
     }
+
+    /**
+     * Returns whether this node contains a method with the specified name and signature.
+     *
+     * @param methodName
+     *         the name of the method
+     * @param signature
+     *         the signature of the method
+     *
+     * @return {@code true} if this node has a child with the specified name and signature, {@code false} otherwise
+     */
+    public boolean hasMethod(final String methodName, final String signature) {
+        return getAllMethodNodes().stream()
+                .anyMatch(m -> m.getMethodName().equals(methodName) && m.getSignature().equals(signature));
+    }
 }

--- a/src/main/java/edu/hm/hafner/coverage/ClassNode.java
+++ b/src/main/java/edu/hm/hafner/coverage/ClassNode.java
@@ -36,19 +36,4 @@ public final class ClassNode extends Node {
         addChild(fileNode);
         return fileNode;
     }
-
-    /**
-     * Returns whether this node contains a method with the specified name and signature.
-     *
-     * @param methodName
-     *         the name of the method
-     * @param signature
-     *         the signature of the method
-     *
-     * @return {@code true} if this node has a child with the specified name and signature, {@code false} otherwise
-     */
-    public boolean hasMethod(final String methodName, final String signature) {
-        return getAllMethodNodes().stream()
-                .anyMatch(m -> m.getMethodName().equals(methodName) && m.getSignature().equals(signature));
-    }
 }

--- a/src/main/java/edu/hm/hafner/coverage/Percentage.java
+++ b/src/main/java/edu/hm/hafner/coverage/Percentage.java
@@ -118,6 +118,15 @@ public final class Percentage implements Serializable {
     }
 
     /**
+     * Returns this percentage as an int value in the interval [0, 100].
+     *
+     * @return the coverage percentage
+     */
+    public int toInt() {
+        return Math.round(items * 100.0f / total);
+    }
+
+    /**
      * Formats a percentage to plain text and rounds the value to two decimals.
      *
      * @param locale

--- a/src/main/java/edu/hm/hafner/coverage/parser/CoberturaParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/parser/CoberturaParser.java
@@ -217,7 +217,7 @@ public class CoberturaParser extends CoverageParser {
         }
         var signature = getValueOf(element, SIGNATURE);
         var classNode = (ClassNode) parentNode;
-        if (classNode.hasMethod(name, signature) && ignoreErrors()) {
+        if (classNode.findMethod(name, signature).isPresent() && ignoreErrors()) {
             log.logError("Found a duplicate method '%s' with signature '%s' in '%s'", name, signature, parentNode.getName());
             name = name + "-" + createId();
         }

--- a/src/test/java/edu/hm/hafner/coverage/PercentageTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/PercentageTest.java
@@ -20,6 +20,7 @@ class PercentageTest {
         Fraction fraction = Fraction.getFraction(Integer.MAX_VALUE - 1, Integer.MAX_VALUE - 1);
         Percentage percentage = Percentage.valueOf(fraction);
         assertThat(percentage.toDouble()).isEqualTo(100);
+        assertThat(percentage.toInt()).isEqualTo(100);
     }
 
     @Test

--- a/src/test/resources/edu/hm/hafner/coverage/parser/cobertura-duplicate-classes.xml
+++ b/src/test/resources/edu/hm/hafner/coverage/parser/cobertura-duplicate-classes.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="utf-8"?>
+<coverage line-rate="0.8301000000000001" branch-rate="0.75" version="1.9" timestamp="1663310122" lines-covered="44"
+          lines-valid="53" branches-covered="3" branches-valid="4">
+  <sources>
+    <source>/CoverageTest.Service/</source>
+  </sources>
+  <packages>
+    <package name="CoverageTest.Service" line-rate="0.8301000000000001" branch-rate="0.75" complexity="8">
+      <classes>
+        <class name="VisualOn.Data.DataSourceProvider" filename="src/VisualOn.Core/Data/DataSourceProvider.cs"
+               line-rate="0.925" branch-rate="0.7692307692307693" complexity="18">
+          <methods>
+            <method name="Enumerate" signature="()" line-rate="1" branch-rate="1" complexity="2">
+              <lines>
+                <line number="61" hits="2" branch="true" condition-coverage="100% (2/2)"/>
+                <line number="63" hits="2" branch="false"/>
+                <line number="65" hits="1" branch="false"/>
+              </lines>
+            </method>
+          </methods>
+          <lines>
+            <line number="13" hits="2" branch="false"/>
+            <line number="15" hits="2" branch="false"/>
+            <line number="16" hits="2" branch="false"/>
+            <line number="17" hits="2" branch="false"/>
+            <line number="20" hits="2" branch="true" condition-coverage="50% (1/2)"/>
+            <line number="24" hits="2" branch="false"/>
+            <line number="25" hits="2" branch="true" condition-coverage="100% (4/4)"/>
+            <line number="26" hits="2" branch="false"/>
+            <line number="28" hits="2" branch="false"/>
+            <line number="30" hits="2" branch="true" condition-coverage="50% (1/2)"/>
+            <line number="33" hits="2" branch="false"/>
+            <line number="37" hits="2" branch="true" condition-coverage="50% (1/2)"/>
+            <line number="38" hits="1" branch="false"/>
+            <line number="40" hits="2" branch="false"/>
+            <line number="41" hits="2" branch="false"/>
+            <line number="46" hits="2" branch="true" condition-coverage="50% (1/2)"/>
+            <line number="47" hits="0" branch="false"/>
+            <line number="48" hits="2" branch="false"/>
+            <line number="53" hits="2" branch="true" condition-coverage="50% (1/2)"/>
+            <line number="54" hits="0" branch="false"/>
+            <line number="56" hits="2" branch="false"/>
+            <line number="61" hits="2" branch="true" condition-coverage="100% (2/2)"/>
+            <line number="63" hits="2" branch="false"/>
+            <line number="65" hits="1" branch="false"/>
+            <line number="69" hits="1" branch="false"/>
+            <line number="71" hits="1" branch="true" condition-coverage="100% (2/2)"/>
+            <line number="73" hits="1" branch="false"/>
+            <line number="75" hits="1" branch="false"/>
+            <line number="77" hits="1" branch="false"/>
+            <line number="81" hits="2" branch="true" condition-coverage="50% (1/2)"/>
+            <line number="82" hits="0" branch="false"/>
+            <line number="84" hits="2" branch="false"/>
+            <line number="85" hits="2" branch="false"/>
+            <line number="87" hits="2" branch="true" condition-coverage="100% (2/2)"/>
+            <line number="88" hits="2" branch="false"/>
+            <line number="90" hits="2" branch="true" condition-coverage="100% (2/2)"/>
+            <line number="91" hits="2" branch="false"/>
+            <line number="93" hits="2" branch="true" condition-coverage="100% (2/2)"/>
+            <line number="94" hits="2" branch="false"/>
+            <line number="96" hits="2" branch="false"/>
+          </lines>
+        </class>
+        <class name="VisualOn.Data.DataSourceProvider" filename="src/VisualOn.Core/Data/DataSourceProvider.cs"
+               line-rate="0.925" branch-rate="0.7692307692307693" complexity="18">
+          <methods>
+            <method name="Enumerate" signature="()" line-rate="1" branch-rate="1" complexity="2">
+              <lines>
+                <line number="61" hits="2" branch="true" condition-coverage="100% (2/2)"/>
+                <line number="63" hits="2" branch="false"/>
+                <line number="65" hits="1" branch="false"/>
+              </lines>
+            </method>
+          </methods>
+          <lines>
+            <line number="13" hits="2" branch="false"/>
+            <line number="15" hits="2" branch="false"/>
+            <line number="16" hits="2" branch="false"/>
+            <line number="17" hits="2" branch="false"/>
+            <line number="20" hits="2" branch="true" condition-coverage="50% (1/2)"/>
+            <line number="24" hits="2" branch="false"/>
+            <line number="25" hits="2" branch="true" condition-coverage="100% (4/4)"/>
+            <line number="26" hits="2" branch="false"/>
+            <line number="28" hits="2" branch="false"/>
+            <line number="30" hits="2" branch="true" condition-coverage="50% (1/2)"/>
+            <line number="33" hits="2" branch="false"/>
+            <line number="37" hits="2" branch="true" condition-coverage="50% (1/2)"/>
+            <line number="38" hits="1" branch="false"/>
+            <line number="40" hits="2" branch="false"/>
+            <line number="41" hits="2" branch="false"/>
+            <line number="46" hits="2" branch="true" condition-coverage="50% (1/2)"/>
+            <line number="47" hits="0" branch="false"/>
+            <line number="48" hits="2" branch="false"/>
+            <line number="53" hits="2" branch="true" condition-coverage="50% (1/2)"/>
+            <line number="54" hits="0" branch="false"/>
+            <line number="56" hits="2" branch="false"/>
+            <line number="61" hits="2" branch="true" condition-coverage="100% (2/2)"/>
+            <line number="63" hits="2" branch="false"/>
+            <line number="65" hits="1" branch="false"/>
+            <line number="69" hits="1" branch="false"/>
+            <line number="71" hits="1" branch="true" condition-coverage="100% (2/2)"/>
+            <line number="73" hits="1" branch="false"/>
+            <line number="75" hits="1" branch="false"/>
+            <line number="77" hits="1" branch="false"/>
+            <line number="81" hits="2" branch="true" condition-coverage="50% (1/2)"/>
+            <line number="82" hits="0" branch="false"/>
+            <line number="84" hits="2" branch="false"/>
+            <line number="85" hits="2" branch="false"/>
+            <line number="87" hits="2" branch="true" condition-coverage="100% (2/2)"/>
+            <line number="88" hits="2" branch="false"/>
+            <line number="90" hits="2" branch="true" condition-coverage="100% (2/2)"/>
+            <line number="91" hits="2" branch="false"/>
+            <line number="93" hits="2" branch="true" condition-coverage="100% (2/2)"/>
+            <line number="94" hits="2" branch="false"/>
+            <line number="96" hits="2" branch="false"/>
+          </lines>
+        </class>
+      </classes>
+    </package>
+  </packages>
+</coverage>


### PR DESCRIPTION
Duplicate classes and methods now get a new generated suffix in the name to make them unique.

See https://github.com/jenkinsci/code-coverage-api-plugin/pull/788#issuecomment-1789752978