### PR TITLE
Add support for OpenCover format

### DIFF
--- a/src/main/java/edu/hm/hafner/coverage/parser/OpenCoverParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/parser/OpenCoverParser.java
@@ -289,7 +289,7 @@ public class OpenCoverParser extends CoverageParser {
             else if (event.isEndElement()) {
                 var endElement = event.asEndElement();
                 if (SEQUENCE_POINT.equals(endElement.getName()) || SEQUENCE_POINTS.equals(endElement.getName())) {
-                    return;
+                    break;
                 }
             }
         }
@@ -310,7 +310,7 @@ public class OpenCoverParser extends CoverageParser {
             else if (event.isEndElement()) {
                 var endElement = event.asEndElement();
                 if (BRANCH_POINT.equals(endElement.getName()) || BRANCH_POINTS.equals(endElement.getName())) {
-                    return;
+                    break;
                 }
             }
         }

--- a/src/main/java/edu/hm/hafner/coverage/parser/OpenCoverParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/parser/OpenCoverParser.java
@@ -92,7 +92,7 @@ public class OpenCoverParser extends CoverageParser {
     protected ModuleNode parseReport(final Reader reader, final FilteredLog log) {
         try {
             var eventReader = new SecureXmlParserFactory().createXmlEventReader(reader);
-            var root = new ModuleNode("-");
+            var root = new ModuleNode(EMPTY);
             var isEmpty = true;
             while (eventReader.hasNext()) {
                 XMLEvent event = eventReader.nextEvent();
@@ -124,7 +124,7 @@ public class OpenCoverParser extends CoverageParser {
         Map<String, String> files = new LinkedHashMap<>();
         List<CoverageClassHolder> classes = new LinkedList<>();
         boolean isEmpty = true;
-        PackageNode packageNode = new PackageNode("-");
+        PackageNode packageNode = new PackageNode(EMPTY);
         while (reader.hasNext()) {
             XMLEvent event = reader.nextEvent();
             if (event.isStartElement()) {

--- a/src/main/java/edu/hm/hafner/coverage/parser/OpenCoverParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/parser/OpenCoverParser.java
@@ -1,0 +1,443 @@
+package edu.hm.hafner.coverage.parser;
+
+import java.io.Reader;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLEventReader;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.events.StartElement;
+import javax.xml.stream.events.XMLEvent;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.MutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+
+import edu.hm.hafner.coverage.ClassNode;
+import edu.hm.hafner.coverage.Coverage.CoverageBuilder;
+import edu.hm.hafner.coverage.CoverageParser;
+import edu.hm.hafner.coverage.CyclomaticComplexity;
+import edu.hm.hafner.coverage.FileNode;
+import edu.hm.hafner.coverage.MethodNode;
+import edu.hm.hafner.coverage.Metric;
+import edu.hm.hafner.coverage.ModuleNode;
+import edu.hm.hafner.coverage.PackageNode;
+import edu.hm.hafner.util.FilteredLog;
+import edu.hm.hafner.util.PathUtil;
+import edu.hm.hafner.util.SecureXmlParserFactory;
+import edu.hm.hafner.util.SecureXmlParserFactory.ParsingException;
+
+/**
+ * A parser which parses reports made by OpenCover into a Java Object Model.
+ *
+ */
+@SuppressWarnings({"checkstyle:ClassDataAbstractionCoupling", "PMD.GodClass"})
+public class OpenCoverParser extends CoverageParser {
+    private static final long serialVersionUID = 1L;
+
+    private static final PathUtil PATH_UTIL = new PathUtil();
+
+    /** XML elements. */
+    private static final QName MODULE = new QName("Module");
+    private static final QName CLASS = new QName("Class");
+    private static final QName METHOD = new QName("Method");
+    private static final QName CLASS_NAME = new QName("FullName");
+    private static final QName METHOD_NAME = new QName("Name");
+    private static final QName MODULE_NAME = new QName("ModuleName");
+    private static final QName FILE = new QName("File");
+    private static final QName FILE_REF = new QName("FileRef");
+    private static final QName SUMMARY = new QName("Summary");
+    private static final QName SEQUENCE_POINTS = new QName("SequencePoints");
+    private static final QName SEQUENCE_POINT = new QName("SequencePoint");
+    private static final QName BRANCH_POINTS = new QName("BranchPoints");
+    private static final QName BRANCH_POINT = new QName("BranchPoint");
+
+    private static final QName SOURCE_LINE_NUMBER = new QName("sl");
+    private static final QName SOURCE_LINE_HINT = new QName("vc");
+    private static final QName MODULE_SKIPPED = new QName("skippedDueTo");
+    private static final QName METHOD_VISITED = new QName("visited");
+    private static final QName UID = new QName("uid");
+    private static final QName FULL_PATH = new QName("fullPath");
+    private static final QName METHOD_INTRUCTION_COVERED = new QName("visitedSequencePoints");
+    private static final QName METHOD_INTRUCTION_TOTAL = new QName("numSequencePoints");
+    private static final QName METHOD_BRANCH_COVERED = new QName("visitedBranchPoints");
+    private static final QName METHOD_BRANCH_TOTAL = new QName("numBranchPoints");
+    private static final QName METHOD_CYCLOMATIC_COMPLEXITY = new QName("cyclomaticComplexity");
+
+    @Override
+    @SuppressWarnings("PMD.CyclomaticComplexity")
+    protected ModuleNode parseReport(final Reader reader, final FilteredLog log) {
+        try {
+            var eventReader = new SecureXmlParserFactory().createXmlEventReader(reader);
+            var root = new ModuleNode("-");
+            var isEmpty = true;
+            while (eventReader.hasNext()) {
+                XMLEvent event = eventReader.nextEvent();
+                if (event.isStartElement()) {
+                    var startElement = event.asStartElement();
+                    var tagName = startElement.getName();
+                    if (MODULE.equals(tagName) && startElement.getAttributeByName(MODULE_SKIPPED) == null) {
+                        isEmpty = readModule(eventReader, root);
+                    }
+                }
+            }
+            if (isEmpty) { 
+                if (ignoreErrors()) { 
+                    log.logError("No coverage information found in the specified file."); 
+                } 
+                else { 
+                    throw new NoSuchElementException("No coverage information found in the specified file."); 
+                } 
+            }
+            return root;
+        }
+        catch (XMLStreamException exception) {
+            throw new ParsingException(exception);
+        }
+    }
+
+    @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.CognitiveComplexity"})
+    private boolean readModule(final XMLEventReader reader, final ModuleNode root) throws XMLStreamException {
+        Map<String, String> files = new LinkedHashMap<>();
+        List<CoverageClassHolder> classes = new LinkedList<>();
+        boolean isEmpty = true;
+        PackageNode packageNode = new PackageNode("-");
+        while (reader.hasNext()) {
+            XMLEvent event = reader.nextEvent();
+            if (event.isStartElement()) {
+                var nextElement = event.asStartElement();
+                if (CLASS.equals(nextElement.getName())) {
+                    classes.add(readClass(reader));
+                }
+                else if (FILE.equals(nextElement.getName())) {
+                    var fileName = getValueOf(nextElement, FULL_PATH);
+                    var uid = getValueOf(nextElement, UID);
+                    var relativePath = PATH_UTIL.getRelativePath(fileName);
+                    files.put(uid, relativePath);
+                }
+                else if (MODULE_NAME.equals(nextElement.getName())) {
+                    String packageName = reader.nextEvent().asCharacters().getData();
+                    packageNode = root.findOrCreatePackageNode(packageName);
+                    isEmpty = false;
+                }
+            }
+            else if (event.isEndElement()) {
+                var nextElement = event.asEndElement();
+                if (MODULE.equals(nextElement.getName())) {
+                    break;
+                }
+            }
+        }
+
+        if (isEmpty) {
+            return true;
+        }
+
+        // Creating all nodes
+        for (var file : files.entrySet()) {
+            FileNode fileNode = packageNode.findOrCreateFileNode(getFileName(file.getValue()), getTreeStringBuilder().intern(file.getValue()));
+            for (CoverageClassHolder clazz : classes) {
+                if (clazz.hasMethods() && clazz.getFileId() != null && clazz.getFileId().equals(file.getKey())) {
+                    ClassNode classNode = fileNode.createClassNode(clazz.getClassName());
+                    for (var method : clazz.getMethods()) {
+                        if (classNode.findMethod(method.getMethodName(), method.getMethodName()).isEmpty()) {
+                            createPoints(fileNode, classNode, method);
+                        }
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    private void createPoints(final FileNode fileNode, final ClassNode classNode, final CoverageMethod method) {
+        MethodNode methodNode = classNode.createMethodNode(method.getMethodName(), method.getMethodName());
+        var builder = new CoverageBuilder();
+        var branchCoverage = builder.withMetric(Metric.BRANCH)
+                    .withCovered(method.getBranchCovered())
+                    .withMissed(method.getBranchMissed()).build();
+        var instructionCoverage = builder.withMetric(Metric.INSTRUCTION)
+                    .withCovered(method.getInstructionCovered())
+                    .withMissed(method.getInstructionMissed()).build();
+        var lineCoverage = builder.withMetric(Metric.LINE)
+                    .withCovered(method.getInstructionCovered())
+                    .withMissed(method.getInstructionMissed()).build();
+        methodNode.addValue(lineCoverage);
+        methodNode.addValue(branchCoverage);
+        methodNode.addValue(instructionCoverage);
+        methodNode.addValue(new CyclomaticComplexity(method.getComplexity(), Metric.COMPLEXITY));
+        Map<Integer, Pair<Integer, Integer>> points = new LinkedHashMap<>();
+
+        // Line coverage only
+        for (var sequencePoint : method.getSequencePoints()) {
+            points.put(sequencePoint.getLineNumber(), Pair.of(sequencePoint.getHint(), 0));
+        }
+
+        // Branch coverage (update existing line coverage)
+        for (var branchPoint : method.getBranchPoints()) {
+            if (points.containsKey(branchPoint.getLineNumber())) {
+                points.put(branchPoint.getLineNumber(), Pair.of(points.get(branchPoint.getLineNumber()).getLeft(), branchPoint.getRight()));
+            }
+        }
+
+        // Create all counters for each point
+        for (var point : points.entrySet()) {
+            addCounters(fileNode, point.getKey(), point.getValue().getLeft(), point.getValue().getRight());
+        }
+    }
+
+    @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.CognitiveComplexity"})
+    private CoverageClassHolder readClass(final XMLEventReader reader) throws XMLStreamException {
+        String className = StringUtils.EMPTY;
+        List<CoverageMethod> methods = new LinkedList<>();
+        while (reader.hasNext()) {
+            XMLEvent event = reader.nextEvent();
+            if (event.isStartElement()) {
+                var nextElement = event.asStartElement();
+                if (CLASS_NAME.equals(nextElement.getName())) {
+                    className = reader.nextEvent().asCharacters().getData();
+                }
+                // Only add visited methods
+                var visited = nextElement.getAttributeByName(METHOD_VISITED);
+                if (METHOD.equals(nextElement.getName()) && (visited == null || visited.getValue().equals("true"))) {
+                    methods.add(readMethod(reader, nextElement));
+                }
+            }
+            else if (event.isEndElement()) {
+                var endElement = event.asEndElement();
+                if (CLASS.equals(endElement.getName())) {
+                    return new CoverageClassHolder(className, methods);
+                }
+            }
+        }
+
+        throw new NoSuchElementException("Unable to parse class " + className);
+    }
+
+    @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.CognitiveComplexity"})
+    private CoverageMethod readMethod(final XMLEventReader reader, final StartElement parentElement) throws XMLStreamException {
+        CoverageMethod coverageMethod = new CoverageMethod();
+        coverageMethod.setComplexity(getIntegerValueOf(parentElement, METHOD_CYCLOMATIC_COMPLEXITY));
+        while (reader.hasNext()) {
+            XMLEvent event = reader.nextEvent();
+            if (event.isStartElement()) {
+                var nextElement = event.asStartElement();
+                if (METHOD_NAME.equals(nextElement.getName())) {
+                    coverageMethod.setMethodName(reader.nextEvent().asCharacters().getData());
+                }
+                if (SUMMARY.equals(nextElement.getName())) {
+                    readMethodSummary(coverageMethod, nextElement);
+                }
+                if (BRANCH_POINTS.equals(nextElement.getName())) {
+                    readBranchPoints(reader, coverageMethod);
+                }
+                if (SEQUENCE_POINTS.equals(nextElement.getName())) {
+                    readSequencePoints(reader, coverageMethod);
+                }
+                if (FILE_REF.equals(nextElement.getName())) {
+                    coverageMethod.setFileId(getValueOf(nextElement, UID));
+                }
+            }
+            else if (event.isEndElement()) {
+                var endElement = event.asEndElement();
+                if (METHOD.equals(endElement.getName())) {
+                    return coverageMethod;
+                }
+            }
+        }
+
+        throw new NoSuchElementException("Unable to parse method " + coverageMethod.getMethodName());
+    }
+
+    private void readMethodSummary(final CoverageMethod coverageMethod, final StartElement startElement) {
+        coverageMethod.setBranchCovered(getIntegerValueOf(startElement, METHOD_BRANCH_COVERED));
+        coverageMethod.setBranchMissed(getIntegerValueOf(startElement, METHOD_BRANCH_TOTAL) - coverageMethod.getBranchCovered());
+        coverageMethod.setInstructionCovered(getIntegerValueOf(startElement, METHOD_INTRUCTION_COVERED));
+        coverageMethod.setInstructionMissed(getIntegerValueOf(startElement, METHOD_INTRUCTION_TOTAL) - coverageMethod.getInstructionCovered());
+    }
+
+    private void readSequencePoints(final XMLEventReader reader, final CoverageMethod coverageMethod) throws XMLStreamException {
+        while (reader.hasNext()) {
+            XMLEvent event = reader.nextEvent();
+            if (event.isStartElement()) {
+                var nextElement = event.asStartElement();
+                if (SEQUENCE_POINT.equals(nextElement.getName()) && nextElement.getAttributeByName(SOURCE_LINE_NUMBER) != null) {
+                    coverageMethod.getSequencePoints().add(new CoverageHint(
+                            getIntegerValueOf(nextElement, SOURCE_LINE_NUMBER),
+                            getIntegerValueOf(nextElement, SOURCE_LINE_HINT)
+                    ));
+                }
+            }
+            else if (event.isEndElement()) {
+                var endElement = event.asEndElement();
+                if (SEQUENCE_POINT.equals(endElement.getName()) || SEQUENCE_POINTS.equals(endElement.getName())) {
+                    return;
+                }
+            }
+        }
+    }
+
+    private void readBranchPoints(final XMLEventReader reader, final CoverageMethod coverageMethod) throws XMLStreamException {
+        while (reader.hasNext()) {
+            XMLEvent event = reader.nextEvent();
+            if (event.isStartElement()) {
+                var nextElement = event.asStartElement();
+                if (BRANCH_POINT.equals(nextElement.getName()) && nextElement.getAttributeByName(SOURCE_LINE_NUMBER) != null) {
+                    coverageMethod.getBranchPoints().add(new CoverageHint(
+                            getIntegerValueOf(nextElement, SOURCE_LINE_NUMBER),
+                            getIntegerValueOf(nextElement, SOURCE_LINE_HINT)
+                    ));
+                }
+            }
+            else if (event.isEndElement()) {
+                var endElement = event.asEndElement();
+                if (BRANCH_POINT.equals(endElement.getName()) || BRANCH_POINTS.equals(endElement.getName())) {
+                    return;
+                }
+            }
+        }
+    }
+
+    private void addCounters(final FileNode fileNode, final int lineNumber, final int coveredInstructions, final int coveredBranches) {
+        int missed;
+        int covered;
+        if (coveredBranches == 0) { // only instruction coverage found
+            covered = coveredInstructions > 0 ? 1 : 0;
+            missed = covered > 0 ? 0 : 1;
+        }
+        else {
+            covered = coveredBranches;
+            missed = coveredBranches - coveredInstructions;
+        }
+        fileNode.addCounters(lineNumber, covered, missed);
+    }
+
+    private String getFileName(final String relativePath) {
+        var path = Paths.get(PATH_UTIL.getAbsolutePath(relativePath)).getFileName();
+        if (path == null) {
+            return relativePath;
+        }
+        return path.toString();
+    }
+
+    private static class CoverageClassHolder extends MutablePair<String, List<CoverageMethod>> {
+        private static final long serialVersionUID = 1L;
+
+        CoverageClassHolder(final String className, final List<CoverageMethod> methods) {
+            super(className, methods);
+        }
+
+        boolean hasMethods() {
+            return !getMethods().isEmpty();
+        }
+
+        List<CoverageMethod> getMethods() {
+            return getRight();
+        }
+
+        String getClassName() {
+            return getLeft();
+        }
+
+        String getFileId() {
+            return getMethods().get(0).getFileId();
+        }
+    }
+
+    private static class CoverageHint extends MutablePair<Integer, Integer> {
+        private static final long serialVersionUID = 1L;
+
+        CoverageHint(final Integer lineNumber, final Integer hint) {
+            super(lineNumber, hint);
+        }
+
+        Integer getLineNumber() {
+            return getLeft();
+        }
+
+        Integer getHint() {
+            return getRight();
+        }
+    }
+
+    private static class CoverageMethod {
+        private String methodName;
+        private String fileId;
+        private int instructionCovered;
+        private int instructionMissed;
+        private int branchCovered;
+        private int branchMissed;
+        private int complexity;
+        private final List<CoverageHint> sequencePoints = new ArrayList<>();
+        private final List<CoverageHint> branchPoints = new ArrayList<>();
+
+        String getMethodName() {
+            return methodName;
+        }
+
+        void setMethodName(final String methodName) {
+            this.methodName = methodName;
+        }
+
+        String getFileId() {
+            return fileId;
+        }
+
+        void setFileId(final String fileId) {
+            this.fileId = fileId;
+        }
+
+        int getInstructionCovered() {
+            return instructionCovered;
+        }
+
+        void setInstructionCovered(final int instructionCovered) {
+            this.instructionCovered = instructionCovered;
+        }
+
+        int getInstructionMissed() {
+            return instructionMissed;
+        }
+
+        void setInstructionMissed(final int instructionMissed) {
+            this.instructionMissed = instructionMissed;
+        }
+
+        int getBranchCovered() {
+            return branchCovered;
+        }
+
+        void setBranchCovered(final int branchCovered) {
+            this.branchCovered = branchCovered;
+        }
+
+        int getBranchMissed() {
+            return branchMissed;
+        }
+
+        void setBranchMissed(final int branchMissed) {
+            this.branchMissed = branchMissed;
+        }
+
+        int getComplexity() {
+            return complexity;
+        }
+
+        void setComplexity(final int complexity) {
+            this.complexity = complexity;
+        }
+
+        List<CoverageHint> getSequencePoints() {
+            return sequencePoints;
+        }
+
+        List<CoverageHint> getBranchPoints() {
+            return branchPoints;
+        }
+    }
+}

--- a/src/main/java/edu/hm/hafner/coverage/parser/OpenCoverParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/parser/OpenCoverParser.java
@@ -88,7 +88,7 @@ public class OpenCoverParser extends CoverageParser {
     }
 
     @Override
-    @SuppressWarnings({"PMD.CyclomaticComplexity", "AvoidDeeplyNestedIfStmts"})
+    @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.AvoidDeeplyNestedIfStmts"})
     protected ModuleNode parseReport(final Reader reader, final FilteredLog log) {
         try {
             var eventReader = new SecureXmlParserFactory().createXmlEventReader(reader);

--- a/src/main/java/edu/hm/hafner/coverage/parser/OpenCoverParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/parser/OpenCoverParser.java
@@ -101,18 +101,14 @@ public class OpenCoverParser extends CoverageParser {
                     var tagName = startElement.getName();
                     if (MODULE.equals(tagName) && startElement.getAttributeByName(MODULE_SKIPPED) == null) {
                         isEmpty = readModule(eventReader, root);
+                        if (!isEmpty) {
+                            return root;
+                        }
                     }
                 }
             }
-            if (isEmpty) { 
-                if (ignoreErrors()) { 
-                    log.logError("No coverage information found in the specified file."); 
-                } 
-                else { 
-                    throw new NoSuchElementException("No coverage information found in the specified file."); 
-                } 
-            }
-            return root;
+            handleEmptyResults(log, isEmpty);
+            return new ModuleNode("empty");
         }
         catch (XMLStreamException exception) {
             throw new ParsingException(exception);

--- a/src/main/java/edu/hm/hafner/coverage/parser/OpenCoverParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/parser/OpenCoverParser.java
@@ -31,6 +31,7 @@ import edu.hm.hafner.util.FilteredLog;
 import edu.hm.hafner.util.PathUtil;
 import edu.hm.hafner.util.SecureXmlParserFactory;
 import edu.hm.hafner.util.SecureXmlParserFactory.ParsingException;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * A parser which parses reports made by OpenCover into a Java Object Model.
@@ -68,6 +69,23 @@ public class OpenCoverParser extends CoverageParser {
     private static final QName METHOD_BRANCH_COVERED = new QName("visitedBranchPoints");
     private static final QName METHOD_BRANCH_TOTAL = new QName("numBranchPoints");
     private static final QName METHOD_CYCLOMATIC_COMPLEXITY = new QName("cyclomaticComplexity");
+
+    /**
+     * Creates a new instance of {@link OpenCoverParser}.
+     */
+    public OpenCoverParser() {
+        this(ProcessingMode.FAIL_FAST);
+    }
+
+    /**
+     * Creates a new instance of {@link OpenCoverParser}.
+     *
+     * @param processingMode
+     *         determines whether to ignore errors
+     */
+    public OpenCoverParser(final ProcessingMode processingMode) {
+        super(processingMode);
+    }
 
     @Override
     @SuppressWarnings("PMD.CyclomaticComplexity")
@@ -317,12 +335,9 @@ public class OpenCoverParser extends CoverageParser {
         fileNode.addCounters(lineNumber, covered, missed);
     }
 
+    @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     private String getFileName(final String relativePath) {
-        var path = Paths.get(PATH_UTIL.getAbsolutePath(relativePath)).getFileName();
-        if (path == null) {
-            return relativePath;
-        }
-        return path.toString();
+        return Paths.get(PATH_UTIL.getAbsolutePath(relativePath)).getFileName().toString();
     }
 
     private static class CoverageClassHolder extends MutablePair<String, List<CoverageMethod>> {

--- a/src/main/java/edu/hm/hafner/coverage/parser/OpenCoverParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/parser/OpenCoverParser.java
@@ -7,7 +7,6 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.NoSuchElementException;
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLStreamException;
@@ -225,12 +224,12 @@ public class OpenCoverParser extends CoverageParser {
             else if (event.isEndElement()) {
                 var endElement = event.asEndElement();
                 if (CLASS.equals(endElement.getName())) {
-                    return new CoverageClassHolder(className, methods);
+                    break;
                 }
             }
         }
 
-        throw new NoSuchElementException("Unable to parse class " + className);
+        return new CoverageClassHolder(className, methods);
     }
 
     @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.CognitiveComplexity"})
@@ -260,12 +259,12 @@ public class OpenCoverParser extends CoverageParser {
             else if (event.isEndElement()) {
                 var endElement = event.asEndElement();
                 if (METHOD.equals(endElement.getName())) {
-                    return coverageMethod;
+                    break;
                 }
             }
         }
 
-        throw new NoSuchElementException("Unable to parse method " + coverageMethod.getMethodName());
+        return coverageMethod;
     }
 
     private void readMethodSummary(final CoverageMethod coverageMethod, final StartElement startElement) {

--- a/src/main/java/edu/hm/hafner/coverage/parser/OpenCoverParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/parser/OpenCoverParser.java
@@ -134,8 +134,10 @@ public class OpenCoverParser extends CoverageParser {
                     files.put(uid, relativePath);
                 }
                 else if (MODULE_NAME.equals(nextElement.getName())) {
-                    String packageName = reader.nextEvent().asCharacters().getData();
-                    packageNode = root.findOrCreatePackageNode(packageName);
+                    String moduleName = reader.nextEvent().asCharacters().getData();
+                    var moduleNode = new ModuleNode(moduleName);
+                    packageNode = moduleNode.findOrCreatePackageNode(EMPTY);
+                    root.addChild(moduleNode);
                     isEmpty = false;
                 }
             }

--- a/src/main/java/edu/hm/hafner/coverage/parser/OpenCoverParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/parser/OpenCoverParser.java
@@ -88,7 +88,7 @@ public class OpenCoverParser extends CoverageParser {
     }
 
     @Override
-    @SuppressWarnings("PMD.CyclomaticComplexity")
+    @SuppressWarnings({"PMD.CyclomaticComplexity", "AvoidDeeplyNestedIfStmts"})
     protected ModuleNode parseReport(final Reader reader, final FilteredLog log) {
         try {
             var eventReader = new SecureXmlParserFactory().createXmlEventReader(reader);

--- a/src/main/java/edu/hm/hafner/coverage/registry/ParserRegistry.java
+++ b/src/main/java/edu/hm/hafner/coverage/registry/ParserRegistry.java
@@ -7,6 +7,7 @@ import edu.hm.hafner.coverage.CoverageParser.ProcessingMode;
 import edu.hm.hafner.coverage.parser.CoberturaParser;
 import edu.hm.hafner.coverage.parser.JacocoParser;
 import edu.hm.hafner.coverage.parser.JunitParser;
+import edu.hm.hafner.coverage.parser.OpenCoverParser;
 import edu.hm.hafner.coverage.parser.PitestParser;
 
 /**
@@ -18,6 +19,7 @@ public class ParserRegistry {
     /** Supported parsers. */
     public enum CoverageParserType {
         COBERTURA,
+        OPENCOVER,
         JACOCO,
         PIT,
         JUNIT
@@ -56,6 +58,8 @@ public class ParserRegistry {
         switch (parser) {
             case COBERTURA:
                 return new CoberturaParser(processingMode);
+            case OPENCOVER:
+                return new OpenCoverParser();
             case JACOCO:
                 return new JacocoParser();
             case PIT:

--- a/src/test/java/edu/hm/hafner/coverage/parser/OpenCoverParserTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/parser/OpenCoverParserTest.java
@@ -1,0 +1,199 @@
+package edu.hm.hafner.coverage.parser;
+
+import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.DefaultLocale;
+
+import edu.hm.hafner.coverage.Coverage;
+import edu.hm.hafner.coverage.Coverage.CoverageBuilder;
+import edu.hm.hafner.coverage.CoverageParser;
+import edu.hm.hafner.coverage.CyclomaticComplexity;
+import edu.hm.hafner.coverage.FileNode;
+import edu.hm.hafner.coverage.LinesOfCode;
+import edu.hm.hafner.coverage.MethodNode;
+import edu.hm.hafner.coverage.ModuleNode;
+import edu.hm.hafner.coverage.Node;
+
+import static edu.hm.hafner.coverage.Metric.*;
+import static edu.hm.hafner.coverage.assertions.Assertions.assertThat;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@DefaultLocale("en")
+class OpenCoverParserTest extends AbstractParserTest {
+    @Override
+    CoverageParser createParser() {
+        return new OpenCoverParser();
+    }
+
+    @Test
+    void shouldReadReport() {
+        readExampleReport();
+    }
+
+    @Test
+    void shouldCreatePackageName() {
+        ModuleNode tree = readExampleReport();
+        String fileName = "MyLogging.FancyClass.cs";
+        assertThat(tree.find(FILE, fileName)).isNotEmpty()
+                .hasValueSatisfying(node -> assertThat(node).hasName(fileName)
+                        .hasParentName("MyLogging")
+                        .hasParent()
+                        .isNotRoot());
+    }
+
+    @Test
+    void shouldFilterByFiles() {
+        var root = readExampleReport();
+        assertThat(root.getAll(MODULE)).hasSize(1);
+        assertThat(root.getAll(PACKAGE)).hasSize(1);
+        assertThat(root.getAll(FILE)).hasSize(3);
+        assertThat(root.getAll(CLASS)).hasSize(3);
+        assertThat(root.getAll(METHOD)).hasSize(21);
+
+        assertThat(root.aggregateValues()).contains(
+                Coverage.valueOf(MODULE, "1/1"),
+                Coverage.valueOf(PACKAGE, "1/1"),
+                Coverage.valueOf(METHOD, "19/21"),
+                Coverage.valueOf(BRANCH, "35/48"),
+                Coverage.valueOf(INSTRUCTION, "122/138"),
+                new CyclomaticComplexity(61, COMPLEXITY),
+                new CyclomaticComplexity(16, COMPLEXITY_MAXIMUM),
+                new LinesOfCode(138));
+        var fileNode = getFileNode(root);
+        assertThat(fileNode).hasMissedLines(32).hasCoveredLines(16, 30, 34, 36, 38, 40, 51, 127, 161, 188, 197, 218, 226);
+        verifyCoverageMetrics(root);
+        verifyLineCoverage(fileNode);
+    }
+
+    @Test
+    void shouldDetectMethodCoverage() {
+        ModuleNode module = readExampleReport();
+
+        assertThat(module.getAll(PACKAGE)).hasSize(1);
+        assertThat(module.findFile("MyLogging.FancyClass.cs")).isPresent().hasValueSatisfying(
+                file -> assertThat(file.findClass("MyLogging.FancyClass")).isPresent()
+                        .hasValueSatisfying(
+                                classNode -> assertThat(file.getAll(METHOD).size()).isEqualTo(14)));
+
+        var methods = module.getAll(METHOD);
+        assertThat(methods).hasSize(21);
+        assertThat(module.getValue(METHOD)).isPresent().get().isInstanceOfSatisfying(Coverage.class,
+                coverage -> assertThat(coverage).hasTotal(21).hasCovered(19));
+    }
+
+    @Test
+    void shouldReportTestSourceFiles() {
+        ModuleNode module = readReport("opencover-reporttotestsourcefiles.xml");
+        assertThat(module.getAll(MODULE)).hasSize(1);
+        assertThat(module.getAll(PACKAGE)).hasSize(1);
+        assertThat(module.getAll(FILE)).hasSize(1);
+        assertThat(module.getAll(CLASS)).hasSize(1);
+        assertThat(module.getAll(METHOD)).hasSize(1);
+
+        assertThat(module.aggregateValues()).contains(
+                Coverage.valueOf(MODULE, "1/1"),
+                Coverage.valueOf(PACKAGE, "1/1"),
+                Coverage.valueOf(METHOD, "1/1"),
+                Coverage.valueOf(BRANCH, "3/6"),
+                Coverage.valueOf(INSTRUCTION, "9/15"),
+                new CyclomaticComplexity(6, COMPLEXITY),
+                new CyclomaticComplexity(6, COMPLEXITY_MAXIMUM),
+                new LinesOfCode(15));
+    }
+
+    @Test
+    void shouldReportWithSkippedModules() {
+        ModuleNode module = readReport("opencover-withskippedmodules.xml");
+        assertThat(module.getAll(MODULE)).hasSize(1);
+        assertThat(module.getAll(PACKAGE)).hasSize(1);
+        assertThat(module.getAll(FILE)).hasSize(25);
+        assertThat(module.getAll(CLASS)).hasSize(15);
+        assertThat(module.getAll(METHOD)).hasSize(103);
+
+        assertThat(module.aggregateValues()).contains(
+                Coverage.valueOf(MODULE, "1/1"),
+                Coverage.valueOf(PACKAGE, "1/1"),
+                Coverage.valueOf(METHOD, "90/103"),
+                Coverage.valueOf(BRANCH, "322/379"),
+                Coverage.valueOf(INSTRUCTION, "807/826"),
+                new CyclomaticComplexity(256, COMPLEXITY),
+                new CyclomaticComplexity(18, COMPLEXITY_MAXIMUM),
+                new LinesOfCode(826));
+    }
+
+    private void verifyLineCoverage(final FileNode a) {
+        var children = a.getAll(METHOD).stream()
+                .filter(m -> "System.Boolean MyLogging.FancyClass::get_IsMyCodeWrittenWell()System.Boolean MyLogging.FancyClass::get_IsMyCodeWrittenWell()".equals(m.getName()))
+                .collect(Collectors.toList());
+
+        assertThat(children).hasSize(1)
+                .element(0)
+                .isInstanceOfSatisfying(MethodNode.class,
+                        m -> assertThat(m)
+                                .hasName("System.Boolean MyLogging.FancyClass::get_IsMyCodeWrittenWell()System.Boolean MyLogging.FancyClass::get_IsMyCodeWrittenWell()")
+                                .hasSignature("System.Boolean MyLogging.FancyClass::get_IsMyCodeWrittenWell()")
+                                .hasValues(
+                                        createLineCoverage(1, 0),
+                                        createBranchCoverage(1, 1),
+                                        new CyclomaticComplexity(2)));
+    }
+
+    private Coverage createBranchCoverage(final int covered, final int missed) {
+        return new CoverageBuilder().withMetric(BRANCH).withCovered(covered).withMissed(missed).build();
+    }
+
+    private Coverage createLineCoverage(final int covered, final int missed) {
+        return new CoverageBuilder().withMetric(LINE).withCovered(covered).withMissed(missed).build();
+    }
+
+    private FileNode getFileNode(final ModuleNode a) {
+        var fileNodes = a.getAllFileNodes();
+        assertThat(fileNodes).hasSize(3);
+
+        var lineRange = fileNodes.get(0);
+        assertThat(lineRange)
+                .hasName("MyLogging.FancyClass.cs")
+                .hasRelativePath("C:/temp/opencovertests/MyLogging.FancyClass.cs");
+
+        return lineRange;
+    }
+
+    private void verifyCoverageMetrics(final Node tree) {
+        List<Node> nodes = tree.getAll(FILE);
+
+        long missedInstructions = 0;
+        long coveredInstructions = 0;
+        long missedBranches = 0;
+        long coveredBranches = 0;
+        long missedLines = 0;
+        long coveredLines = 0;
+        for (Node node : nodes) {
+            var instructionCoverage = (Coverage) node.getValue(INSTRUCTION).orElse(Coverage.nullObject(INSTRUCTION));
+            missedInstructions = missedInstructions + instructionCoverage.getMissed();
+            coveredInstructions = coveredInstructions + instructionCoverage.getCovered();
+            var branchCoverage = (Coverage) node.getValue(BRANCH).orElse(Coverage.nullObject(BRANCH));
+            missedBranches = missedBranches + branchCoverage.getMissed();
+            coveredBranches = coveredBranches + branchCoverage.getCovered();
+            var lineCoverage = (Coverage) node.getValue(LINE).orElse(Coverage.nullObject(LINE));
+            missedLines = missedLines + lineCoverage.getMissed();
+            coveredLines = coveredLines + lineCoverage.getCovered();
+        }
+
+        assertThat(missedInstructions).isEqualTo(16L);
+        assertThat(coveredInstructions).isEqualTo(122L);
+        assertThat(missedBranches).isEqualTo(13L);
+        assertThat(coveredBranches).isEqualTo(35L);
+        assertThat(missedLines).isEqualTo(16L);
+        assertThat(coveredLines).isEqualTo(122L);
+    }
+
+    private ModuleNode readExampleReport() {
+        return readReport("opencover.xml", new OpenCoverParser());
+    }
+
+    @Override
+    protected String getFolder() {
+        return "opencover";
+    }
+}

--- a/src/test/java/edu/hm/hafner/coverage/parser/OpenCoverParserTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/parser/OpenCoverParserTest.java
@@ -50,10 +50,15 @@ class OpenCoverParserTest extends AbstractParserTest {
     @Test
     void shouldCreatePackageName() {
         ModuleNode tree = readExampleReport();
+        assertThat(tree.find(PACKAGE, "-")).isNotEmpty()
+                .hasValueSatisfying(node -> assertThat(node).hasName("-")
+                        .hasParentName("-.MyLogging")
+                        .hasParent()
+                        .isNotRoot());
         String fileName = "MyLogging.FancyClass.cs";
         assertThat(tree.find(FILE, fileName)).isNotEmpty()
                 .hasValueSatisfying(node -> assertThat(node).hasName(fileName)
-                        .hasParentName("MyLogging")
+                        .hasParentName("-")
                         .hasParent()
                         .isNotRoot());
     }
@@ -61,14 +66,14 @@ class OpenCoverParserTest extends AbstractParserTest {
     @Test
     void shouldFilterByFiles() {
         var root = readExampleReport();
-        assertThat(root.getAll(MODULE)).hasSize(1);
+        assertThat(root.getAll(MODULE)).hasSize(2);
         assertThat(root.getAll(PACKAGE)).hasSize(1);
         assertThat(root.getAll(FILE)).hasSize(3);
         assertThat(root.getAll(CLASS)).hasSize(3);
         assertThat(root.getAll(METHOD)).hasSize(21);
 
         assertThat(root.aggregateValues()).contains(
-                Coverage.valueOf(MODULE, "1/1"),
+                Coverage.valueOf(MODULE, "2/2"),
                 Coverage.valueOf(PACKAGE, "1/1"),
                 Coverage.valueOf(METHOD, "19/21"),
                 Coverage.valueOf(BRANCH, "35/48"),
@@ -101,14 +106,14 @@ class OpenCoverParserTest extends AbstractParserTest {
     @Test
     void shouldReportTestSourceFiles() {
         ModuleNode module = readReport("opencover-reporttotestsourcefiles.xml");
-        assertThat(module.getAll(MODULE)).hasSize(1);
+        assertThat(module.getAll(MODULE)).hasSize(2);
         assertThat(module.getAll(PACKAGE)).hasSize(1);
         assertThat(module.getAll(FILE)).hasSize(1);
         assertThat(module.getAll(CLASS)).hasSize(1);
         assertThat(module.getAll(METHOD)).hasSize(1);
 
         assertThat(module.aggregateValues()).contains(
-                Coverage.valueOf(MODULE, "1/1"),
+                Coverage.valueOf(MODULE, "2/2"),
                 Coverage.valueOf(PACKAGE, "1/1"),
                 Coverage.valueOf(METHOD, "1/1"),
                 Coverage.valueOf(BRANCH, "3/6"),
@@ -121,14 +126,14 @@ class OpenCoverParserTest extends AbstractParserTest {
     @Test
     void shouldReportWithSkippedModules() {
         ModuleNode module = readReport("opencover-withskippedmodules.xml");
-        assertThat(module.getAll(MODULE)).hasSize(1);
+        assertThat(module.getAll(MODULE)).hasSize(2);
         assertThat(module.getAll(PACKAGE)).hasSize(1);
         assertThat(module.getAll(FILE)).hasSize(25);
         assertThat(module.getAll(CLASS)).hasSize(15);
         assertThat(module.getAll(METHOD)).hasSize(103);
 
         assertThat(module.aggregateValues()).contains(
-                Coverage.valueOf(MODULE, "1/1"),
+                Coverage.valueOf(MODULE, "2/2"),
                 Coverage.valueOf(PACKAGE, "1/1"),
                 Coverage.valueOf(METHOD, "90/103"),
                 Coverage.valueOf(BRANCH, "322/379"),

--- a/src/test/java/edu/hm/hafner/coverage/parser/OpenCoverParserTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/parser/OpenCoverParserTest.java
@@ -23,8 +23,8 @@ import java.util.stream.Collectors;
 @DefaultLocale("en")
 class OpenCoverParserTest extends AbstractParserTest {
     @Override
-    CoverageParser createParser() {
-        return new OpenCoverParser();
+    CoverageParser createParser(final ProcessingMode processingMode) {
+        return new OpenCoverParser(processingMode);
     }
 
     @Test

--- a/src/test/java/edu/hm/hafner/coverage/parser/OpenCoverParserTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/parser/OpenCoverParserTest.java
@@ -33,11 +33,6 @@ class OpenCoverParserTest extends AbstractParserTest {
     }
 
     @Test
-    void shouldReadEmptyReportAndIgnoreErrors() {
-        readReport("opencover-empty.xml", new OpenCoverParser(ProcessingMode.IGNORE_ERRORS));
-    }
-
-    @Test
     void shouldReadEmptyModules() {
         readReport("opencover-empty-module.xml", new OpenCoverParser(ProcessingMode.IGNORE_ERRORS));
     }

--- a/src/test/java/edu/hm/hafner/coverage/parser/OpenCoverParserTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/parser/OpenCoverParserTest.java
@@ -38,6 +38,16 @@ class OpenCoverParserTest extends AbstractParserTest {
     }
 
     @Test
+    void shouldReadWithMissingModuleName() {
+        readReport("opencover-missing-module-name.xml", new OpenCoverParser(ProcessingMode.IGNORE_ERRORS));
+    }
+
+    @Test
+    void shouldReadWithMissingSourceLine() {
+        readReport("opencover-missing-source-line.xml", new OpenCoverParser(ProcessingMode.IGNORE_ERRORS));
+    }
+
+    @Test
     void shouldCreatePackageName() {
         ModuleNode tree = readExampleReport();
         String fileName = "MyLogging.FancyClass.cs";

--- a/src/test/java/edu/hm/hafner/coverage/parser/OpenCoverParserTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/parser/OpenCoverParserTest.java
@@ -6,6 +6,7 @@ import org.junitpioneer.jupiter.DefaultLocale;
 import edu.hm.hafner.coverage.Coverage;
 import edu.hm.hafner.coverage.Coverage.CoverageBuilder;
 import edu.hm.hafner.coverage.CoverageParser;
+import edu.hm.hafner.coverage.CoverageParser.ProcessingMode;
 import edu.hm.hafner.coverage.CyclomaticComplexity;
 import edu.hm.hafner.coverage.FileNode;
 import edu.hm.hafner.coverage.LinesOfCode;
@@ -29,6 +30,16 @@ class OpenCoverParserTest extends AbstractParserTest {
     @Test
     void shouldReadReport() {
         readExampleReport();
+    }
+
+    @Test
+    void shouldReadEmptyReportAndIgnoreErrors() {
+        readReport("opencover-empty.xml", new OpenCoverParser(ProcessingMode.IGNORE_ERRORS));
+    }
+
+    @Test
+    void shouldReadEmptyModules() {
+        readReport("opencover-empty-module.xml", new OpenCoverParser(ProcessingMode.IGNORE_ERRORS));
     }
 
     @Test

--- a/src/test/java/edu/hm/hafner/coverage/registry/ParserRegistryTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/registry/ParserRegistryTest.java
@@ -7,6 +7,7 @@ import edu.hm.hafner.coverage.parser.CoberturaParser;
 import edu.hm.hafner.coverage.parser.JacocoParser;
 import edu.hm.hafner.coverage.parser.JunitParser;
 import edu.hm.hafner.coverage.parser.PitestParser;
+import edu.hm.hafner.coverage.parser.OpenCoverParser;
 import edu.hm.hafner.coverage.registry.ParserRegistry.CoverageParserType;
 
 import static org.assertj.core.api.Assertions.*;
@@ -24,6 +25,7 @@ class ParserRegistryTest {
                 .isInstanceOf(PitestParser.class);
         assertThat(registry.get(CoverageParserType.JUNIT, ProcessingMode.IGNORE_ERRORS))
                 .isInstanceOf(JunitParser.class);
+        assertThat(registry.get(CoverageParserType.OPENCOVER, ProcessingMode.IGNORE_ERRORS)).isInstanceOf(OpenCoverParser.class);
     }
 
     @Test

--- a/src/test/resources/edu/hm/hafner/coverage/parser/opencover/empty.xml
+++ b/src/test/resources/edu/hm/hafner/coverage/parser/opencover/empty.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <CoverageSession>
   <Summar />
-  <Modules /> 
+  <Modules />
 </CoverageSession>

--- a/src/test/resources/edu/hm/hafner/coverage/parser/opencover/opencover-empty-module.xml
+++ b/src/test/resources/edu/hm/hafner/coverage/parser/opencover/opencover-empty-module.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<CoverageSession>
+  <Summary numSequencePoints="138" visitedSequencePoints="122" numBranchPoints="48" visitedBranchPoints="35" sequenceCoverage="88.4" branchCoverage="72.9" maxCyclomaticComplexity="67" minCyclomaticComplexity="67" visitedClasses="3" numClasses="4" visitedMethods="19" numMethods="21" />
+  <Modules>
+    <Module hash="D581F35C-22FE-42E6-B430-ADF48F3E7D6D">
+      <ModulePath>MyLogging.dll</ModulePath>
+      <ModuleTime>2019-10-11T04:15:26</ModuleTime>
+      <ModuleName>MyLogging</ModuleName>
+    </Module>
+    <Module />
+  </Modules>
+</CoverageSession>

--- a/src/test/resources/edu/hm/hafner/coverage/parser/opencover/opencover-empty.xml
+++ b/src/test/resources/edu/hm/hafner/coverage/parser/opencover/opencover-empty.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<CoverageSession>
+  <Summar />
+  <Modules /> 
+</CoverageSession>

--- a/src/test/resources/edu/hm/hafner/coverage/parser/opencover/opencover-missing-module-name.xml
+++ b/src/test/resources/edu/hm/hafner/coverage/parser/opencover/opencover-missing-module-name.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<CoverageSession>
+  <Summary numSequencePoints="138" visitedSequencePoints="122" numBranchPoints="48" visitedBranchPoints="35" sequenceCoverage="88.4" branchCoverage="72.9" maxCyclomaticComplexity="67" minCyclomaticComplexity="67" visitedClasses="3" numClasses="4" visitedMethods="19" numMethods="21" />
+  <Modules>
+    <Module hash="D581F35C-22FE-42E6-B430-ADF48F3E7D6D">
+      <ModulePath>MyLogging.dll</ModulePath>
+      <ModuleTime>2019-10-11T04:15:26</ModuleTime>
+    </Module>
+  </Modules>
+</CoverageSession>

--- a/src/test/resources/edu/hm/hafner/coverage/parser/opencover/opencover-missing-source-line.xml
+++ b/src/test/resources/edu/hm/hafner/coverage/parser/opencover/opencover-missing-source-line.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<CoverageSession>
+  <Summary numSequencePoints="138" visitedSequencePoints="122" numBranchPoints="48" visitedBranchPoints="35" sequenceCoverage="88.4" branchCoverage="72.9" maxCyclomaticComplexity="67" minCyclomaticComplexity="67" visitedClasses="3" numClasses="4" visitedMethods="19" numMethods="21" />
+  <Modules>
+    <Module hash="D581F35C-22FE-42E6-B430-ADF48F3E7D6D">
+      <ModulePath>MyLogging.dll</ModulePath>
+      <ModuleTime>2019-10-11T04:15:26</ModuleTime>
+      <ModuleName>MyLogging</ModuleName>
+      <Files>
+        <File uid="1" fullPath="C:\temp\opencovertests\MyLogging.FancyClass.cs" />
+      </Files>
+      <Classes>
+        <Class>
+          <Summary numSequencePoints="121" visitedSequencePoints="106" numBranchPoints="46" visitedBranchPoints="33" sequenceCoverage="87.6" branchCoverage="71.73" maxCyclomaticComplexity="16" minCyclomaticComplexity="1" visitedClasses="1" numClasses="1" visitedMethods="13" numMethods="14" />
+          <FullName>MyLogging.FancyClass</FullName>
+          <Methods>
+            <Method cyclomaticComplexity="2" nPathComplexity="0" sequenceCoverage="100" branchCoverage="50" isConstructor="False" isGetter="True" isSetter="False" isStatic="True">
+              <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="2" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="50" maxCyclomaticComplexity="2" minCyclomaticComplexity="2" visitedClasses="0" numClasses="0" visitedMethods="1" numMethods="1" />
+              <MetadataToken />
+              <Name>System.Boolean MyLogging.FancyClass::get_IsMyCodeWrittenWell()</Name>
+              <FileRef uid="1" />
+              <SequencePoints>
+                <SequencePoint />
+              </SequencePoints>
+              <BranchPoints>
+                <BranchPoint />
+              </BranchPoints>
+              <MethodPoint />
+            </Method>
+          </Methods>
+        </Class>
+      </Classes>
+    </Module>
+  </Modules>
+</CoverageSession>

--- a/src/test/resources/edu/hm/hafner/coverage/parser/opencover/opencover-reporttotestsourcefiles.xml
+++ b/src/test/resources/edu/hm/hafner/coverage/parser/opencover/opencover-reporttotestsourcefiles.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<CoverageSession>
+  <Summary numSequencePoints="15" visitedSequencePoints="9" numBranchPoints="6" visitedBranchPoints="3" sequenceCoverage="60" branchCoverage="50" maxCyclomaticComplexity="6" minCyclomaticComplexity="6" visitedClasses="1" numClasses="1" visitedMethods="1" numMethods="1" />
+  <Modules>
+    <Module hash="31750BAB-054A-4C4B-8763-D76F95F0353A">
+      <ModulePath>ClassLibrary.dll</ModulePath>
+      <ModuleTime>2019-12-13T01:36:13</ModuleTime>
+      <ModuleName>ClassLibrary</ModuleName>
+      <Files>
+        <File uid="1" fullPath="[PLACEHOLDER]" />
+      </Files>
+      <Classes>
+        <Class>
+          <Summary numSequencePoints="15" visitedSequencePoints="9" numBranchPoints="6" visitedBranchPoints="3" sequenceCoverage="60" branchCoverage="50" maxCyclomaticComplexity="6" minCyclomaticComplexity="6" visitedClasses="1" numClasses="1" visitedMethods="1" numMethods="1" />
+          <FullName>ClassLibrary.LibraryClass</FullName>
+          <Methods>
+            <Method cyclomaticComplexity="6" nPathComplexity="0" sequenceCoverage="60" branchCoverage="50" isConstructor="False" isGetter="False" isSetter="False" isStatic="True">
+              <Summary numSequencePoints="15" visitedSequencePoints="9" numBranchPoints="6" visitedBranchPoints="3" sequenceCoverage="60" branchCoverage="50" maxCyclomaticComplexity="6" minCyclomaticComplexity="6" visitedClasses="0" numClasses="0" visitedMethods="1" numMethods="1" />
+              <MetadataToken />
+              <Name>System.Int32 ClassLibrary.LibraryClass::Sum(System.Int32,System.Int32)</Name>
+              <FileRef uid="1" />
+              <SequencePoints>
+                <SequencePoint vc="2" uspid="8" ordinal="0" sl="8" sc="1" el="8" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="2" uspid="9" ordinal="1" sl="9" sc="1" el="9" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="2" uspid="10" ordinal="2" sl="10" sc="1" el="10" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="0" uspid="13" ordinal="3" sl="13" sc="1" el="13" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="0" uspid="14" ordinal="4" sl="14" sc="1" el="14" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="0" uspid="16" ordinal="5" sl="16" sc="1" el="16" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="0" uspid="17" ordinal="6" sl="17" sc="1" el="17" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="0" uspid="19" ordinal="7" sl="19" sc="1" el="19" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="0" uspid="20" ordinal="8" sl="20" sc="1" el="20" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="1" uspid="22" ordinal="9" sl="22" sc="1" el="22" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="1" uspid="23" ordinal="10" sl="23" sc="1" el="23" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="1" uspid="25" ordinal="11" sl="25" sc="1" el="25" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="1" uspid="26" ordinal="12" sl="26" sc="1" el="26" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="2" uspid="28" ordinal="13" sl="28" sc="1" el="28" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="2" uspid="29" ordinal="14" sl="29" sc="1" el="29" ec="2" bec="0" bev="0" fileid="1" />
+              </SequencePoints>
+              <BranchPoints>
+                <BranchPoint vc="0" uspid="10" ordinal="1" path="1" offset="8" offsetend="35" sl="10" fileid="1" />
+                <BranchPoint vc="0" uspid="10" ordinal="2" path="2" offset="8" offsetend="44" sl="10" fileid="1" />
+                <BranchPoint vc="0" uspid="10" ordinal="3" path="3" offset="8" offsetend="53" sl="10" fileid="1" />
+                <BranchPoint vc="1" uspid="10" ordinal="4" path="4" offset="8" offsetend="62" sl="10" fileid="1" />
+                <BranchPoint vc="1" uspid="10" ordinal="5" path="5" offset="8" offsetend="71" sl="10" fileid="1" />
+                <BranchPoint vc="2" uspid="10" ordinal="0" path="0" offset="8" offsetend="80" sl="10" fileid="1" />
+              </BranchPoints>
+              <MethodPoint vc="9" uspid="0" p8:type="SequencePoint" ordinal="0" offset="0" sc="0" sl="8" ec="1" el="29" bec="0" bev="0" fileid="1" xmlns:p8="xsi" />
+            </Method>
+          </Methods>
+        </Class>
+      </Classes>
+    </Module>
+  </Modules>
+</CoverageSession>

--- a/src/test/resources/edu/hm/hafner/coverage/parser/opencover/opencover-withskippedmodules.xml
+++ b/src/test/resources/edu/hm/hafner/coverage/parser/opencover/opencover-withskippedmodules.xml
@@ -1,0 +1,7126 @@
+<?xml version="1.0" encoding="utf-8"?>
+<CoverageSession xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <Summary numSequencePoints="1657" visitedSequencePoints="1577" numBranchPoints="922" visitedBranchPoints="769" sequenceCoverage="95.17" branchCoverage="83.41" maxCyclomaticComplexity="31" minCyclomaticComplexity="1" />
+    <Modules>
+        <Module skippedDueTo="Filter" hash="9F-2C-35-C9-C2-56-F9-13-24-3D-34-BA-07-41-CA-21-16-AA-DC-5C">
+            <FullName>C:\WINDOWS\assembly\GAC_64\mscorlib\2.0.0.0__b77a5c561934e089\mscorlib.dll</FullName>
+            <ModuleName>mscorlib</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="F9-04-A8-31-CD-FB-23-72-95-63-5D-14-9A-A0-66-8E-7F-44-93-7A">
+            <FullName>C:\WINDOWS\assembly\GAC_64\mscorlib\2.0.0.0__b77a5c561934e089\sorttbls.nlp</FullName>
+            <ModuleName>mscorlib</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="6E-30-2E-50-36-FB-60-2C-8E-50-C0-83-54-8B-CC-EA-A8-91-B6-CC">
+            <FullName>C:\WINDOWS\assembly\GAC_64\mscorlib\2.0.0.0__b77a5c561934e089\sortkey.nlp</FullName>
+            <ModuleName>mscorlib</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="15-F9-CC-81-CD-CD-F1-5D-31-3E-DE-51-94-0C-FB-02-80-CA-17-6B">
+            <FullName>C:\Projects\opencover.git\working\main\packages\NUnit.Runners.2.6.2\tools\nunit-console.exe</FullName>
+            <ModuleName>nunit-console</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="79-F8-9A-22-4E-29-52-37-00-CF-81-FF-1F-EA-05-EC-74-2A-2E-C8">
+            <FullName>C:\Projects\opencover.git\working\main\packages\NUnit.Runners.2.6.2\tools\lib\nunit-console-runner.dll</FullName>
+            <ModuleName>nunit-console-runner</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="23-35-8C-86-05-D5-AE-FE-3C-1F-09-A0-86-02-40-7C-4F-CA-59-41">
+            <FullName>C:\Projects\opencover.git\working\main\packages\NUnit.Runners.2.6.2\tools\lib\nunit.core.dll</FullName>
+            <ModuleName>nunit.core</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="57-DD-20-42-DA-33-B3-EE-DA-8C-8E-25-C9-E5-07-B5-08-62-0F-88">
+            <FullName>C:\Projects\opencover.git\working\main\packages\NUnit.Runners.2.6.2\tools\lib\nunit.util.dll</FullName>
+            <ModuleName>nunit.util</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="AD-76-2F-3C-5E-F6-77-0D-C6-AD-AF-A3-90-85-28-07-2D-A0-59-50">
+            <FullName>C:\Projects\opencover.git\working\main\packages\NUnit.Runners.2.6.2\tools\lib\nunit.core.interfaces.dll</FullName>
+            <ModuleName>nunit.core.interfaces</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="9C-94-42-8B-62-A5-15-B5-51-84-5C-71-7F-D3-E7-5A-7E-85-31-87">
+            <FullName>C:\WINDOWS\assembly\GAC_MSIL\System.Configuration\2.0.0.0__b03f5f7f11d50a3a\System.Configuration.dll</FullName>
+            <ModuleName>System.Configuration</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="E6-2E-3C-6A-7C-F7-D2-62-DF-6E-50-C5-89-8F-C2-74-C0-77-53-79">
+            <FullName>C:\WINDOWS\assembly\GAC_MSIL\System\2.0.0.0__b77a5c561934e089\System.dll</FullName>
+            <ModuleName>System</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="F1-7D-6A-27-58-B4-36-F8-0B-89-50-5E-CA-EE-F6-22-99-A8-65-41">
+            <FullName>C:\WINDOWS\assembly\GAC_MSIL\System.Xml\2.0.0.0__b77a5c561934e089\System.Xml.dll</FullName>
+            <ModuleName>System.Xml</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="FD-F4-B7-70-2D-F1-F3-04-39-92-18-C8-86-1A-16-F8-F1-3D-F4-B5">
+            <FullName>C:\WINDOWS\assembly\GAC_MSIL\System.Runtime.Remoting\2.0.0.0__b77a5c561934e089\System.Runtime.Remoting.dll</FullName>
+            <ModuleName>System.Runtime.Remoting</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="28-AC-43-43-3F-69-94-59-0A-98-91-C3-7E-67-FD-0E-6A-53-72-20">
+            <FullName>C:\WINDOWS\Microsoft.Net\assembly\GAC_64\mscorlib\v4.0_4.0.0.0__b77a5c561934e089\mscorlib.dll</FullName>
+            <ModuleName>mscorlib</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="FB-85-03-F6-E1-75-BB-8A-0F-44-79-E7-A8-B3-A4-E6-DF-72-B0-75">
+            <FullName>C:\Projects\opencover.git\working\main\packages\NUnit.Runners.2.6.2\tools\nunit-agent.exe</FullName>
+            <ModuleName>nunit-agent</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="23-35-8C-86-05-D5-AE-FE-3C-1F-09-A0-86-02-40-7C-4F-CA-59-41">
+            <FullName>C:\Projects\opencover.git\working\main\packages\NUnit.Runners.2.6.2\tools\lib\nunit.core.dll</FullName>
+            <ModuleName>nunit.core</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="57-DD-20-42-DA-33-B3-EE-DA-8C-8E-25-C9-E5-07-B5-08-62-0F-88">
+            <FullName>C:\Projects\opencover.git\working\main\packages\NUnit.Runners.2.6.2\tools\lib\nunit.util.dll</FullName>
+            <ModuleName>nunit.util</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="AD-76-2F-3C-5E-F6-77-0D-C6-AD-AF-A3-90-85-28-07-2D-A0-59-50">
+            <FullName>C:\Projects\opencover.git\working\main\packages\NUnit.Runners.2.6.2\tools\lib\nunit.core.interfaces.dll</FullName>
+            <ModuleName>nunit.core.interfaces</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="CA-AC-BC-58-33-04-2D-56-AD-2D-1A-4A-3F-54-AD-BE-FE-AE-9D-EE">
+            <FullName>C:\WINDOWS\Microsoft.Net\assembly\GAC_MSIL\System\v4.0_4.0.0.0__b77a5c561934e089\System.dll</FullName>
+            <ModuleName>System</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="84-64-E1-D2-0A-E2-91-23-AD-BD-B9-7A-3C-89-7B-66-65-58-46-1C">
+            <FullName>C:\WINDOWS\Microsoft.Net\assembly\GAC_MSIL\System.Runtime.Remoting\v4.0_4.0.0.0__b77a5c561934e089\System.Runtime.Remoting.dll</FullName>
+            <ModuleName>System.Runtime.Remoting</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="80-32-3B-47-08-F0-74-C4-64-F6-98-9B-54-B3-69-B5-B9-29-D3-E9">
+            <FullName>C:\WINDOWS\Microsoft.Net\assembly\GAC_MSIL\System.Configuration\v4.0_4.0.0.0__b03f5f7f11d50a3a\System.Configuration.dll</FullName>
+            <ModuleName>System.Configuration</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4B-C6-12-DA-61-6B-39-09-CD-DF-A1-00-79-12-63-F9-8E-72-76-27">
+            <FullName>C:\WINDOWS\Microsoft.Net\assembly\GAC_MSIL\System.Xml\v4.0_4.0.0.0__b77a5c561934e089\System.Xml.dll</FullName>
+            <ModuleName>System.Xml</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="59-42-E6-F8-DD-8B-B7-45-80-77-BD-4E-59-0E-95-5F-C2-7C-53-D8">
+            <FullName>C:\WINDOWS\Microsoft.Net\assembly\GAC_64\System.Web\v4.0_4.0.0.0__b03f5f7f11d50a3a\System.Web.dll</FullName>
+            <ModuleName>System.Web</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="33-1B-4C-D6-28-A3-2C-70-5A-64-4E-DB-C9-FA-04-E4-02-01-D4-27">
+            <FullName>C:\WINDOWS\assembly\GAC_64\System.Web\2.0.0.0__b03f5f7f11d50a3a\System.Web.dll</FullName>
+            <ModuleName>System.Web</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="23-35-8C-86-05-D5-AE-FE-3C-1F-09-A0-86-02-40-7C-4F-CA-59-41">
+            <FullName>C:\Projects\opencover.git\working\main\packages\NUnit.Runners.2.6.2\tools\lib\nunit.core.dll</FullName>
+            <ModuleName>nunit.core</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="CA-AC-BC-58-33-04-2D-56-AD-2D-1A-4A-3F-54-AD-BE-FE-AE-9D-EE">
+            <FullName>C:\WINDOWS\Microsoft.Net\assembly\GAC_MSIL\System\v4.0_4.0.0.0__b77a5c561934e089\System.dll</FullName>
+            <ModuleName>System</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="C8-69-A6-5A-0E-1E-E0-29-EB-EF-CA-C5-2C-E2-B7-EB-F6-D9-64-1A">
+            <FullName>C:\Projects\opencover.git\working\main\packages\NUnit.Runners.2.6.2\tools\pnunit.framework.dll</FullName>
+            <ModuleName>pnunit.framework</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="F9-30-3E-D0-DF-D4-B8-50-24-2D-CB-99-08-61-9C-77-28-1C-6D-29">
+            <FullName>C:\Projects\opencover.git\working\main\packages\NUnit.Runners.2.6.2\tools\pnunit-agent.exe</FullName>
+            <ModuleName>pnunit-agent</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="AD-76-2F-3C-5E-F6-77-0D-C6-AD-AF-A3-90-85-28-07-2D-A0-59-50">
+            <FullName>C:\Projects\opencover.git\working\main\packages\NUnit.Runners.2.6.2\tools\lib\nunit.core.interfaces.dll</FullName>
+            <ModuleName>nunit.core.interfaces</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="DD-C7-A4-7B-11-C7-A0-E1-A2-8C-24-0F-E4-65-6C-79-65-CC-42-92">
+            <FullName>C:\Projects\opencover.git\working\main\bin\Debug\OpenCover.Test.dll</FullName>
+            <ModuleName>OpenCover.Test</ModuleName>
+            <Classes />
+        </Module>
+        <Module hash="B0-C2-FD-A1-3A-C9-E1-62-0F-2F-6D-EB-74-68-5A-20-27-5F-00-BC">
+            <Summary numSequencePoints="1657" visitedSequencePoints="1577" numBranchPoints="922" visitedBranchPoints="769" sequenceCoverage="95.17" branchCoverage="83.41" maxCyclomaticComplexity="31" minCyclomaticComplexity="1" />
+            <FullName>C:\Projects\opencover.git\working\main\bin\Debug\OpenCover.Framework.dll</FullName>
+            <ModuleName>OpenCover.Framework</ModuleName>
+            <Files>
+                <File uid="1" fullPath="c:\Projects\opencover.git\working\main\OpenCover.Framework\Bootstrapper.cs" />
+                <File uid="2" fullPath="c:\Projects\opencover.git\working\main\OpenCover.Framework\CommandLineParserBase.cs" />
+                <File uid="3" fullPath="c:\Projects\opencover.git\working\main\OpenCover.Framework\CommandLineParser.cs" />
+                <File uid="5" fullPath="c:\Projects\opencover.git\working\main\OpenCover.Framework\Communication\MarshalWapper.cs" />
+                <File uid="6" fullPath="c:\Projects\opencover.git\working\main\OpenCover.Framework\Manager\MemoryManager.cs" />
+                <File uid="7" fullPath="c:\Projects\opencover.git\working\main\OpenCover.Framework\Manager\ProfilerManager.cs" />
+                <File uid="9" fullPath="c:\Projects\opencover.git\working\main\OpenCover.Framework\Communication\MessageHandler.cs" />
+                <File uid="10" fullPath="c:\Projects\opencover.git\working\main\OpenCover.Framework\Model\InstrumentationPoint.cs" />
+                <File uid="12" fullPath="c:\Projects\opencover.git\working\main\OpenCover.Framework\Model\InstrumentationModelBuilderFactory.cs" />
+                <File uid="13" fullPath="c:\Projects\opencover.git\working\main\OpenCover.Framework\Model\SkippedEntity.cs" />
+                <File uid="14" fullPath="c:\Projects\opencover.git\working\main\OpenCover.Framework\Model\TrackedMethod.cs" />
+                <File uid="15" fullPath="c:\Projects\opencover.git\working\main\OpenCover.Framework\Persistance\BasePersistance.cs" />
+                <File uid="25" fullPath="c:\Projects\opencover.git\working\main\OpenCover.Framework\Persistance\FilePersistance.cs" />
+                <File uid="26" fullPath="c:\Projects\opencover.git\working\main\OpenCover.Framework\Filter.cs" />
+                <File uid="34" fullPath="c:\Projects\opencover.git\working\main\OpenCover.Framework\Model\InstrumentationModelBuilder.cs" />
+                <File uid="35" fullPath="c:\Projects\opencover.git\working\main\OpenCover.Framework\Model\Class.cs" />
+                <File uid="36" fullPath="c:\Projects\opencover.git\working\main\OpenCover.Framework\Model\CoverageSession.cs" />
+                <File uid="37" fullPath="c:\Projects\opencover.git\working\main\OpenCover.Framework\Model\File.cs" />
+                <File uid="39" fullPath="c:\Projects\opencover.git\working\main\OpenCover.Framework\Model\Method.cs" />
+                <File uid="40" fullPath="c:\Projects\opencover.git\working\main\OpenCover.Framework\Model\Module.cs" />
+                <File uid="41" fullPath="c:\Projects\opencover.git\working\main\OpenCover.Framework\ProfilerRegistration.cs" />
+                <File uid="42" fullPath="c:\Projects\opencover.git\working\main\OpenCover.Framework\Service\ProfilerCommunication.cs" />
+                <File uid="45" fullPath="c:\Projects\opencover.git\working\main\OpenCover.Framework\Strategy\TrackMSTestTestMethods.cs" />
+                <File uid="46" fullPath="c:\Projects\opencover.git\working\main\OpenCover.Framework\Strategy\TrackNUnitTestMethods.cs" />
+                <File uid="47" fullPath="c:\Projects\opencover.git\working\main\OpenCover.Framework\Symbols\CecilSymbolManager.cs" />
+            </Files>
+            <Classes>
+                <Class>
+                    <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="0" minCyclomaticComplexity="0" />
+                    <FullName>&lt;Module&gt;</FullName>
+                    <Methods />
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="22" visitedSequencePoints="22" numBranchPoints="3" visitedBranchPoints="3" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                    <FullName>OpenCover.Framework.Bootstrapper</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="3" visitedSequencePoints="3" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663298</MetadataToken>
+                            <Name>Microsoft.Practices.Unity.IUnityContainer OpenCover.Framework.Bootstrapper::get_Container()</Name>
+                            <FileRef uid="1" />
+                            <SequencePoints>
+                                <SequencePoint vc="2" uspid="1" ordinal="0" offset="0" sl="46" sc="17" el="46" ec="18" />
+                                <SequencePoint vc="2" uspid="2" ordinal="1" offset="1" sl="46" sc="19" el="46" ec="37" />
+                                <SequencePoint vc="2" uspid="3" ordinal="2" offset="10" sl="46" sc="38" el="46" ec="39" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="2" uspid="1" ordinal="0" offset="0" sl="46" sc="17" el="46" ec="18" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="5" visitedSequencePoints="5" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663297</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Bootstrapper::.ctor(log4net.ILog)</Name>
+                            <FileRef uid="1" />
+                            <SequencePoints>
+                                <SequencePoint vc="2" uspid="4" ordinal="0" offset="0" sl="35" sc="9" el="35" ec="41" />
+                                <SequencePoint vc="2" uspid="5" ordinal="1" offset="7" sl="36" sc="9" el="36" ec="10" />
+                                <SequencePoint vc="2" uspid="6" ordinal="2" offset="8" sl="37" sc="13" el="37" ec="30" />
+                                <SequencePoint vc="2" uspid="7" ordinal="3" offset="15" sl="38" sc="13" el="38" ec="47" />
+                                <SequencePoint vc="2" uspid="8" ordinal="4" offset="26" sl="39" sc="9" el="39" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="2" uspid="4" ordinal="0" offset="0" sl="35" sc="9" el="35" ec="41" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="14" visitedSequencePoints="14" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663299</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Bootstrapper::Initialise(OpenCover.Framework.IFilter,OpenCover.Framework.ICommandLine,OpenCover.Framework.Persistance.IPersistance,OpenCover.Framework.Manager.IMemoryManager)</Name>
+                            <FileRef uid="1" />
+                            <SequencePoints>
+                                <SequencePoint vc="2" uspid="9" ordinal="0" offset="0" sl="56" sc="9" el="56" ec="10" />
+                                <SequencePoint vc="2" uspid="10" ordinal="1" offset="1" sl="57" sc="13" el="57" ec="50" />
+                                <SequencePoint vc="2" uspid="11" ordinal="2" offset="19" sl="58" sc="13" el="58" ec="49" />
+                                <SequencePoint vc="2" uspid="12" ordinal="3" offset="32" sl="59" sc="13" el="59" ec="54" />
+                                <SequencePoint vc="2" uspid="13" ordinal="4" offset="45" sl="60" sc="13" el="60" ec="54" />
+                                <SequencePoint vc="2" uspid="14" ordinal="5" offset="58" sl="61" sc="13" el="61" ec="56" />
+                                <SequencePoint vc="2" uspid="15" ordinal="6" offset="72" sl="62" sc="13" el="62" ec="112" />
+                                <SequencePoint vc="2" uspid="16" ordinal="7" offset="90" sl="63" sc="13" el="63" ec="74" />
+                                <SequencePoint vc="2" uspid="17" ordinal="8" offset="108" sl="64" sc="13" el="64" ec="86" />
+                                <SequencePoint vc="2" uspid="18" ordinal="9" offset="126" sl="65" sc="13" el="65" ec="72" />
+                                <SequencePoint vc="2" uspid="19" ordinal="10" offset="144" sl="66" sc="13" el="66" ec="72" />
+                                <SequencePoint vc="2" uspid="20" ordinal="11" offset="162" sl="67" sc="13" el="67" ec="124" />
+                                <SequencePoint vc="2" uspid="21" ordinal="12" offset="195" sl="68" sc="13" el="68" ec="126" />
+                                <SequencePoint vc="2" uspid="22" ordinal="13" offset="228" sl="69" sc="9" el="69" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="2" uspid="9" ordinal="0" offset="0" sl="56" sc="9" el="56" ec="10" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="41" visitedSequencePoints="41" numBranchPoints="17" visitedBranchPoints="17" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="6" minCyclomaticComplexity="1" />
+                    <FullName>OpenCover.Framework.CommandLineParserBase</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663301</MetadataToken>
+                            <Name>System.Collections.Generic.IDictionary`2&lt;System.String,System.String&gt; OpenCover.Framework.CommandLineParserBase::get_ParsedArguments()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="259" uspid="23" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663302</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.CommandLineParserBase::set_ParsedArguments(System.Collections.Generic.IDictionary`2&lt;System.String,System.String&gt;)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="47" uspid="24" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="3" visitedSequencePoints="3" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663304</MetadataToken>
+                            <Name>System.Int32 OpenCover.Framework.CommandLineParserBase::get_ArgumentCount()</Name>
+                            <FileRef uid="2" />
+                            <SequencePoints>
+                                <SequencePoint vc="8" uspid="25" ordinal="0" offset="0" sl="56" sc="40" el="56" ec="41" />
+                                <SequencePoint vc="8" uspid="26" ordinal="1" offset="1" sl="56" sc="42" el="56" ec="71" />
+                                <SequencePoint vc="8" uspid="27" ordinal="2" offset="15" sl="56" sc="72" el="56" ec="73" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="8" uspid="25" ordinal="0" offset="0" sl="56" sc="40" el="56" ec="41" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="6" visitedSequencePoints="6" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663300</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.CommandLineParserBase::.ctor(System.String[])</Name>
+                            <FileRef uid="2" />
+                            <SequencePoints>
+                                <SequencePoint vc="47" uspid="28" ordinal="0" offset="0" sl="20" sc="9" el="20" ec="60" />
+                                <SequencePoint vc="47" uspid="29" ordinal="1" offset="7" sl="21" sc="9" el="21" ec="10" />
+                                <SequencePoint vc="47" uspid="30" ordinal="2" offset="8" sl="22" sc="13" el="22" ec="36" />
+                                <SequencePoint vc="47" uspid="31" ordinal="3" offset="15" sl="23" sc="13" el="23" ec="64" />
+                                <SequencePoint vc="47" uspid="32" ordinal="4" offset="27" sl="24" sc="13" el="24" ec="30" />
+                                <SequencePoint vc="47" uspid="33" ordinal="5" offset="34" sl="25" sc="9" el="25" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="47" uspid="28" ordinal="0" offset="0" sl="20" sc="9" el="20" ec="60" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="6" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="26" visitedSequencePoints="26" numBranchPoints="11" visitedBranchPoints="11" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="6" minCyclomaticComplexity="6" />
+                            <MetadataToken>100663303</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.CommandLineParserBase::ParseArguments()</Name>
+                            <FileRef uid="2" />
+                            <SequencePoints>
+                                <SequencePoint vc="47" uspid="34" ordinal="0" offset="0" sl="30" sc="9" el="30" ec="10" />
+                                <SequencePoint vc="47" uspid="35" ordinal="1" offset="1" sl="31" sc="13" el="31" ec="36" />
+                                <SequencePoint vc="1" uspid="36" ordinal="2" offset="19" sl="31" sc="37" el="31" ec="44" />
+                                <SequencePoint vc="46" uspid="37" ordinal="3" offset="24" sl="33" sc="13" el="33" ec="20" />
+                                <SequencePoint vc="46" uspid="38" ordinal="4" offset="25" sl="33" sc="38" el="33" ec="48" />
+                                <SequencePoint vc="82" uspid="39" ordinal="5" offset="41" sl="33" sc="22" el="33" ec="34" />
+                                <SequencePoint vc="82" uspid="40" ordinal="6" offset="47" sl="34" sc="13" el="34" ec="14" />
+                                <SequencePoint vc="82" uspid="41" ordinal="7" offset="48" sl="35" sc="17" el="35" ec="47" />
+                                <SequencePoint vc="82" uspid="42" ordinal="8" offset="55" sl="36" sc="17" el="36" ec="46" />
+                                <SequencePoint vc="3" uspid="43" ordinal="9" offset="72" sl="36" sc="47" el="36" ec="56" />
+                                <SequencePoint vc="79" uspid="44" ordinal="10" offset="74" sl="37" sc="17" el="37" ec="48" />
+                                <SequencePoint vc="79" uspid="45" ordinal="11" offset="82" sl="38" sc="17" el="38" ec="51" />
+                                <SequencePoint vc="1" uspid="46" ordinal="12" offset="97" sl="38" sc="52" el="38" ec="61" />
+                                <SequencePoint vc="78" uspid="47" ordinal="13" offset="99" sl="39" sc="17" el="39" ec="53" />
+                                <SequencePoint vc="78" uspid="48" ordinal="14" offset="108" sl="40" sc="17" el="40" ec="32" />
+                                <SequencePoint vc="63" uspid="49" ordinal="15" offset="121" sl="41" sc="17" el="41" ec="18" />
+                                <SequencePoint vc="63" uspid="50" ordinal="16" offset="122" sl="42" sc="21" el="42" ec="62" />
+                                <SequencePoint vc="63" uspid="51" ordinal="17" offset="131" sl="43" sc="21" el="43" ec="63" />
+                                <SequencePoint vc="63" uspid="52" ordinal="18" offset="142" sl="44" sc="21" el="44" ec="51" />
+                                <SequencePoint vc="63" uspid="53" ordinal="19" offset="157" sl="45" sc="17" el="45" ec="18" />
+                                <SequencePoint vc="15" uspid="54" ordinal="20" offset="160" sl="47" sc="17" el="47" ec="18" />
+                                <SequencePoint vc="15" uspid="55" ordinal="21" offset="161" sl="48" sc="21" el="48" ec="64" />
+                                <SequencePoint vc="15" uspid="56" ordinal="22" offset="179" sl="49" sc="17" el="49" ec="18" />
+                                <SequencePoint vc="78" uspid="57" ordinal="23" offset="180" sl="50" sc="13" el="50" ec="14" />
+                                <SequencePoint vc="128" uspid="58" ordinal="24" offset="187" sl="33" sc="35" el="33" ec="37" />
+                                <SequencePoint vc="47" uspid="59" ordinal="25" offset="204" sl="51" sc="9" el="51" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="1" uspid="60" ordinal="0" offset="17" path="0" />
+                                <BranchPoint vc="46" uspid="61" ordinal="1" offset="17" path="1" />
+                                <BranchPoint vc="3" uspid="62" ordinal="2" offset="70" path="0" />
+                                <BranchPoint vc="79" uspid="63" ordinal="3" offset="70" path="1" />
+                                <BranchPoint vc="1" uspid="64" ordinal="4" offset="95" path="0" />
+                                <BranchPoint vc="78" uspid="65" ordinal="5" offset="95" path="1" />
+                                <BranchPoint vc="63" uspid="66" ordinal="6" offset="119" path="0" />
+                                <BranchPoint vc="15" uspid="67" ordinal="7" offset="119" path="1" />
+                                <BranchPoint vc="46" uspid="68" ordinal="8" offset="199" path="0" />
+                                <BranchPoint vc="82" uspid="69" ordinal="9" offset="199" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="47" uspid="34" ordinal="0" offset="0" sl="30" sc="9" el="30" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="3" visitedSequencePoints="3" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663305</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.CommandLineParserBase::HasArgument(System.String)</Name>
+                            <FileRef uid="2" />
+                            <SequencePoints>
+                                <SequencePoint vc="74" uspid="70" ordinal="0" offset="0" sl="64" sc="9" el="64" ec="10" />
+                                <SequencePoint vc="74" uspid="71" ordinal="1" offset="1" sl="65" sc="13" el="65" ec="58" />
+                                <SequencePoint vc="74" uspid="72" ordinal="2" offset="16" sl="66" sc="9" el="66" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="74" uspid="70" ordinal="0" offset="0" sl="64" sc="9" el="64" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="3" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="3" visitedSequencePoints="3" numBranchPoints="3" visitedBranchPoints="3" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="3" minCyclomaticComplexity="3" />
+                            <MetadataToken>100663306</MetadataToken>
+                            <Name>System.String OpenCover.Framework.CommandLineParserBase::GetArgumentValue(System.String)</Name>
+                            <FileRef uid="2" />
+                            <SequencePoints>
+                                <SequencePoint vc="64" uspid="73" ordinal="0" offset="0" sl="74" sc="9" el="74" ec="10" />
+                                <SequencePoint vc="64" uspid="74" ordinal="1" offset="1" sl="75" sc="13" el="75" ec="85" />
+                                <SequencePoint vc="64" uspid="75" ordinal="2" offset="33" sl="76" sc="9" el="76" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="1" uspid="76" ordinal="0" offset="8" path="0" />
+                                <BranchPoint vc="63" uspid="77" ordinal="1" offset="8" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="64" uspid="73" ordinal="0" offset="0" sl="74" sc="9" el="74" ec="10" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="142" visitedSequencePoints="142" numBranchPoints="59" visitedBranchPoints="55" sequenceCoverage="100" branchCoverage="93.22" maxCyclomaticComplexity="30" minCyclomaticComplexity="1" />
+                    <FullName>OpenCover.Framework.CommandLineParser</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663316</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.CommandLineParser::get_Register()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="3" uspid="78" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663317</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.CommandLineParser::set_Register(System.Boolean)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="2" uspid="79" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663318</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.CommandLineParser::get_UserRegistration()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="3" uspid="80" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663319</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.CommandLineParser::set_UserRegistration(System.Boolean)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="2" uspid="81" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663320</MetadataToken>
+                            <Name>System.String OpenCover.Framework.CommandLineParser::get_Target()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="31" uspid="82" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663321</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.CommandLineParser::set_Target(System.String)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="30" uspid="83" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663322</MetadataToken>
+                            <Name>System.String OpenCover.Framework.CommandLineParser::get_TargetDir()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="1" uspid="84" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663323</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.CommandLineParser::set_TargetDir(System.String)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="1" uspid="85" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663324</MetadataToken>
+                            <Name>System.String OpenCover.Framework.CommandLineParser::get_TargetArgs()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="1" uspid="86" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663325</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.CommandLineParser::set_TargetArgs(System.String)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="1" uspid="87" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663326</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.CommandLineParser::get_PrintUsage()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="32" uspid="88" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663327</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.CommandLineParser::set_PrintUsage(System.Boolean)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="1" uspid="89" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663328</MetadataToken>
+                            <Name>System.String OpenCover.Framework.CommandLineParser::get_OutputFile()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="1" uspid="90" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663329</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.CommandLineParser::set_OutputFile(System.String)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="38" uspid="91" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663330</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.CommandLineParser::get_NoDefaultFilters()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="2" uspid="92" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663331</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.CommandLineParser::set_NoDefaultFilters(System.Boolean)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="1" uspid="93" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663332</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.CommandLineParser::get_MergeByHash()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="2" uspid="94" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663333</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.CommandLineParser::set_MergeByHash(System.Boolean)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="1" uspid="95" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663334</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.CommandLineParser::get_ShowUnvisited()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="2" uspid="96" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663335</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.CommandLineParser::set_ShowUnvisited(System.Boolean)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="1" uspid="97" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663336</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.CommandLineParser::get_ReturnTargetCode()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="2" uspid="98" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663337</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.CommandLineParser::set_ReturnTargetCode(System.Boolean)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="3" uspid="99" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663338</MetadataToken>
+                            <Name>System.Collections.Generic.List`1&lt;System.String&gt; OpenCover.Framework.CommandLineParser::get_Filters()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="7" uspid="100" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663339</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.CommandLineParser::set_Filters(System.Collections.Generic.List`1&lt;System.String&gt;)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="40" uspid="101" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663340</MetadataToken>
+                            <Name>System.String OpenCover.Framework.CommandLineParser::get_FilterFile()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="1" uspid="102" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663341</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.CommandLineParser::set_FilterFile(System.String)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="1" uspid="103" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663342</MetadataToken>
+                            <Name>System.Int32 OpenCover.Framework.CommandLineParser::get_ReturnCodeOffset()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="2" uspid="104" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663343</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.CommandLineParser::set_ReturnCodeOffset(System.Int32)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="1" uspid="105" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663344</MetadataToken>
+                            <Name>System.Collections.Generic.List`1&lt;System.String&gt; OpenCover.Framework.CommandLineParser::get_AttributeExclusionFilters()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="6" uspid="106" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663345</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.CommandLineParser::set_AttributeExclusionFilters(System.Collections.Generic.List`1&lt;System.String&gt;)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="39" uspid="107" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663346</MetadataToken>
+                            <Name>System.Collections.Generic.List`1&lt;System.String&gt; OpenCover.Framework.CommandLineParser::get_FileExclusionFilters()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="6" uspid="108" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663347</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.CommandLineParser::set_FileExclusionFilters(System.Collections.Generic.List`1&lt;System.String&gt;)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="39" uspid="109" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663348</MetadataToken>
+                            <Name>System.Collections.Generic.List`1&lt;System.String&gt; OpenCover.Framework.CommandLineParser::get_TestFilters()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="4" uspid="110" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663349</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.CommandLineParser::set_TestFilters(System.Collections.Generic.List`1&lt;System.String&gt;)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="38" uspid="111" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663350</MetadataToken>
+                            <Name>System.Collections.Generic.List`1&lt;OpenCover.Framework.Model.SkippedMethod&gt; OpenCover.Framework.CommandLineParser::get_HideSkipped()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="11" uspid="112" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663351</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.CommandLineParser::set_HideSkipped(System.Collections.Generic.List`1&lt;OpenCover.Framework.Model.SkippedMethod&gt;)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="43" uspid="113" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663352</MetadataToken>
+                            <Name>log4net.Core.Level OpenCover.Framework.CommandLineParser::get_LogLevel()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="1" uspid="114" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663353</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.CommandLineParser::set_LogLevel(log4net.Core.Level)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="38" uspid="115" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663354</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.CommandLineParser::get_Service()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="2" uspid="116" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663355</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.CommandLineParser::set_Service(System.Boolean)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="1" uspid="117" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663356</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.CommandLineParser::get_OldStyleInstrumentation()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="1" uspid="118" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663357</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.CommandLineParser::set_OldStyleInstrumentation(System.Boolean)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="1" uspid="119" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="10" visitedSequencePoints="10" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663311</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.CommandLineParser::.ctor(System.String[])</Name>
+                            <FileRef uid="3" />
+                            <SequencePoints>
+                                <SequencePoint vc="37" uspid="120" ordinal="0" offset="0" sl="28" sc="9" el="29" ec="30" />
+                                <SequencePoint vc="37" uspid="121" ordinal="1" offset="8" sl="30" sc="9" el="30" ec="10" />
+                                <SequencePoint vc="37" uspid="122" ordinal="2" offset="9" sl="31" sc="13" el="31" ec="40" />
+                                <SequencePoint vc="37" uspid="123" ordinal="3" offset="21" sl="32" sc="13" el="32" ec="42" />
+                                <SequencePoint vc="37" uspid="124" ordinal="4" offset="33" sl="33" sc="13" el="33" ec="60" />
+                                <SequencePoint vc="37" uspid="125" ordinal="5" offset="45" sl="34" sc="13" el="34" ec="55" />
+                                <SequencePoint vc="37" uspid="126" ordinal="6" offset="57" sl="35" sc="13" el="35" ec="46" />
+                                <SequencePoint vc="37" uspid="127" ordinal="7" offset="69" sl="36" sc="13" el="36" ec="35" />
+                                <SequencePoint vc="37" uspid="128" ordinal="8" offset="81" sl="37" sc="13" el="37" ec="53" />
+                                <SequencePoint vc="37" uspid="129" ordinal="9" offset="93" sl="38" sc="9" el="38" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="37" uspid="120" ordinal="0" offset="0" sl="28" sc="9" el="29" ec="30" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="39" visitedSequencePoints="39" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663312</MetadataToken>
+                            <Name>System.String OpenCover.Framework.CommandLineParser::Usage()</Name>
+                            <FileRef uid="3" />
+                            <SequencePoints>
+                                <SequencePoint vc="1" uspid="130" ordinal="0" offset="0" sl="45" sc="9" el="45" ec="10" />
+                                <SequencePoint vc="1" uspid="131" ordinal="1" offset="1" sl="46" sc="13" el="46" ec="47" />
+                                <SequencePoint vc="1" uspid="132" ordinal="2" offset="7" sl="47" sc="13" el="47" ec="42" />
+                                <SequencePoint vc="1" uspid="133" ordinal="3" offset="19" sl="48" sc="13" el="48" ec="76" />
+                                <SequencePoint vc="1" uspid="134" ordinal="4" offset="31" sl="49" sc="13" el="49" ec="79" />
+                                <SequencePoint vc="1" uspid="135" ordinal="5" offset="43" sl="50" sc="13" el="50" ec="96" />
+                                <SequencePoint vc="1" uspid="136" ordinal="6" offset="55" sl="51" sc="13" el="51" ec="58" />
+                                <SequencePoint vc="1" uspid="137" ordinal="7" offset="67" sl="52" sc="13" el="52" ec="72" />
+                                <SequencePoint vc="1" uspid="138" ordinal="8" offset="79" sl="53" sc="13" el="53" ec="83" />
+                                <SequencePoint vc="1" uspid="139" ordinal="9" offset="91" sl="54" sc="13" el="54" ec="76" />
+                                <SequencePoint vc="1" uspid="140" ordinal="10" offset="103" sl="55" sc="13" el="55" ec="59" />
+                                <SequencePoint vc="1" uspid="141" ordinal="11" offset="115" sl="56" sc="13" el="56" ec="54" />
+                                <SequencePoint vc="1" uspid="142" ordinal="12" offset="127" sl="57" sc="13" el="57" ec="56" />
+                                <SequencePoint vc="1" uspid="143" ordinal="13" offset="139" sl="58" sc="13" el="58" ec="89" />
+                                <SequencePoint vc="1" uspid="144" ordinal="14" offset="151" sl="59" sc="13" el="59" ec="92" />
+                                <SequencePoint vc="1" uspid="145" ordinal="15" offset="163" sl="60" sc="13" el="60" ec="87" />
+                                <SequencePoint vc="1" uspid="146" ordinal="16" offset="175" sl="61" sc="13" el="61" ec="85" />
+                                <SequencePoint vc="1" uspid="147" ordinal="17" offset="187" sl="62" sc="13" el="62" ec="130" />
+                                <SequencePoint vc="1" uspid="148" ordinal="18" offset="199" sl="63" sc="13" el="63" ec="92" />
+                                <SequencePoint vc="1" uspid="149" ordinal="19" offset="211" sl="64" sc="13" el="64" ec="50" />
+                                <SequencePoint vc="1" uspid="150" ordinal="20" offset="223" sl="65" sc="13" el="65" ec="51" />
+                                <SequencePoint vc="1" uspid="151" ordinal="21" offset="235" sl="66" sc="13" el="66" ec="38" />
+                                <SequencePoint vc="1" uspid="152" ordinal="22" offset="247" sl="67" sc="13" el="67" ec="42" />
+                                <SequencePoint vc="1" uspid="153" ordinal="23" offset="259" sl="68" sc="13" el="68" ec="36" />
+                                <SequencePoint vc="1" uspid="154" ordinal="24" offset="271" sl="69" sc="13" el="69" ec="101" />
+                                <SequencePoint vc="1" uspid="155" ordinal="25" offset="283" sl="70" sc="13" el="70" ec="87" />
+                                <SequencePoint vc="1" uspid="156" ordinal="26" offset="295" sl="71" sc="13" el="71" ec="36" />
+                                <SequencePoint vc="1" uspid="157" ordinal="27" offset="307" sl="72" sc="13" el="72" ec="44" />
+                                <SequencePoint vc="1" uspid="158" ordinal="28" offset="319" sl="73" sc="13" el="73" ec="107" />
+                                <SequencePoint vc="1" uspid="159" ordinal="29" offset="331" sl="74" sc="13" el="74" ec="112" />
+                                <SequencePoint vc="1" uspid="160" ordinal="30" offset="343" sl="75" sc="13" el="75" ec="107" />
+                                <SequencePoint vc="1" uspid="161" ordinal="31" offset="355" sl="76" sc="13" el="76" ec="48" />
+                                <SequencePoint vc="1" uspid="162" ordinal="32" offset="367" sl="77" sc="13" el="77" ec="44" />
+                                <SequencePoint vc="1" uspid="163" ordinal="33" offset="379" sl="78" sc="13" el="78" ec="109" />
+                                <SequencePoint vc="1" uspid="164" ordinal="34" offset="391" sl="79" sc="13" el="79" ec="88" />
+                                <SequencePoint vc="1" uspid="165" ordinal="35" offset="403" sl="80" sc="13" el="80" ec="42" />
+                                <SequencePoint vc="1" uspid="166" ordinal="36" offset="415" sl="81" sc="13" el="81" ec="114" />
+                                <SequencePoint vc="1" uspid="167" ordinal="37" offset="427" sl="83" sc="13" el="83" ec="39" />
+                                <SequencePoint vc="1" uspid="168" ordinal="38" offset="436" sl="84" sc="9" el="84" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="1" uspid="130" ordinal="0" offset="0" sl="45" sc="9" el="45" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="30" sequenceCoverage="100" branchCoverage="92.31" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="63" visitedSequencePoints="63" numBranchPoints="39" visitedBranchPoints="36" sequenceCoverage="100" branchCoverage="92.31" maxCyclomaticComplexity="30" minCyclomaticComplexity="30" />
+                            <MetadataToken>100663313</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.CommandLineParser::ExtractAndValidateArguments()</Name>
+                            <FileRef uid="3" />
+                            <SequencePoints>
+                                <SequencePoint vc="36" uspid="169" ordinal="0" offset="0" sl="90" sc="9" el="90" ec="10" />
+                                <SequencePoint vc="36" uspid="170" ordinal="1" offset="1" sl="91" sc="13" el="91" ec="20" />
+                                <SequencePoint vc="36" uspid="171" ordinal="2" offset="2" sl="91" sc="33" el="91" ec="53" />
+                                <SequencePoint vc="64" uspid="172" ordinal="3" offset="25" sl="91" sc="22" el="91" ec="29" />
+                                <SequencePoint vc="64" uspid="173" ordinal="4" offset="33" sl="92" sc="13" el="92" ec="14" />
+                                <SequencePoint vc="64" uspid="174" ordinal="5" offset="34" sl="93" sc="17" el="93" ec="52" />
+                                <SequencePoint vc="64" uspid="175" ordinal="6" offset="48" sl="94" sc="17" el="94" ec="30" />
+                                <SequencePoint vc="2" uspid="176" ordinal="7" offset="431" sl="97" sc="25" el="97" ec="41" />
+                                <SequencePoint vc="2" uspid="177" ordinal="8" offset="439" sl="98" sc="25" el="98" ec="104" />
+                                <SequencePoint vc="2" uspid="178" ordinal="9" offset="472" sl="99" sc="25" el="99" ec="31" />
+                                <SequencePoint vc="30" uspid="179" ordinal="10" offset="477" sl="101" sc="25" el="101" ec="61" />
+                                <SequencePoint vc="30" uspid="180" ordinal="11" offset="495" sl="102" sc="25" el="102" ec="31" />
+                                <SequencePoint vc="1" uspid="181" ordinal="12" offset="500" sl="104" sc="25" el="104" ec="67" />
+                                <SequencePoint vc="1" uspid="182" ordinal="13" offset="518" sl="105" sc="25" el="105" ec="31" />
+                                <SequencePoint vc="1" uspid="183" ordinal="14" offset="523" sl="107" sc="25" el="107" ec="69" />
+                                <SequencePoint vc="1" uspid="184" ordinal="15" offset="541" sl="108" sc="25" el="108" ec="31" />
+                                <SequencePoint vc="1" uspid="185" ordinal="16" offset="546" sl="110" sc="25" el="110" ec="65" />
+                                <SequencePoint vc="1" uspid="186" ordinal="17" offset="564" sl="111" sc="25" el="111" ec="31" />
+                                <SequencePoint vc="1" uspid="187" ordinal="18" offset="569" sl="113" sc="25" el="113" ec="49" />
+                                <SequencePoint vc="1" uspid="188" ordinal="19" offset="577" sl="114" sc="25" el="114" ec="31" />
+                                <SequencePoint vc="1" uspid="189" ordinal="20" offset="582" sl="116" sc="25" el="116" ec="44" />
+                                <SequencePoint vc="1" uspid="190" ordinal="21" offset="590" sl="117" sc="25" el="117" ec="31" />
+                                <SequencePoint vc="1" uspid="191" ordinal="22" offset="595" sl="119" sc="25" el="119" ec="46" />
+                                <SequencePoint vc="1" uspid="192" ordinal="23" offset="603" sl="120" sc="25" el="120" ec="31" />
+                                <SequencePoint vc="3" uspid="193" ordinal="24" offset="608" sl="122" sc="25" el="122" ec="49" />
+                                <SequencePoint vc="3" uspid="194" ordinal="25" offset="616" sl="123" sc="25" el="123" ec="77" />
+                                <SequencePoint vc="3" uspid="195" ordinal="26" offset="628" sl="124" sc="25" el="124" ec="54" />
+                                <SequencePoint vc="2" uspid="196" ordinal="27" offset="648" sl="125" sc="25" el="125" ec="26" />
+                                <SequencePoint vc="2" uspid="197" ordinal="28" offset="649" sl="127" sc="29" el="127" ec="68" />
+                                <SequencePoint vc="1" uspid="198" ordinal="29" offset="666" sl="128" sc="33" el="128" ec="59" />
+                                <SequencePoint vc="1" uspid="199" ordinal="30" offset="676" sl="130" sc="33" el="130" ec="121" />
+                                <SequencePoint vc="1" uspid="200" ordinal="31" offset="687" sl="131" sc="25" el="131" ec="26" />
+                                <SequencePoint vc="2" uspid="201" ordinal="32" offset="688" sl="132" sc="25" el="132" ec="31" />
+                                <SequencePoint vc="3" uspid="202" ordinal="33" offset="693" sl="134" sc="25" el="134" ec="78" />
+                                <SequencePoint vc="3" uspid="203" ordinal="34" offset="716" sl="135" sc="25" el="135" ec="31" />
+                                <SequencePoint vc="1" uspid="204" ordinal="35" offset="721" sl="137" sc="25" el="137" ec="69" />
+                                <SequencePoint vc="1" uspid="205" ordinal="36" offset="739" sl="138" sc="25" el="138" ec="31" />
+                                <SequencePoint vc="2" uspid="206" ordinal="37" offset="744" sl="140" sc="25" el="141" ec="50" />
+                                <SequencePoint vc="2" uspid="207" ordinal="38" offset="788" sl="142" sc="25" el="142" ec="31" />
+                                <SequencePoint vc="2" uspid="208" ordinal="39" offset="793" sl="144" sc="25" el="145" ec="50" />
+                                <SequencePoint vc="2" uspid="209" ordinal="40" offset="837" sl="146" sc="25" el="146" ec="31" />
+                                <SequencePoint vc="7" uspid="210" ordinal="41" offset="842" sl="148" sc="25" el="148" ec="87" />
+                                <SequencePoint vc="6" uspid="211" ordinal="42" offset="865" sl="149" sc="25" el="149" ec="31" />
+                                <SequencePoint vc="1" uspid="212" ordinal="43" offset="870" sl="151" sc="25" el="152" ec="50" />
+                                <SequencePoint vc="1" uspid="213" ordinal="44" offset="914" sl="153" sc="25" el="153" ec="31" />
+                                <SequencePoint vc="2" uspid="214" ordinal="45" offset="919" sl="155" sc="25" el="155" ec="61" />
+                                <SequencePoint vc="2" uspid="215" ordinal="46" offset="937" sl="156" sc="25" el="157" ec="137" />
+                                <SequencePoint vc="1" uspid="216" ordinal="47" offset="999" sl="158" sc="25" el="158" ec="31" />
+                                <SequencePoint vc="1" uspid="217" ordinal="48" offset="1001" sl="160" sc="25" el="160" ec="40" />
+                                <SequencePoint vc="1" uspid="218" ordinal="49" offset="1009" sl="161" sc="25" el="161" ec="31" />
+                                <SequencePoint vc="1" uspid="219" ordinal="50" offset="1011" sl="163" sc="25" el="163" ec="56" />
+                                <SequencePoint vc="1" uspid="220" ordinal="51" offset="1019" sl="164" sc="25" el="164" ec="31" />
+                                <SequencePoint vc="1" uspid="221" ordinal="52" offset="1021" sl="166" sc="25" el="166" ec="43" />
+                                <SequencePoint vc="1" uspid="222" ordinal="53" offset="1029" sl="167" sc="25" el="167" ec="31" />
+                                <SequencePoint vc="2" uspid="223" ordinal="54" offset="1031" sl="169" sc="25" el="169" ec="119" />
+                                <SequencePoint vc="59" uspid="224" ordinal="55" offset="1048" sl="171" sc="13" el="171" ec="14" />
+                                <SequencePoint vc="95" uspid="225" ordinal="56" offset="1049" sl="91" sc="30" el="91" ec="32" />
+                                <SequencePoint vc="31" uspid="226" ordinal="57" offset="1088" sl="173" sc="13" el="173" ec="28" />
+                                <SequencePoint vc="1" uspid="227" ordinal="58" offset="1103" sl="173" sc="29" el="173" ec="36" />
+                                <SequencePoint vc="30" uspid="228" ordinal="59" offset="1105" sl="175" sc="13" el="175" ec="51" />
+                                <SequencePoint vc="1" uspid="229" ordinal="60" offset="1125" sl="176" sc="13" el="176" ec="14" />
+                                <SequencePoint vc="1" uspid="230" ordinal="61" offset="1126" sl="177" sc="17" el="177" ec="88" />
+                                <SequencePoint vc="30" uspid="231" ordinal="62" offset="1137" sl="179" sc="9" el="179" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="64" uspid="232" ordinal="0" offset="53" path="0" />
+                                <BranchPoint vc="0" uspid="233" ordinal="1" offset="53" path="1" />
+                                <BranchPoint vc="1" uspid="234" ordinal="2" offset="65" path="0" />
+                                <BranchPoint vc="63" uspid="235" ordinal="3" offset="65" path="1" />
+                                <BranchPoint vc="62" uspid="236" ordinal="4" offset="338" path="0" />
+                                <BranchPoint vc="2" uspid="237" ordinal="5" offset="338" path="1" />
+                                <BranchPoint vc="0" uspid="238" ordinal="6" offset="345" path="0" />
+                                <BranchPoint vc="2" uspid="239" ordinal="7" offset="345" path="1" />
+                                <BranchPoint vc="30" uspid="240" ordinal="8" offset="345" path="2" />
+                                <BranchPoint vc="1" uspid="241" ordinal="9" offset="345" path="3" />
+                                <BranchPoint vc="1" uspid="242" ordinal="10" offset="345" path="4" />
+                                <BranchPoint vc="1" uspid="243" ordinal="11" offset="345" path="5" />
+                                <BranchPoint vc="1" uspid="244" ordinal="12" offset="345" path="6" />
+                                <BranchPoint vc="1" uspid="245" ordinal="13" offset="345" path="7" />
+                                <BranchPoint vc="1" uspid="246" ordinal="14" offset="345" path="8" />
+                                <BranchPoint vc="3" uspid="247" ordinal="15" offset="345" path="9" />
+                                <BranchPoint vc="3" uspid="248" ordinal="16" offset="345" path="10" />
+                                <BranchPoint vc="1" uspid="249" ordinal="17" offset="345" path="11" />
+                                <BranchPoint vc="2" uspid="250" ordinal="18" offset="345" path="12" />
+                                <BranchPoint vc="2" uspid="251" ordinal="19" offset="345" path="13" />
+                                <BranchPoint vc="7" uspid="252" ordinal="20" offset="345" path="14" />
+                                <BranchPoint vc="1" uspid="253" ordinal="21" offset="345" path="15" />
+                                <BranchPoint vc="2" uspid="254" ordinal="22" offset="345" path="16" />
+                                <BranchPoint vc="1" uspid="255" ordinal="23" offset="345" path="17" />
+                                <BranchPoint vc="1" uspid="256" ordinal="24" offset="345" path="18" />
+                                <BranchPoint vc="1" uspid="257" ordinal="25" offset="345" path="19" />
+                                <BranchPoint vc="2" uspid="258" ordinal="26" offset="646" path="0" />
+                                <BranchPoint vc="1" uspid="259" ordinal="27" offset="646" path="1" />
+                                <BranchPoint vc="1" uspid="260" ordinal="28" offset="664" path="0" />
+                                <BranchPoint vc="1" uspid="261" ordinal="29" offset="664" path="1" />
+                                <BranchPoint vc="31" uspid="262" ordinal="30" offset="1060" path="0" />
+                                <BranchPoint vc="64" uspid="263" ordinal="31" offset="1060" path="1" />
+                                <BranchPoint vc="36" uspid="264" ordinal="32" offset="1076" path="0" />
+                                <BranchPoint vc="0" uspid="265" ordinal="33" offset="1076" path="1" />
+                                <BranchPoint vc="1" uspid="266" ordinal="34" offset="1101" path="0" />
+                                <BranchPoint vc="30" uspid="267" ordinal="35" offset="1101" path="1" />
+                                <BranchPoint vc="1" uspid="268" ordinal="36" offset="1123" path="0" />
+                                <BranchPoint vc="29" uspid="269" ordinal="37" offset="1123" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="36" uspid="169" ordinal="0" offset="0" sl="90" sc="9" el="90" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="3" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="4" visitedSequencePoints="4" numBranchPoints="5" visitedBranchPoints="5" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="3" minCyclomaticComplexity="3" />
+                            <MetadataToken>100663314</MetadataToken>
+                            <Name>System.Collections.Generic.List`1&lt;System.String&gt; OpenCover.Framework.CommandLineParser::ExtractFilters(System.String)</Name>
+                            <FileRef uid="3" />
+                            <SequencePoints>
+                                <SequencePoint vc="3" uspid="270" ordinal="0" offset="0" sl="182" sc="9" el="182" ec="10" />
+                                <SequencePoint vc="3" uspid="271" ordinal="1" offset="1" sl="185" sc="13" el="185" ec="63" />
+                                <SequencePoint vc="3" uspid="272" ordinal="2" offset="13" sl="187" sc="13" el="187" ec="131" />
+                                <SequencePoint vc="3" uspid="273" ordinal="3" offset="105" sl="188" sc="9" el="188" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="1" uspid="274" ordinal="0" offset="30" path="0" />
+                                <BranchPoint vc="2" uspid="275" ordinal="1" offset="30" path="1" />
+                                <BranchPoint vc="1" uspid="276" ordinal="2" offset="66" path="0" />
+                                <BranchPoint vc="2" uspid="277" ordinal="3" offset="66" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="3" uspid="270" ordinal="0" offset="0" sl="182" sc="9" el="182" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="6" sequenceCoverage="100" branchCoverage="90.91" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="24" visitedSequencePoints="24" numBranchPoints="11" visitedBranchPoints="10" sequenceCoverage="100" branchCoverage="90.91" maxCyclomaticComplexity="6" minCyclomaticComplexity="6" />
+                            <MetadataToken>100663315</MetadataToken>
+                            <Name>System.Collections.Generic.List`1&lt;OpenCover.Framework.Model.SkippedMethod&gt; OpenCover.Framework.CommandLineParser::ExtractSkipped(System.String)</Name>
+                            <FileRef uid="3" />
+                            <SequencePoints>
+                                <SequencePoint vc="7" uspid="278" ordinal="0" offset="0" sl="191" sc="9" el="191" ec="10" />
+                                <SequencePoint vc="7" uspid="279" ordinal="1" offset="1" sl="192" sc="13" el="192" ec="52" />
+                                <SequencePoint vc="1" uspid="280" ordinal="2" offset="16" sl="192" sc="53" el="192" ec="69" />
+                                <SequencePoint vc="7" uspid="281" ordinal="3" offset="23" sl="193" sc="13" el="193" ec="46" />
+                                <SequencePoint vc="7" uspid="282" ordinal="4" offset="46" sl="194" sc="13" el="194" ec="50" />
+                                <SequencePoint vc="7" uspid="283" ordinal="5" offset="52" sl="195" sc="13" el="195" ec="20" />
+                                <SequencePoint vc="7" uspid="284" ordinal="6" offset="53" sl="195" sc="36" el="195" ec="43" />
+                                <SequencePoint vc="13" uspid="285" ordinal="7" offset="61" sl="195" sc="22" el="195" ec="32" />
+                                <SequencePoint vc="13" uspid="286" ordinal="8" offset="67" sl="196" sc="13" el="196" ec="14" />
+                                <SequencePoint vc="13" uspid="287" ordinal="9" offset="68" sl="197" sc="17" el="197" ec="51" />
+                                <SequencePoint vc="3" uspid="288" ordinal="10" offset="96" sl="200" sc="25" el="200" ec="59" />
+                                <SequencePoint vc="3" uspid="289" ordinal="11" offset="104" sl="201" sc="25" el="201" ec="54" />
+                                <SequencePoint vc="3" uspid="290" ordinal="12" offset="112" sl="202" sc="25" el="202" ec="56" />
+                                <SequencePoint vc="3" uspid="291" ordinal="13" offset="120" sl="203" sc="25" el="203" ec="60" />
+                                <SequencePoint vc="3" uspid="292" ordinal="14" offset="128" sl="204" sc="25" el="204" ec="31" />
+                                <SequencePoint vc="10" uspid="293" ordinal="15" offset="130" sl="207" sc="25" el="207" ec="70" />
+                                <SequencePoint vc="1" uspid="294" ordinal="16" offset="145" sl="208" sc="25" el="208" ec="26" />
+                                <SequencePoint vc="1" uspid="295" ordinal="17" offset="146" sl="209" sc="29" el="209" ec="131" />
+                                <SequencePoint vc="9" uspid="296" ordinal="18" offset="163" sl="211" sc="25" el="211" ec="42" />
+                                <SequencePoint vc="9" uspid="297" ordinal="19" offset="171" sl="212" sc="25" el="212" ec="31" />
+                                <SequencePoint vc="12" uspid="298" ordinal="20" offset="173" sl="214" sc="13" el="214" ec="14" />
+                                <SequencePoint vc="19" uspid="299" ordinal="21" offset="180" sl="195" sc="33" el="195" ec="35" />
+                                <SequencePoint vc="6" uspid="300" ordinal="22" offset="197" sl="215" sc="13" el="215" ec="45" />
+                                <SequencePoint vc="6" uspid="301" ordinal="23" offset="212" sl="216" sc="9" el="216" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="1" uspid="302" ordinal="0" offset="14" path="0" />
+                                <BranchPoint vc="6" uspid="303" ordinal="1" offset="14" path="1" />
+                                <BranchPoint vc="13" uspid="304" ordinal="2" offset="78" path="0" />
+                                <BranchPoint vc="0" uspid="305" ordinal="3" offset="78" path="1" />
+                                <BranchPoint vc="10" uspid="306" ordinal="4" offset="92" path="0" />
+                                <BranchPoint vc="3" uspid="307" ordinal="5" offset="92" path="1" />
+                                <BranchPoint vc="1" uspid="308" ordinal="6" offset="143" path="0" />
+                                <BranchPoint vc="9" uspid="309" ordinal="7" offset="143" path="1" />
+                                <BranchPoint vc="6" uspid="310" ordinal="8" offset="192" path="0" />
+                                <BranchPoint vc="13" uspid="311" ordinal="9" offset="192" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="7" uspid="278" ordinal="0" offset="0" sl="191" sc="9" el="191" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663358</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.CommandLineParser::&lt;ExtractFilters&gt;b__3(System.Text.RegularExpressions.Match)</Name>
+                            <FileRef uid="3" />
+                            <SequencePoints>
+                                <SequencePoint vc="4" uspid="312" ordinal="0" offset="0" sl="187" sc="77" el="187" ec="92" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="4" uspid="312" ordinal="0" offset="0" sl="187" sc="77" el="187" ec="92" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663359</MetadataToken>
+                            <Name>System.String OpenCover.Framework.CommandLineParser::&lt;ExtractFilters&gt;b__4(System.Text.RegularExpressions.Match)</Name>
+                            <FileRef uid="3" />
+                            <SequencePoints>
+                                <SequencePoint vc="4" uspid="313" ordinal="0" offset="0" sl="187" sc="100" el="187" ec="120" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="4" uspid="313" ordinal="0" offset="0" sl="187" sc="100" el="187" ec="120" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                    <FullName>OpenCover.Framework.CommandLineParser/&lt;&gt;c__DisplayClass1</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663727</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.CommandLineParser/&lt;&gt;c__DisplayClass1::.ctor()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="64" uspid="314" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663728</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.CommandLineParser/&lt;&gt;c__DisplayClass1::&lt;ExtractAndValidateArguments&gt;b__0(System.Reflection.FieldInfo)</Name>
+                            <FileRef uid="3" />
+                            <SequencePoints>
+                                <SequencePoint vc="29" uspid="315" ordinal="0" offset="0" sl="157" sc="41" el="157" ec="111" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="29" uspid="315" ordinal="0" offset="0" sl="157" sc="41" el="157" ec="111" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="6" visitedSequencePoints="0" numBranchPoints="2" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                    <FullName>OpenCover.Framework.Communication.MarshalWrapper</FullName>
+                    <Methods>
+                        <Method visited="false" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="3" visitedSequencePoints="0" numBranchPoints="1" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663362</MetadataToken>
+                            <Name>T OpenCover.Framework.Communication.MarshalWrapper::PtrToStructure(System.IntPtr)</Name>
+                            <FileRef uid="5" />
+                            <SequencePoints>
+                                <SequencePoint vc="0" uspid="316" ordinal="0" offset="0" sl="23" sc="9" el="23" ec="10" />
+                                <SequencePoint vc="0" uspid="317" ordinal="1" offset="1" sl="24" sc="13" el="24" ec="71" />
+                                <SequencePoint vc="0" uspid="318" ordinal="2" offset="25" sl="25" sc="9" el="25" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="0" uspid="316" ordinal="0" offset="0" sl="23" sc="9" el="23" ec="10" />
+                        </Method>
+                        <Method visited="false" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="3" visitedSequencePoints="0" numBranchPoints="1" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663363</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Communication.MarshalWrapper::StructureToPtr(T,System.IntPtr,System.Boolean)</Name>
+                            <FileRef uid="5" />
+                            <SequencePoints>
+                                <SequencePoint vc="0" uspid="319" ordinal="0" offset="0" sl="28" sc="9" el="28" ec="10" />
+                                <SequencePoint vc="0" uspid="320" ordinal="1" offset="1" sl="29" sc="13" el="29" ec="73" />
+                                <SequencePoint vc="0" uspid="321" ordinal="2" offset="15" sl="30" sc="9" el="30" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="0" uspid="319" ordinal="0" offset="0" sl="28" sc="9" el="28" ec="10" />
+                        </Method>
+                        <Method visited="false" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663364</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Communication.MarshalWrapper::.ctor()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="0" uspid="322" ordinal="0" offset="0" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="51" visitedSequencePoints="50" numBranchPoints="24" visitedBranchPoints="19" sequenceCoverage="98.04" branchCoverage="79.17" maxCyclomaticComplexity="4" minCyclomaticComplexity="1" />
+                    <FullName>OpenCover.Framework.Manager.MemoryManager</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="3" visitedSequencePoints="3" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663372</MetadataToken>
+                            <Name>System.Collections.Generic.IList`1&lt;OpenCover.Framework.Manager.MemoryManager/ManagedMemoryBlock&gt; OpenCover.Framework.Manager.MemoryManager::get_GetBlocks()</Name>
+                            <FileRef uid="6" />
+                            <SequencePoints>
+                                <SequencePoint vc="9" uspid="323" ordinal="0" offset="0" sl="64" sc="17" el="64" ec="18" />
+                                <SequencePoint vc="9" uspid="324" ordinal="1" offset="1" sl="64" sc="19" el="64" ec="34" />
+                                <SequencePoint vc="9" uspid="325" ordinal="2" offset="10" sl="64" sc="35" el="64" ec="36" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="9" uspid="323" ordinal="0" offset="0" sl="64" sc="17" el="64" ec="18" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="2" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="7" visitedSequencePoints="7" numBranchPoints="3" visitedBranchPoints="3" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="2" minCyclomaticComplexity="2" />
+                            <MetadataToken>100663369</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Manager.MemoryManager::Initialise(System.String,System.String)</Name>
+                            <FileRef uid="6" />
+                            <SequencePoints>
+                                <SequencePoint vc="10" uspid="326" ordinal="0" offset="0" sl="29" sc="9" el="29" ec="10" />
+                                <SequencePoint vc="10" uspid="327" ordinal="1" offset="1" sl="30" sc="13" el="30" ec="30" />
+                                <SequencePoint vc="5" uspid="328" ordinal="2" offset="14" sl="30" sc="31" el="30" ec="38" />
+                                <SequencePoint vc="5" uspid="329" ordinal="3" offset="16" sl="31" sc="13" el="31" ec="37" />
+                                <SequencePoint vc="5" uspid="330" ordinal="4" offset="23" sl="32" sc="13" el="32" ec="24" />
+                                <SequencePoint vc="5" uspid="331" ordinal="5" offset="30" sl="33" sc="13" el="33" ec="33" />
+                                <SequencePoint vc="10" uspid="332" ordinal="6" offset="37" sl="34" sc="9" el="34" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="5" uspid="333" ordinal="0" offset="12" path="0" />
+                                <BranchPoint vc="5" uspid="334" ordinal="1" offset="12" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="10" uspid="326" ordinal="0" offset="0" sl="29" sc="9" el="29" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="3" sequenceCoverage="93.33" branchCoverage="60" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="15" visitedSequencePoints="14" numBranchPoints="5" visitedBranchPoints="3" sequenceCoverage="93.33" branchCoverage="60" maxCyclomaticComplexity="3" minCyclomaticComplexity="3" />
+                            <MetadataToken>100663370</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Manager.MemoryManager::AllocateMemoryBuffer(System.Int32,System.UInt32)</Name>
+                            <FileRef uid="6" />
+                            <SequencePoints>
+                                <SequencePoint vc="5" uspid="335" ordinal="0" offset="0" sl="37" sc="9" el="37" ec="10" />
+                                <SequencePoint vc="5" uspid="336" ordinal="1" offset="1" sl="38" sc="13" el="38" ec="31" />
+                                <SequencePoint vc="0" uspid="337" ordinal="2" offset="11" sl="38" sc="32" el="38" ec="39" />
+                                <SequencePoint vc="5" uspid="338" ordinal="3" offset="18" sl="40" sc="13" el="40" ec="30" />
+                                <SequencePoint vc="5" uspid="339" ordinal="4" offset="34" sl="41" sc="13" el="41" ec="14" />
+                                <SequencePoint vc="5" uspid="340" ordinal="5" offset="35" sl="42" sc="17" el="42" ec="54" />
+                                <SequencePoint vc="5" uspid="341" ordinal="6" offset="41" sl="43" sc="17" el="43" ec="176" />
+                                <SequencePoint vc="5" uspid="342" ordinal="7" offset="68" sl="44" sc="17" el="44" ec="184" />
+                                <SequencePoint vc="5" uspid="343" ordinal="8" offset="95" sl="45" sc="17" el="45" ec="142" />
+                                <SequencePoint vc="5" uspid="344" ordinal="9" offset="122" sl="46" sc="17" el="46" ec="130" />
+                                <SequencePoint vc="5" uspid="345" ordinal="10" offset="145" sl="47" sc="17" el="47" ec="83" />
+                                <SequencePoint vc="5" uspid="346" ordinal="11" offset="165" sl="48" sc="17" el="48" ec="47" />
+                                <SequencePoint vc="5" uspid="347" ordinal="12" offset="173" sl="50" sc="17" el="50" ec="36" />
+                                <SequencePoint vc="5" uspid="348" ordinal="13" offset="186" sl="51" sc="13" el="51" ec="14" />
+                                <SequencePoint vc="5" uspid="349" ordinal="14" offset="206" sl="52" sc="9" el="52" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="0" uspid="350" ordinal="0" offset="9" path="0" />
+                                <BranchPoint vc="5" uspid="351" ordinal="1" offset="9" path="1" />
+                                <BranchPoint vc="5" uspid="352" ordinal="2" offset="195" path="0" />
+                                <BranchPoint vc="0" uspid="353" ordinal="3" offset="195" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="5" uspid="335" ordinal="0" offset="0" sl="37" sc="9" el="37" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="3" sequenceCoverage="100" branchCoverage="80" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="5" visitedSequencePoints="5" numBranchPoints="5" visitedBranchPoints="4" sequenceCoverage="100" branchCoverage="80" maxCyclomaticComplexity="3" minCyclomaticComplexity="3" />
+                            <MetadataToken>100663371</MetadataToken>
+                            <Name>System.Collections.Generic.IList`1&lt;System.Threading.WaitHandle&gt; OpenCover.Framework.Manager.MemoryManager::GetHandles()</Name>
+                            <FileRef uid="6" />
+                            <SequencePoints>
+                                <SequencePoint vc="10" uspid="354" ordinal="0" offset="0" sl="55" sc="9" el="55" ec="10" />
+                                <SequencePoint vc="10" uspid="355" ordinal="1" offset="3" sl="56" sc="13" el="56" ec="30" />
+                                <SequencePoint vc="10" uspid="356" ordinal="2" offset="19" sl="57" sc="13" el="57" ec="14" />
+                                <SequencePoint vc="10" uspid="357" ordinal="3" offset="20" sl="58" sc="17" el="58" ec="87" />
+                                <SequencePoint vc="10" uspid="358" ordinal="4" offset="87" sl="60" sc="9" el="60" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="1" uspid="359" ordinal="0" offset="31" path="0" />
+                                <BranchPoint vc="9" uspid="360" ordinal="1" offset="31" path="1" />
+                                <BranchPoint vc="10" uspid="361" ordinal="2" offset="76" path="0" />
+                                <BranchPoint vc="0" uspid="362" ordinal="3" offset="76" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="10" uspid="354" ordinal="0" offset="0" sl="55" sc="9" el="55" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="3" visitedSequencePoints="3" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663373</MetadataToken>
+                            <Name>System.String OpenCover.Framework.Manager.MemoryManager::MakeName(System.String,System.Int64)</Name>
+                            <FileRef uid="6" />
+                            <SequencePoints>
+                                <SequencePoint vc="15" uspid="363" ordinal="0" offset="0" sl="68" sc="9" el="68" ec="10" />
+                                <SequencePoint vc="15" uspid="364" ordinal="1" offset="1" sl="69" sc="13" el="69" ec="78" />
+                                <SequencePoint vc="15" uspid="365" ordinal="2" offset="53" sl="70" sc="9" el="70" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="15" uspid="363" ordinal="0" offset="0" sl="68" sc="9" el="68" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="4" sequenceCoverage="100" branchCoverage="71.43" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="14" visitedSequencePoints="14" numBranchPoints="7" visitedBranchPoints="5" sequenceCoverage="100" branchCoverage="71.43" maxCyclomaticComplexity="4" minCyclomaticComplexity="4" />
+                            <MetadataToken>100663374</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Manager.MemoryManager::Dispose()</Name>
+                            <FileRef uid="6" />
+                            <SequencePoints>
+                                <SequencePoint vc="5" uspid="366" ordinal="0" offset="0" sl="73" sc="9" el="73" ec="10" />
+                                <SequencePoint vc="5" uspid="367" ordinal="1" offset="3" sl="74" sc="13" el="74" ec="30" />
+                                <SequencePoint vc="5" uspid="368" ordinal="2" offset="19" sl="75" sc="13" el="75" ec="14" />
+                                <SequencePoint vc="5" uspid="369" ordinal="3" offset="20" sl="76" sc="17" el="76" ec="24" />
+                                <SequencePoint vc="5" uspid="370" ordinal="4" offset="21" sl="76" sc="52" el="76" ec="59" />
+                                <SequencePoint vc="5" uspid="371" ordinal="5" offset="35" sl="76" sc="26" el="76" ec="48" />
+                                <SequencePoint vc="5" uspid="372" ordinal="6" offset="42" sl="77" sc="17" el="77" ec="18" />
+                                <SequencePoint vc="5" uspid="373" ordinal="7" offset="43" sl="78" sc="21" el="78" ec="72" />
+                                <SequencePoint vc="5" uspid="374" ordinal="8" offset="55" sl="79" sc="21" el="79" ec="61" />
+                                <SequencePoint vc="5" uspid="375" ordinal="9" offset="67" sl="80" sc="17" el="80" ec="18" />
+                                <SequencePoint vc="10" uspid="376" ordinal="10" offset="68" sl="76" sc="49" el="76" ec="51" />
+                                <SequencePoint vc="5" uspid="377" ordinal="11" offset="101" sl="81" sc="17" el="81" ec="33" />
+                                <SequencePoint vc="5" uspid="378" ordinal="12" offset="113" sl="82" sc="13" el="82" ec="14" />
+                                <SequencePoint vc="5" uspid="379" ordinal="13" offset="135" sl="83" sc="9" el="83" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="5" uspid="380" ordinal="0" offset="78" path="0" />
+                                <BranchPoint vc="5" uspid="381" ordinal="1" offset="78" path="1" />
+                                <BranchPoint vc="5" uspid="382" ordinal="2" offset="90" path="0" />
+                                <BranchPoint vc="0" uspid="383" ordinal="3" offset="90" path="1" />
+                                <BranchPoint vc="5" uspid="384" ordinal="4" offset="124" path="0" />
+                                <BranchPoint vc="0" uspid="385" ordinal="5" offset="124" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="5" uspid="366" ordinal="0" offset="0" sl="73" sc="9" el="73" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="3" visitedSequencePoints="3" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663375</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Manager.MemoryManager::.ctor()</Name>
+                            <FileRef uid="6" />
+                            <SequencePoints>
+                                <SequencePoint vc="5" uspid="386" ordinal="0" offset="0" sl="14" sc="9" el="14" ec="50" />
+                                <SequencePoint vc="5" uspid="387" ordinal="1" offset="11" sl="16" sc="9" el="16" ec="84" />
+                                <SequencePoint vc="5" uspid="388" ordinal="2" offset="22" sl="27" sc="9" el="27" ec="43" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="5" uspid="386" ordinal="0" offset="0" sl="14" sc="9" el="14" ec="50" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663376</MetadataToken>
+                            <Name>System.Threading.EventWaitHandle OpenCover.Framework.Manager.MemoryManager::&lt;GetHandles&gt;b__2(OpenCover.Framework.Manager.MemoryManager/ManagedMemoryBlock)</Name>
+                            <FileRef uid="6" />
+                            <SequencePoints>
+                                <SequencePoint vc="10" uspid="389" ordinal="0" offset="0" sl="58" sc="44" el="58" ec="64" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="10" uspid="389" ordinal="0" offset="0" sl="58" sc="44" el="58" ec="64" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                    <FullName>OpenCover.Framework.Manager.MemoryManager/ManagedMemoryBlock</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663377</MetadataToken>
+                            <Name>System.Threading.EventWaitHandle OpenCover.Framework.Manager.MemoryManager/ManagedMemoryBlock::get_ProfilerHasResults()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="14" uspid="390" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663378</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Manager.MemoryManager/ManagedMemoryBlock::set_ProfilerHasResults(System.Threading.EventWaitHandle)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="5" uspid="391" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663379</MetadataToken>
+                            <Name>System.Threading.EventWaitHandle OpenCover.Framework.Manager.MemoryManager/ManagedMemoryBlock::get_ResultsHaveBeenReceived()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="4" uspid="392" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663380</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Manager.MemoryManager/ManagedMemoryBlock::set_ResultsHaveBeenReceived(System.Threading.EventWaitHandle)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="5" uspid="393" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663381</MetadataToken>
+                            <Name>System.IO.MemoryMappedFiles.MemoryMappedFile OpenCover.Framework.Manager.MemoryManager/ManagedMemoryBlock::get_MMFResults()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="10" uspid="394" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663382</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Manager.MemoryManager/ManagedMemoryBlock::set_MMFResults(System.IO.MemoryMappedFiles.MemoryMappedFile)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="5" uspid="395" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663383</MetadataToken>
+                            <Name>System.IO.MemoryMappedFiles.MemoryMappedViewStream OpenCover.Framework.Manager.MemoryManager/ManagedMemoryBlock::get_StreamAccessorResults()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="28" uspid="396" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663384</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Manager.MemoryManager/ManagedMemoryBlock::set_StreamAccessorResults(System.IO.MemoryMappedFiles.MemoryMappedViewStream)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="5" uspid="397" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663385</MetadataToken>
+                            <Name>System.Int32 OpenCover.Framework.Manager.MemoryManager/ManagedMemoryBlock::get_BufferSize()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="18" uspid="398" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663386</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Manager.MemoryManager/ManagedMemoryBlock::set_BufferSize(System.Int32)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="5" uspid="399" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663387</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Manager.MemoryManager/ManagedMemoryBlock::.ctor()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="5" uspid="400" ordinal="0" offset="0" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="81" visitedSequencePoints="80" numBranchPoints="25" visitedBranchPoints="18" sequenceCoverage="98.77" branchCoverage="72" maxCyclomaticComplexity="8" minCyclomaticComplexity="1" />
+                    <FullName>OpenCover.Framework.Manager.ProfilerManager</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="6" visitedSequencePoints="6" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663389</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Manager.ProfilerManager::.ctor(OpenCover.Framework.Communication.IMessageHandler,OpenCover.Framework.Persistance.IPersistance,OpenCover.Framework.Manager.IMemoryManager)</Name>
+                            <FileRef uid="7" />
+                            <SequencePoints>
+                                <SequencePoint vc="5" uspid="401" ordinal="0" offset="0" sl="41" sc="9" el="41" ec="119" />
+                                <SequencePoint vc="5" uspid="402" ordinal="1" offset="7" sl="42" sc="9" el="42" ec="10" />
+                                <SequencePoint vc="5" uspid="403" ordinal="2" offset="8" sl="43" sc="13" el="43" ec="46" />
+                                <SequencePoint vc="5" uspid="404" ordinal="3" offset="15" sl="44" sc="13" el="44" ec="40" />
+                                <SequencePoint vc="5" uspid="405" ordinal="4" offset="22" sl="45" sc="13" el="45" ec="44" />
+                                <SequencePoint vc="5" uspid="406" ordinal="5" offset="29" sl="46" sc="9" el="46" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="5" uspid="401" ordinal="0" offset="0" sl="41" sc="9" el="41" ec="119" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="8" sequenceCoverage="96.88" branchCoverage="53.85" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="32" visitedSequencePoints="31" numBranchPoints="13" visitedBranchPoints="7" sequenceCoverage="96.88" branchCoverage="53.85" maxCyclomaticComplexity="8" minCyclomaticComplexity="8" />
+                            <MetadataToken>100663390</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Manager.ProfilerManager::RunProcess(System.Action`1&lt;System.Action`1&lt;System.Collections.Specialized.StringDictionary&gt;&gt;,System.Boolean)</Name>
+                            <FileRef uid="7" />
+                            <SequencePoints>
+                                <SequencePoint vc="5" uspid="407" ordinal="0" offset="29" sl="49" sc="9" el="49" ec="10" />
+                                <SequencePoint vc="5" uspid="408" ordinal="1" offset="30" sl="50" sc="13" el="50" ec="66" />
+                                <SequencePoint vc="5" uspid="409" ordinal="2" offset="71" sl="51" sc="13" el="51" ec="57" />
+                                <SequencePoint vc="5" uspid="410" ordinal="3" offset="84" sl="52" sc="13" el="52" ec="55" />
+                                <SequencePoint vc="5" uspid="411" ordinal="4" offset="97" sl="53" sc="13" el="53" ec="64" />
+                                <SequencePoint vc="5" uspid="412" ordinal="5" offset="110" sl="54" sc="13" el="54" ec="64" />
+                                <SequencePoint vc="5" uspid="413" ordinal="6" offset="132" sl="56" sc="13" el="56" ec="64" />
+                                <SequencePoint vc="5" uspid="414" ordinal="7" offset="155" sl="58" sc="13" el="58" ec="56" />
+                                <SequencePoint vc="5" uspid="415" ordinal="8" offset="181" sl="60" sc="13" el="61" ec="90" />
+                                <SequencePoint vc="5" uspid="416" ordinal="9" offset="218" sl="62" sc="13" el="63" ec="93" />
+                                <SequencePoint vc="5" uspid="417" ordinal="10" offset="255" sl="64" sc="13" el="65" ec="91" />
+                                <SequencePoint vc="5" uspid="418" ordinal="11" offset="292" sl="67" sc="13" el="67" ec="55" />
+                                <SequencePoint vc="5" uspid="419" ordinal="12" offset="305" sl="69" sc="13" el="69" ec="59" />
+                                <SequencePoint vc="5" uspid="420" ordinal="13" offset="316" sl="71" sc="20" el="71" ec="145" />
+                                <SequencePoint vc="5" uspid="421" ordinal="14" offset="352" sl="72" sc="13" el="72" ec="18" />
+                                <SequencePoint vc="5" uspid="422" ordinal="15" offset="380" sl="73" sc="13" el="73" ec="14" />
+                                <SequencePoint vc="5" uspid="423" ordinal="16" offset="381" sl="74" sc="17" el="94" ec="20" />
+                                <SequencePoint vc="5" uspid="424" ordinal="17" offset="410" sl="96" sc="17" el="113" ec="20" />
+                                <SequencePoint vc="5" uspid="425" ordinal="18" offset="439" sl="116" sc="17" el="116" ec="103" />
+                                <SequencePoint vc="0" uspid="426" ordinal="19" offset="487" sl="117" sc="21" el="117" ec="28" />
+                                <SequencePoint vc="5" uspid="427" ordinal="20" offset="489" sl="119" sc="17" el="119" ec="59" />
+                                <SequencePoint vc="5" uspid="428" ordinal="21" offset="505" sl="120" sc="17" el="120" ec="91" />
+                                <SequencePoint vc="5" uspid="429" ordinal="22" offset="518" sl="122" sc="17" el="122" ec="18" />
+                                <SequencePoint vc="5" uspid="430" ordinal="23" offset="519" sl="123" sc="21" el="123" ec="59" />
+                                <SequencePoint vc="5" uspid="431" ordinal="24" offset="528" sl="124" sc="17" el="124" ec="18" />
+                                <SequencePoint vc="5" uspid="432" ordinal="25" offset="531" sl="126" sc="17" el="126" ec="18" />
+                                <SequencePoint vc="5" uspid="433" ordinal="26" offset="532" sl="127" sc="21" el="127" ec="40" />
+                                <SequencePoint vc="5" uspid="434" ordinal="27" offset="540" sl="128" sc="17" el="128" ec="18" />
+                                <SequencePoint vc="5" uspid="435" ordinal="28" offset="543" sl="130" sc="17" el="130" ec="37" />
+                                <SequencePoint vc="5" uspid="436" ordinal="29" offset="556" sl="131" sc="13" el="131" ec="14" />
+                                <SequencePoint vc="5" uspid="437" ordinal="30" offset="601" sl="132" sc="9" el="132" ec="10" />
+                                <SequencePoint vc="5" uspid="438" ordinal="31" offset="603" sl="132" sc="9" el="132" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="5" uspid="440" ordinal="0" offset="135" path="0" />
+                                <BranchPoint vc="0" uspid="441" ordinal="1" offset="135" path="1" />
+                                <BranchPoint vc="5" uspid="442" ordinal="2" offset="383" path="0" />
+                                <BranchPoint vc="0" uspid="443" ordinal="3" offset="383" path="1" />
+                                <BranchPoint vc="5" uspid="444" ordinal="4" offset="412" path="0" />
+                                <BranchPoint vc="0" uspid="445" ordinal="5" offset="412" path="1" />
+                                <BranchPoint vc="0" uspid="446" ordinal="6" offset="485" path="0" />
+                                <BranchPoint vc="5" uspid="447" ordinal="7" offset="485" path="1" />
+                                <BranchPoint vc="5" uspid="448" ordinal="8" offset="568" path="0" />
+                                <BranchPoint vc="0" uspid="449" ordinal="9" offset="568" path="1" />
+                                <BranchPoint vc="5" uspid="450" ordinal="10" offset="590" path="0" />
+                                <BranchPoint vc="0" uspid="451" ordinal="11" offset="590" path="1" />
+                            </BranchPoints>
+                            <MethodPoint vc="5" uspid="439" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="7" sequenceCoverage="100" branchCoverage="90" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="37" visitedSequencePoints="37" numBranchPoints="10" visitedBranchPoints="9" sequenceCoverage="100" branchCoverage="90" maxCyclomaticComplexity="7" minCyclomaticComplexity="7" />
+                            <MetadataToken>100663391</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Manager.ProfilerManager::ProcessMessages(System.Collections.Generic.List`1&lt;System.Threading.WaitHandle&gt;,System.Runtime.InteropServices.GCHandle)</Name>
+                            <FileRef uid="7" />
+                            <SequencePoints>
+                                <SequencePoint vc="5" uspid="452" ordinal="0" offset="0" sl="135" sc="9" el="135" ec="10" />
+                                <SequencePoint vc="5" uspid="453" ordinal="1" offset="1" sl="136" sc="13" el="136" ec="37" />
+                                <SequencePoint vc="10" uspid="454" ordinal="2" offset="3" sl="138" sc="13" el="138" ec="14" />
+                                <SequencePoint vc="10" uspid="455" ordinal="3" offset="4" sl="139" sc="17" el="139" ec="61" />
+                                <SequencePoint vc="10" uspid="456" ordinal="4" offset="11" sl="140" sc="17" el="140" ec="63" />
+                                <SequencePoint vc="10" uspid="457" ordinal="5" offset="29" sl="142" sc="17" el="142" ec="67" />
+                                <SequencePoint vc="10" uspid="458" ordinal="6" offset="41" sl="143" sc="17" el="143" ec="31" />
+                                <SequencePoint vc="5" uspid="459" ordinal="7" offset="61" sl="146" sc="25" el="146" ec="46" />
+                                <SequencePoint vc="5" uspid="460" ordinal="8" offset="63" sl="147" sc="25" el="147" ec="31" />
+                                <SequencePoint vc="1" uspid="461" ordinal="9" offset="68" sl="149" sc="25" el="149" ec="62" />
+                                <SequencePoint vc="1" uspid="462" ordinal="10" offset="80" sl="151" sc="25" el="151" ec="72" />
+                                <SequencePoint vc="1" uspid="463" ordinal="11" offset="95" sl="152" sc="25" el="152" ec="100" />
+                                <SequencePoint vc="1" uspid="464" ordinal="12" offset="125" sl="154" sc="25" el="157" ec="62" />
+                                <SequencePoint vc="1" uspid="465" ordinal="13" offset="168" sl="159" sc="25" el="159" ec="68" />
+                                <SequencePoint vc="1" uspid="466" ordinal="14" offset="176" sl="160" sc="25" el="160" ec="31" />
+                                <SequencePoint vc="4" uspid="467" ordinal="15" offset="178" sl="162" sc="25" el="162" ec="73" />
+                                <SequencePoint vc="4" uspid="468" ordinal="16" offset="199" sl="163" sc="25" el="163" ec="63" />
+                                <SequencePoint vc="4" uspid="469" ordinal="17" offset="213" sl="164" sc="25" el="164" ec="58" />
+                                <SequencePoint vc="4" uspid="470" ordinal="18" offset="226" sl="166" sc="25" el="166" ec="79" />
+                                <SequencePoint vc="4" uspid="471" ordinal="19" offset="242" sl="167" sc="25" el="167" ec="85" />
+                                <SequencePoint vc="4" uspid="472" ordinal="20" offset="265" sl="169" sc="25" el="169" ec="61" />
+                                <SequencePoint vc="4" uspid="473" ordinal="21" offset="278" sl="170" sc="25" el="170" ec="53" />
+                                <SequencePoint vc="4" uspid="474" ordinal="22" offset="292" sl="171" sc="25" el="171" ec="31" />
+                                <SequencePoint vc="10" uspid="475" ordinal="23" offset="294" sl="173" sc="13" el="173" ec="14" />
+                                <SequencePoint vc="10" uspid="476" ordinal="24" offset="295" sl="173" sc="15" el="173" ec="36" />
+                                <SequencePoint vc="5" uspid="477" ordinal="25" offset="305" sl="175" sc="13" el="175" ec="20" />
+                                <SequencePoint vc="5" uspid="478" ordinal="26" offset="306" sl="175" sc="35" el="175" ec="59" />
+                                <SequencePoint vc="5" uspid="479" ordinal="27" offset="326" sl="175" sc="22" el="175" ec="31" />
+                                <SequencePoint vc="5" uspid="480" ordinal="28" offset="335" sl="176" sc="13" el="176" ec="14" />
+                                <SequencePoint vc="5" uspid="481" ordinal="29" offset="336" sl="177" sc="17" el="177" ec="55" />
+                                <SequencePoint vc="5" uspid="482" ordinal="30" offset="350" sl="178" sc="17" el="178" ec="71" />
+                                <SequencePoint vc="5" uspid="483" ordinal="31" offset="366" sl="179" sc="17" el="179" ec="77" />
+                                <SequencePoint vc="5" uspid="484" ordinal="32" offset="389" sl="180" sc="17" el="180" ec="45" />
+                                <SequencePoint vc="5" uspid="485" ordinal="33" offset="403" sl="181" sc="13" el="181" ec="14" />
+                                <SequencePoint vc="10" uspid="486" ordinal="34" offset="404" sl="175" sc="32" el="175" ec="34" />
+                                <SequencePoint vc="5" uspid="487" ordinal="35" offset="440" sl="183" sc="13" el="183" ec="48" />
+                                <SequencePoint vc="5" uspid="488" ordinal="36" offset="458" sl="184" sc="9" el="184" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="4" uspid="489" ordinal="0" offset="46" path="0" />
+                                <BranchPoint vc="5" uspid="490" ordinal="1" offset="46" path="1" />
+                                <BranchPoint vc="1" uspid="491" ordinal="2" offset="46" path="2" />
+                                <BranchPoint vc="5" uspid="492" ordinal="3" offset="300" path="0" />
+                                <BranchPoint vc="5" uspid="493" ordinal="4" offset="300" path="1" />
+                                <BranchPoint vc="5" uspid="494" ordinal="5" offset="415" path="0" />
+                                <BranchPoint vc="5" uspid="495" ordinal="6" offset="415" path="1" />
+                                <BranchPoint vc="5" uspid="496" ordinal="7" offset="428" path="0" />
+                                <BranchPoint vc="0" uspid="497" ordinal="8" offset="428" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="5" uspid="452" ordinal="0" offset="0" sl="135" sc="9" el="135" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="6" visitedSequencePoints="6" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663392</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Manager.ProfilerManager::SendChunkAndWaitForConfirmation(System.Int32)</Name>
+                            <FileRef uid="7" />
+                            <SequencePoints>
+                                <SequencePoint vc="1" uspid="498" ordinal="0" offset="0" sl="187" sc="9" el="187" ec="10" />
+                                <SequencePoint vc="1" uspid="499" ordinal="1" offset="1" sl="188" sc="13" el="188" ec="60" />
+                                <SequencePoint vc="1" uspid="500" ordinal="2" offset="16" sl="189" sc="13" el="189" ec="74" />
+                                <SequencePoint vc="1" uspid="501" ordinal="3" offset="36" sl="191" sc="13" el="191" ec="96" />
+                                <SequencePoint vc="1" uspid="502" ordinal="4" offset="54" sl="192" sc="13" el="192" ec="48" />
+                                <SequencePoint vc="1" uspid="503" ordinal="5" offset="66" sl="193" sc="9" el="193" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="1" uspid="498" ordinal="0" offset="0" sl="187" sc="9" el="187" ec="10" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="30" visitedSequencePoints="29" numBranchPoints="11" visitedBranchPoints="9" sequenceCoverage="96.67" branchCoverage="81.82" maxCyclomaticComplexity="3" minCyclomaticComplexity="1" />
+                    <FullName>OpenCover.Framework.Manager.ProfilerManager/&lt;&gt;c__DisplayClass6</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663729</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Manager.ProfilerManager/&lt;&gt;c__DisplayClass6::.ctor()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="5" uspid="504" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="2" sequenceCoverage="100" branchCoverage="66.67" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="8" visitedSequencePoints="8" numBranchPoints="3" visitedBranchPoints="2" sequenceCoverage="100" branchCoverage="66.67" maxCyclomaticComplexity="2" minCyclomaticComplexity="2" />
+                            <MetadataToken>100663730</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Manager.ProfilerManager/&lt;&gt;c__DisplayClass6::&lt;RunProcess&gt;b__1(System.Object)</Name>
+                            <FileRef uid="7" />
+                            <SequencePoints>
+                                <SequencePoint vc="5" uspid="505" ordinal="0" offset="2" sl="75" sc="17" el="75" ec="18" />
+                                <SequencePoint vc="5" uspid="506" ordinal="1" offset="3" sl="77" sc="21" el="77" ec="22" />
+                                <SequencePoint vc="5" uspid="507" ordinal="2" offset="4" sl="78" sc="25" el="88" ec="28" />
+                                <SequencePoint vc="5" uspid="508" ordinal="3" offset="35" sl="89" sc="21" el="89" ec="22" />
+                                <SequencePoint vc="5" uspid="509" ordinal="4" offset="38" sl="91" sc="21" el="91" ec="22" />
+                                <SequencePoint vc="5" uspid="510" ordinal="5" offset="39" sl="92" sc="25" el="92" ec="43" />
+                                <SequencePoint vc="5" uspid="511" ordinal="6" offset="51" sl="93" sc="21" el="93" ec="22" />
+                                <SequencePoint vc="5" uspid="512" ordinal="7" offset="54" sl="94" sc="17" el="94" ec="18" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="5" uspid="514" ordinal="0" offset="11" path="0" />
+                                <BranchPoint vc="0" uspid="515" ordinal="1" offset="11" path="1" />
+                            </BranchPoints>
+                            <MethodPoint vc="5" uspid="513" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="3" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="12" visitedSequencePoints="12" numBranchPoints="5" visitedBranchPoints="5" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="3" minCyclomaticComplexity="3" />
+                            <MetadataToken>100663731</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Manager.ProfilerManager/&lt;&gt;c__DisplayClass6::&lt;RunProcess&gt;b__3(System.Object)</Name>
+                            <FileRef uid="7" />
+                            <SequencePoints>
+                                <SequencePoint vc="5" uspid="516" ordinal="0" offset="0" sl="97" sc="17" el="97" ec="18" />
+                                <SequencePoint vc="14" uspid="517" ordinal="1" offset="3" sl="99" sc="21" el="99" ec="22" />
+                                <SequencePoint vc="745166" uspid="518" ordinal="2" offset="6" sl="102" sc="29" el="102" ec="44" />
+                                <SequencePoint vc="745180" uspid="519" ordinal="3" offset="12" sl="101" sc="25" el="101" ec="68" />
+                                <SequencePoint vc="14" uspid="520" ordinal="4" offset="37" sl="104" sc="25" el="104" ec="46" />
+                                <SequencePoint vc="5" uspid="521" ordinal="5" offset="50" sl="105" sc="25" el="105" ec="26" />
+                                <SequencePoint vc="5" uspid="522" ordinal="6" offset="51" sl="106" sc="29" el="106" ec="56" />
+                                <SequencePoint vc="5" uspid="523" ordinal="7" offset="68" sl="107" sc="29" el="107" ec="45" />
+                                <SequencePoint vc="5" uspid="524" ordinal="8" offset="80" sl="108" sc="29" el="108" ec="36" />
+                                <SequencePoint vc="9" uspid="525" ordinal="9" offset="82" sl="111" sc="25" el="111" ec="58" />
+                                <SequencePoint vc="9" uspid="526" ordinal="10" offset="100" sl="112" sc="21" el="112" ec="22" />
+                                <SequencePoint vc="14" uspid="527" ordinal="11" offset="101" sl="98" sc="21" el="98" ec="33" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="14" uspid="528" ordinal="0" offset="35" path="0" />
+                                <BranchPoint vc="745166" uspid="529" ordinal="1" offset="35" path="1" />
+                                <BranchPoint vc="5" uspid="530" ordinal="2" offset="48" path="0" />
+                                <BranchPoint vc="9" uspid="531" ordinal="3" offset="48" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="5" uspid="516" ordinal="0" offset="0" sl="97" sc="17" el="97" ec="18" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="2" sequenceCoverage="90" branchCoverage="66.67" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="10" visitedSequencePoints="9" numBranchPoints="3" visitedBranchPoints="2" sequenceCoverage="90" branchCoverage="66.67" maxCyclomaticComplexity="2" minCyclomaticComplexity="2" />
+                            <MetadataToken>100663732</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Manager.ProfilerManager/&lt;&gt;c__DisplayClass6::&lt;RunProcess&gt;b__2(System.Collections.Specialized.StringDictionary)</Name>
+                            <FileRef uid="7" />
+                            <SequencePoints>
+                                <SequencePoint vc="5" uspid="532" ordinal="0" offset="0" sl="79" sc="25" el="79" ec="26" />
+                                <SequencePoint vc="5" uspid="533" ordinal="1" offset="1" sl="80" sc="29" el="80" ec="52" />
+                                <SequencePoint vc="0" uspid="534" ordinal="2" offset="12" sl="80" sc="53" el="80" ec="60" />
+                                <SequencePoint vc="5" uspid="535" ordinal="3" offset="14" sl="81" sc="29" el="81" ec="73" />
+                                <SequencePoint vc="5" uspid="536" ordinal="4" offset="32" sl="82" sc="29" el="82" ec="86" />
+                                <SequencePoint vc="5" uspid="537" ordinal="5" offset="50" sl="83" sc="29" el="83" ec="99" />
+                                <SequencePoint vc="5" uspid="538" ordinal="6" offset="67" sl="84" sc="29" el="84" ec="70" />
+                                <SequencePoint vc="5" uspid="539" ordinal="7" offset="84" sl="85" sc="29" el="85" ec="103" />
+                                <SequencePoint vc="5" uspid="540" ordinal="8" offset="101" sl="86" sc="29" el="86" ec="74" />
+                                <SequencePoint vc="5" uspid="541" ordinal="9" offset="118" sl="87" sc="29" el="87" ec="54" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="0" uspid="542" ordinal="0" offset="10" path="0" />
+                                <BranchPoint vc="5" uspid="543" ordinal="1" offset="10" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="5" uspid="532" ordinal="0" offset="0" sl="79" sc="25" el="79" ec="26" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="112" visitedSequencePoints="112" numBranchPoints="32" visitedBranchPoints="30" sequenceCoverage="100" branchCoverage="93.75" maxCyclomaticComplexity="18" minCyclomaticComplexity="1" />
+                    <FullName>OpenCover.Framework.Communication.MessageHandler</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="2" sequenceCoverage="100" branchCoverage="66.67" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="7" visitedSequencePoints="7" numBranchPoints="3" visitedBranchPoints="2" sequenceCoverage="100" branchCoverage="66.67" maxCyclomaticComplexity="2" minCyclomaticComplexity="2" />
+                            <MetadataToken>100663398</MetadataToken>
+                            <Name>System.Int32 OpenCover.Framework.Communication.MessageHandler::get_ReadSize()</Name>
+                            <FileRef uid="9" />
+                            <SequencePoints>
+                                <SequencePoint vc="1" uspid="544" ordinal="0" offset="0" sl="162" sc="13" el="162" ec="14" />
+                                <SequencePoint vc="1" uspid="545" ordinal="1" offset="1" sl="163" sc="17" el="163" ec="36" />
+                                <SequencePoint vc="1" uspid="546" ordinal="2" offset="20" sl="164" sc="17" el="164" ec="18" />
+                                <SequencePoint vc="1" uspid="547" ordinal="3" offset="21" sl="165" sc="21" el="176" ec="30" />
+                                <SequencePoint vc="1" uspid="548" ordinal="4" offset="222" sl="177" sc="17" el="177" ec="18" />
+                                <SequencePoint vc="1" uspid="549" ordinal="5" offset="223" sl="178" sc="17" el="178" ec="34" />
+                                <SequencePoint vc="1" uspid="550" ordinal="6" offset="232" sl="179" sc="13" el="179" ec="14" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="1" uspid="551" ordinal="0" offset="15" path="0" />
+                                <BranchPoint vc="0" uspid="552" ordinal="1" offset="15" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="1" uspid="544" ordinal="0" offset="0" sl="162" sc="13" el="162" ec="14" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="7" visitedSequencePoints="7" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663396</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Communication.MessageHandler::.ctor(OpenCover.Framework.Service.IProfilerCommunication,OpenCover.Framework.Communication.IMarshalWrapper,OpenCover.Framework.Manager.IMemoryManager)</Name>
+                            <FileRef uid="9" />
+                            <SequencePoints>
+                                <SequencePoint vc="11" uspid="553" ordinal="0" offset="0" sl="157" sc="9" el="157" ec="36" />
+                                <SequencePoint vc="11" uspid="554" ordinal="1" offset="7" sl="33" sc="9" el="33" ec="138" />
+                                <SequencePoint vc="11" uspid="555" ordinal="2" offset="14" sl="34" sc="9" el="34" ec="10" />
+                                <SequencePoint vc="11" uspid="556" ordinal="3" offset="15" sl="35" sc="13" el="35" ec="60" />
+                                <SequencePoint vc="11" uspid="557" ordinal="4" offset="22" sl="36" sc="13" el="36" ec="46" />
+                                <SequencePoint vc="11" uspid="558" ordinal="5" offset="29" sl="37" sc="13" el="37" ec="44" />
+                                <SequencePoint vc="11" uspid="559" ordinal="6" offset="36" sl="38" sc="9" el="38" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="11" uspid="553" ordinal="0" offset="0" sl="157" sc="9" el="157" ec="36" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="18" sequenceCoverage="100" branchCoverage="96.30" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="95" visitedSequencePoints="95" numBranchPoints="27" visitedBranchPoints="26" sequenceCoverage="100" branchCoverage="96.30" maxCyclomaticComplexity="18" minCyclomaticComplexity="18" />
+                            <MetadataToken>100663397</MetadataToken>
+                            <Name>System.Int32 OpenCover.Framework.Communication.MessageHandler::StandardMessage(OpenCover.Framework.Communication.MSG_Type,System.IntPtr,System.Action`1&lt;System.Int32&gt;)</Name>
+                            <FileRef uid="9" />
+                            <SequencePoints>
+                                <SequencePoint vc="9" uspid="560" ordinal="0" offset="0" sl="41" sc="9" el="41" ec="10" />
+                                <SequencePoint vc="9" uspid="561" ordinal="1" offset="1" sl="42" sc="13" el="42" ec="31" />
+                                <SequencePoint vc="9" uspid="562" ordinal="2" offset="3" sl="43" sc="13" el="43" ec="29" />
+                                <SequencePoint vc="1" uspid="563" ordinal="3" offset="40" sl="46" sc="21" el="46" ec="22" />
+                                <SequencePoint vc="1" uspid="564" ordinal="4" offset="41" sl="47" sc="25" el="47" ec="109" />
+                                <SequencePoint vc="1" uspid="565" ordinal="5" offset="54" sl="48" sc="25" el="48" ec="75" />
+                                <SequencePoint vc="1" uspid="566" ordinal="6" offset="62" sl="49" sc="25" el="49" ec="119" />
+                                <SequencePoint vc="1" uspid="567" ordinal="7" offset="94" sl="50" sc="25" el="50" ec="89" />
+                                <SequencePoint vc="1" uspid="568" ordinal="8" offset="109" sl="51" sc="25" el="51" ec="89" />
+                                <SequencePoint vc="1" uspid="569" ordinal="9" offset="125" sl="52" sc="21" el="52" ec="22" />
+                                <SequencePoint vc="1" uspid="570" ordinal="10" offset="126" sl="53" sc="21" el="53" ec="27" />
+                                <SequencePoint vc="3" uspid="571" ordinal="11" offset="131" sl="56" sc="21" el="56" ec="22" />
+                                <SequencePoint vc="3" uspid="572" ordinal="12" offset="132" sl="57" sc="25" el="57" ec="114" />
+                                <SequencePoint vc="3" uspid="573" ordinal="13" offset="145" sl="59" sc="25" el="59" ec="80" />
+                                <SequencePoint vc="3" uspid="574" ordinal="14" offset="153" sl="60" sc="25" el="61" ec="104" />
+                                <SequencePoint vc="3" uspid="575" ordinal="15" offset="188" sl="62" sc="25" el="62" ec="78" />
+                                <SequencePoint vc="3" uspid="576" ordinal="16" offset="202" sl="64" sc="25" el="64" ec="39" />
+                                <SequencePoint vc="3" uspid="577" ordinal="17" offset="205" sl="65" sc="25" el="65" ec="80" />
+                                <SequencePoint vc="4" uspid="578" ordinal="18" offset="222" sl="67" sc="25" el="67" ec="26" />
+                                <SequencePoint vc="4" uspid="579" ordinal="19" offset="223" sl="68" sc="29" el="68" ec="97" />
+                                <SequencePoint vc="4" uspid="580" ordinal="20" offset="239" sl="69" sc="29" el="69" ec="66" />
+                                <SequencePoint vc="4" uspid="581" ordinal="21" offset="252" sl="70" sc="29" el="70" ec="87" />
+                                <SequencePoint vc="4" uspid="582" ordinal="22" offset="272" sl="71" sc="29" el="71" ec="94" />
+                                <SequencePoint vc="4" uspid="583" ordinal="23" offset="288" sl="72" sc="34" el="72" ec="44" />
+                                <SequencePoint vc="102" uspid="584" ordinal="24" offset="293" sl="73" sc="29" el="73" ec="30" />
+                                <SequencePoint vc="102" uspid="585" ordinal="25" offset="294" sl="74" sc="33" el="74" ec="69" />
+                                <SequencePoint vc="102" uspid="586" ordinal="26" offset="302" sl="75" sc="33" el="75" ec="73" />
+                                <SequencePoint vc="102" uspid="587" ordinal="27" offset="319" sl="76" sc="33" el="76" ec="88" />
+                                <SequencePoint vc="102" uspid="588" ordinal="28" offset="336" sl="78" sc="33" el="78" ec="104" />
+                                <SequencePoint vc="102" uspid="589" ordinal="29" offset="358" sl="79" sc="33" el="79" ec="52" />
+                                <SequencePoint vc="102" uspid="590" ordinal="30" offset="363" sl="80" sc="33" el="80" ec="41" />
+                                <SequencePoint vc="102" uspid="591" ordinal="31" offset="369" sl="81" sc="29" el="81" ec="30" />
+                                <SequencePoint vc="102" uspid="592" ordinal="32" offset="370" sl="72" sc="68" el="72" ec="71" />
+                                <SequencePoint vc="106" uspid="593" ordinal="33" offset="376" sl="72" sc="45" el="72" ec="66" />
+                                <SequencePoint vc="4" uspid="594" ordinal="34" offset="393" sl="83" sc="29" el="83" ec="50" />
+                                <SequencePoint vc="1" uspid="595" ordinal="35" offset="409" sl="84" sc="29" el="84" ec="30" />
+                                <SequencePoint vc="1" uspid="596" ordinal="36" offset="410" sl="85" sc="33" el="85" ec="55" />
+                                <SequencePoint vc="1" uspid="597" ordinal="37" offset="418" sl="86" sc="33" el="86" ec="52" />
+                                <SequencePoint vc="1" uspid="598" ordinal="38" offset="425" sl="87" sc="29" el="87" ec="30" />
+                                <SequencePoint vc="4" uspid="599" ordinal="39" offset="426" sl="88" sc="25" el="88" ec="26" />
+                                <SequencePoint vc="4" uspid="600" ordinal="40" offset="427" sl="88" sc="27" el="88" ec="52" />
+                                <SequencePoint vc="3" uspid="601" ordinal="41" offset="443" sl="89" sc="21" el="89" ec="22" />
+                                <SequencePoint vc="3" uspid="602" ordinal="42" offset="444" sl="90" sc="21" el="90" ec="27" />
+                                <SequencePoint vc="3" uspid="603" ordinal="43" offset="449" sl="93" sc="21" el="93" ec="22" />
+                                <SequencePoint vc="3" uspid="604" ordinal="44" offset="450" sl="94" sc="25" el="94" ec="112" />
+                                <SequencePoint vc="3" uspid="605" ordinal="45" offset="464" sl="96" sc="25" el="96" ec="78" />
+                                <SequencePoint vc="3" uspid="606" ordinal="46" offset="472" sl="97" sc="25" el="98" ec="104" />
+                                <SequencePoint vc="3" uspid="607" ordinal="47" offset="507" sl="99" sc="25" el="99" ec="78" />
+                                <SequencePoint vc="3" uspid="608" ordinal="48" offset="521" sl="101" sc="25" el="101" ec="39" />
+                                <SequencePoint vc="3" uspid="609" ordinal="49" offset="524" sl="102" sc="25" el="102" ec="78" />
+                                <SequencePoint vc="4" uspid="610" ordinal="50" offset="541" sl="104" sc="25" el="104" ec="26" />
+                                <SequencePoint vc="4" uspid="611" ordinal="51" offset="542" sl="105" sc="29" el="105" ec="95" />
+                                <SequencePoint vc="4" uspid="612" ordinal="52" offset="558" sl="106" sc="29" el="106" ec="66" />
+                                <SequencePoint vc="4" uspid="613" ordinal="53" offset="571" sl="107" sc="29" el="107" ec="87" />
+                                <SequencePoint vc="4" uspid="614" ordinal="54" offset="591" sl="108" sc="29" el="108" ec="94" />
+                                <SequencePoint vc="4" uspid="615" ordinal="55" offset="607" sl="109" sc="34" el="109" ec="44" />
+                                <SequencePoint vc="102" uspid="616" ordinal="56" offset="612" sl="110" sc="29" el="110" ec="30" />
+                                <SequencePoint vc="102" uspid="617" ordinal="57" offset="613" sl="111" sc="33" el="111" ec="67" />
+                                <SequencePoint vc="102" uspid="618" ordinal="58" offset="621" sl="112" sc="33" el="112" ec="73" />
+                                <SequencePoint vc="102" uspid="619" ordinal="59" offset="638" sl="113" sc="33" el="113" ec="88" />
+                                <SequencePoint vc="102" uspid="620" ordinal="60" offset="655" sl="114" sc="33" el="114" ec="69" />
+                                <SequencePoint vc="102" uspid="621" ordinal="61" offset="672" sl="116" sc="33" el="116" ec="104" />
+                                <SequencePoint vc="102" uspid="622" ordinal="62" offset="694" sl="117" sc="33" el="117" ec="52" />
+                                <SequencePoint vc="102" uspid="623" ordinal="63" offset="699" sl="118" sc="33" el="118" ec="41" />
+                                <SequencePoint vc="102" uspid="624" ordinal="64" offset="705" sl="119" sc="29" el="119" ec="30" />
+                                <SequencePoint vc="102" uspid="625" ordinal="65" offset="706" sl="109" sc="68" el="109" ec="71" />
+                                <SequencePoint vc="106" uspid="626" ordinal="66" offset="712" sl="109" sc="45" el="109" ec="66" />
+                                <SequencePoint vc="4" uspid="627" ordinal="67" offset="729" sl="121" sc="29" el="121" ec="50" />
+                                <SequencePoint vc="1" uspid="628" ordinal="68" offset="745" sl="122" sc="29" el="122" ec="30" />
+                                <SequencePoint vc="1" uspid="629" ordinal="69" offset="746" sl="123" sc="33" el="123" ec="55" />
+                                <SequencePoint vc="1" uspid="630" ordinal="70" offset="754" sl="124" sc="33" el="124" ec="52" />
+                                <SequencePoint vc="1" uspid="631" ordinal="71" offset="761" sl="125" sc="29" el="125" ec="30" />
+                                <SequencePoint vc="4" uspid="632" ordinal="72" offset="762" sl="126" sc="25" el="126" ec="26" />
+                                <SequencePoint vc="4" uspid="633" ordinal="73" offset="763" sl="126" sc="27" el="126" ec="52" />
+                                <SequencePoint vc="3" uspid="634" ordinal="74" offset="779" sl="127" sc="21" el="127" ec="22" />
+                                <SequencePoint vc="3" uspid="635" ordinal="75" offset="780" sl="128" sc="21" el="128" ec="27" />
+                                <SequencePoint vc="1" uspid="636" ordinal="76" offset="785" sl="131" sc="21" el="131" ec="22" />
+                                <SequencePoint vc="1" uspid="637" ordinal="77" offset="786" sl="132" sc="25" el="132" ec="107" />
+                                <SequencePoint vc="1" uspid="638" ordinal="78" offset="800" sl="133" sc="25" el="133" ec="73" />
+                                <SequencePoint vc="1" uspid="639" ordinal="79" offset="808" sl="135" sc="25" el="136" ec="84" />
+                                <SequencePoint vc="1" uspid="640" ordinal="80" offset="849" sl="137" sc="25" el="137" ec="56" />
+                                <SequencePoint vc="1" uspid="641" ordinal="81" offset="858" sl="138" sc="25" el="138" ec="89" />
+                                <SequencePoint vc="1" uspid="642" ordinal="82" offset="874" sl="139" sc="25" el="139" ec="86" />
+                                <SequencePoint vc="1" uspid="643" ordinal="83" offset="890" sl="140" sc="21" el="140" ec="22" />
+                                <SequencePoint vc="1" uspid="644" ordinal="84" offset="891" sl="141" sc="21" el="141" ec="27" />
+                                <SequencePoint vc="1" uspid="645" ordinal="85" offset="893" sl="144" sc="21" el="144" ec="22" />
+                                <SequencePoint vc="1" uspid="646" ordinal="86" offset="894" sl="145" sc="25" el="145" ec="110" />
+                                <SequencePoint vc="1" uspid="647" ordinal="87" offset="908" sl="146" sc="25" el="146" ec="90" />
+                                <SequencePoint vc="1" uspid="648" ordinal="88" offset="933" sl="147" sc="25" el="147" ec="117" />
+                                <SequencePoint vc="1" uspid="649" ordinal="89" offset="979" sl="148" sc="25" el="148" ec="89" />
+                                <SequencePoint vc="1" uspid="650" ordinal="90" offset="995" sl="149" sc="25" el="149" ec="89" />
+                                <SequencePoint vc="1" uspid="651" ordinal="91" offset="1011" sl="150" sc="21" el="150" ec="22" />
+                                <SequencePoint vc="1" uspid="652" ordinal="92" offset="1012" sl="151" sc="21" el="151" ec="27" />
+                                <SequencePoint vc="9" uspid="653" ordinal="93" offset="1014" sl="153" sc="13" el="153" ec="30" />
+                                <SequencePoint vc="9" uspid="654" ordinal="94" offset="1019" sl="154" sc="9" el="154" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="0" uspid="655" ordinal="0" offset="10" path="0" />
+                                <BranchPoint vc="1" uspid="656" ordinal="1" offset="10" path="1" />
+                                <BranchPoint vc="3" uspid="657" ordinal="2" offset="10" path="2" />
+                                <BranchPoint vc="3" uspid="658" ordinal="3" offset="10" path="3" />
+                                <BranchPoint vc="1" uspid="659" ordinal="4" offset="10" path="4" />
+                                <BranchPoint vc="1" uspid="660" ordinal="5" offset="10" path="5" />
+                                <BranchPoint vc="2" uspid="661" ordinal="6" offset="190" path="0" />
+                                <BranchPoint vc="1" uspid="662" ordinal="7" offset="190" path="1" />
+                                <BranchPoint vc="3" uspid="663" ordinal="8" offset="258" path="0" />
+                                <BranchPoint vc="1" uspid="664" ordinal="9" offset="258" path="1" />
+                                <BranchPoint vc="4" uspid="665" ordinal="10" offset="391" path="0" />
+                                <BranchPoint vc="102" uspid="666" ordinal="11" offset="391" path="1" />
+                                <BranchPoint vc="1" uspid="667" ordinal="12" offset="407" path="0" />
+                                <BranchPoint vc="3" uspid="668" ordinal="13" offset="407" path="1" />
+                                <BranchPoint vc="3" uspid="669" ordinal="14" offset="438" path="0" />
+                                <BranchPoint vc="1" uspid="670" ordinal="15" offset="438" path="1" />
+                                <BranchPoint vc="2" uspid="671" ordinal="16" offset="509" path="0" />
+                                <BranchPoint vc="1" uspid="672" ordinal="17" offset="509" path="1" />
+                                <BranchPoint vc="3" uspid="673" ordinal="18" offset="577" path="0" />
+                                <BranchPoint vc="1" uspid="674" ordinal="19" offset="577" path="1" />
+                                <BranchPoint vc="4" uspid="675" ordinal="20" offset="727" path="0" />
+                                <BranchPoint vc="102" uspid="676" ordinal="21" offset="727" path="1" />
+                                <BranchPoint vc="1" uspid="677" ordinal="22" offset="743" path="0" />
+                                <BranchPoint vc="3" uspid="678" ordinal="23" offset="743" path="1" />
+                                <BranchPoint vc="3" uspid="679" ordinal="24" offset="774" path="0" />
+                                <BranchPoint vc="1" uspid="680" ordinal="25" offset="774" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="9" uspid="560" ordinal="0" offset="0" sl="41" sc="9" el="41" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="3" visitedSequencePoints="3" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663399</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Communication.MessageHandler::Complete()</Name>
+                            <FileRef uid="9" />
+                            <SequencePoints>
+                                <SequencePoint vc="1" uspid="681" ordinal="0" offset="0" sl="183" sc="9" el="183" ec="10" />
+                                <SequencePoint vc="1" uspid="682" ordinal="1" offset="1" sl="184" sc="13" el="184" ec="47" />
+                                <SequencePoint vc="1" uspid="683" ordinal="2" offset="13" sl="185" sc="9" el="185" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="1" uspid="681" ordinal="0" offset="0" sl="183" sc="9" el="183" ec="10" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="44" visitedSequencePoints="44" numBranchPoints="23" visitedBranchPoints="22" sequenceCoverage="100" branchCoverage="95.65" maxCyclomaticComplexity="7" minCyclomaticComplexity="1" />
+                    <FullName>OpenCover.Framework.Model.InstrumentationPoint</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="true" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="3" visitedSequencePoints="3" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663401</MetadataToken>
+                            <Name>System.Int32 OpenCover.Framework.Model.InstrumentationPoint::get_Count()</Name>
+                            <FileRef uid="10" />
+                            <SequencePoints>
+                                <SequencePoint vc="2" uspid="684" ordinal="0" offset="0" sl="26" sc="17" el="26" ec="18" />
+                                <SequencePoint vc="2" uspid="685" ordinal="1" offset="1" sl="26" sc="19" el="26" ec="49" />
+                                <SequencePoint vc="2" uspid="686" ordinal="2" offset="14" sl="26" sc="50" el="26" ec="51" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="2" uspid="684" ordinal="0" offset="0" sl="26" sc="17" el="26" ec="18" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663405</MetadataToken>
+                            <Name>System.Int32 OpenCover.Framework.Model.InstrumentationPoint::get_VisitCount()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="41" uspid="687" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663406</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.InstrumentationPoint::set_VisitCount(System.Int32)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="30" uspid="688" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663407</MetadataToken>
+                            <Name>System.UInt32 OpenCover.Framework.Model.InstrumentationPoint::get_UniqueSequencePoint()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="223" uspid="689" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663408</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.InstrumentationPoint::set_UniqueSequencePoint(System.UInt32)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="10064" uspid="690" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="false" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663409</MetadataToken>
+                            <Name>System.UInt32 OpenCover.Framework.Model.InstrumentationPoint::get_Ordinal()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="0" uspid="691" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663410</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.InstrumentationPoint::set_Ordinal(System.UInt32)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="13" uspid="692" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663411</MetadataToken>
+                            <Name>System.Int32 OpenCover.Framework.Model.InstrumentationPoint::get_Offset()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="216" uspid="693" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663412</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.InstrumentationPoint::set_Offset(System.Int32)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="13" uspid="694" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663413</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Model.InstrumentationPoint::get_IsSkipped()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="2" uspid="695" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663414</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.InstrumentationPoint::set_IsSkipped(System.Boolean)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="3" uspid="696" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="3" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="3" visitedSequencePoints="3" numBranchPoints="3" visitedBranchPoints="3" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="3" minCyclomaticComplexity="3" />
+                            <MetadataToken>100663415</MetadataToken>
+                            <Name>OpenCover.Framework.Model.TrackedMethodRef[] OpenCover.Framework.Model.InstrumentationPoint::get_TrackedMethodRefs()</Name>
+                            <FileRef uid="10" />
+                            <SequencePoints>
+                                <SequencePoint vc="9" uspid="697" ordinal="0" offset="0" sl="116" sc="13" el="116" ec="14" />
+                                <SequencePoint vc="9" uspid="698" ordinal="1" offset="1" sl="117" sc="17" el="117" ec="69" />
+                                <SequencePoint vc="9" uspid="699" ordinal="2" offset="27" sl="118" sc="13" el="118" ec="14" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="1" uspid="700" ordinal="0" offset="7" path="0" />
+                                <BranchPoint vc="8" uspid="701" ordinal="1" offset="7" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="9" uspid="697" ordinal="0" offset="0" sl="116" sc="13" el="116" ec="14" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="2" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="6" visitedSequencePoints="6" numBranchPoints="3" visitedBranchPoints="3" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="2" minCyclomaticComplexity="2" />
+                            <MetadataToken>100663416</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.InstrumentationPoint::set_TrackedMethodRefs(OpenCover.Framework.Model.TrackedMethodRef[])</Name>
+                            <FileRef uid="10" />
+                            <SequencePoints>
+                                <SequencePoint vc="3" uspid="702" ordinal="0" offset="0" sl="120" sc="13" el="120" ec="14" />
+                                <SequencePoint vc="3" uspid="703" ordinal="1" offset="1" sl="121" sc="17" el="121" ec="33" />
+                                <SequencePoint vc="3" uspid="704" ordinal="2" offset="8" sl="122" sc="17" el="122" ec="35" />
+                                <SequencePoint vc="1" uspid="705" ordinal="3" offset="19" sl="122" sc="36" el="122" ec="43" />
+                                <SequencePoint vc="2" uspid="706" ordinal="4" offset="21" sl="123" sc="17" el="123" ec="62" />
+                                <SequencePoint vc="3" uspid="707" ordinal="5" offset="33" sl="124" sc="13" el="124" ec="14" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="1" uspid="708" ordinal="0" offset="17" path="0" />
+                                <BranchPoint vc="2" uspid="709" ordinal="1" offset="17" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="3" uspid="702" ordinal="0" offset="0" sl="120" sc="13" el="120" ec="14" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="true" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="3" visitedSequencePoints="3" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663400</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.InstrumentationPoint::.cctor()</Name>
+                            <FileRef uid="10" />
+                            <SequencePoints>
+                                <SequencePoint vc="1" uspid="710" ordinal="0" offset="0" sl="18" sc="9" el="18" ec="10" />
+                                <SequencePoint vc="1" uspid="711" ordinal="1" offset="1" sl="19" sc="13" el="19" ec="72" />
+                                <SequencePoint vc="1" uspid="712" ordinal="2" offset="21" sl="20" sc="9" el="20" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="1" uspid="710" ordinal="0" offset="0" sl="18" sc="9" el="18" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="3" visitedSequencePoints="3" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663402</MetadataToken>
+                            <Name>System.Int32 OpenCover.Framework.Model.InstrumentationPoint::GetVisitCount(System.UInt32)</Name>
+                            <FileRef uid="10" />
+                            <SequencePoints>
+                                <SequencePoint vc="5" uspid="713" ordinal="0" offset="0" sl="34" sc="9" el="34" ec="10" />
+                                <SequencePoint vc="5" uspid="714" ordinal="1" offset="1" sl="35" sc="13" el="35" ec="60" />
+                                <SequencePoint vc="5" uspid="715" ordinal="2" offset="20" sl="36" sc="9" el="36" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="5" uspid="713" ordinal="0" offset="0" sl="34" sc="9" el="34" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="7" sequenceCoverage="100" branchCoverage="92.31" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="21" visitedSequencePoints="21" numBranchPoints="13" visitedBranchPoints="12" sequenceCoverage="100" branchCoverage="92.31" maxCyclomaticComplexity="7" minCyclomaticComplexity="7" />
+                            <MetadataToken>100663403</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Model.InstrumentationPoint::AddVisitCount(System.UInt32,System.UInt32,System.Int32)</Name>
+                            <FileRef uid="10" />
+                            <SequencePoints>
+                                <SequencePoint vc="16" uspid="716" ordinal="0" offset="17" sl="45" sc="9" el="45" ec="10" />
+                                <SequencePoint vc="16" uspid="717" ordinal="1" offset="18" sl="46" sc="13" el="46" ec="60" />
+                                <SequencePoint vc="12" uspid="718" ordinal="2" offset="52" sl="47" sc="13" el="47" ec="14" />
+                                <SequencePoint vc="12" uspid="719" ordinal="3" offset="53" sl="48" sc="17" el="48" ec="58" />
+                                <SequencePoint vc="12" uspid="720" ordinal="4" offset="65" sl="49" sc="17" el="49" ec="41" />
+                                <SequencePoint vc="12" uspid="721" ordinal="5" offset="80" sl="50" sc="17" el="50" ec="42" />
+                                <SequencePoint vc="4" uspid="722" ordinal="6" offset="99" sl="51" sc="17" el="51" ec="18" />
+                                <SequencePoint vc="4" uspid="723" ordinal="7" offset="100" sl="52" sc="21" el="52" ec="85" />
+                                <SequencePoint vc="4" uspid="724" ordinal="8" offset="121" sl="53" sc="21" el="53" ec="91" />
+                                <SequencePoint vc="4" uspid="725" ordinal="9" offset="153" sl="54" sc="21" el="54" ec="41" />
+                                <SequencePoint vc="3" uspid="726" ordinal="10" offset="166" sl="55" sc="21" el="55" ec="22" />
+                                <SequencePoint vc="3" uspid="727" ordinal="11" offset="167" sl="56" sc="25" el="56" ec="105" />
+                                <SequencePoint vc="3" uspid="728" ordinal="12" offset="197" sl="57" sc="25" el="57" ec="53" />
+                                <SequencePoint vc="3" uspid="729" ordinal="13" offset="210" sl="58" sc="21" el="58" ec="22" />
+                                <SequencePoint vc="1" uspid="730" ordinal="14" offset="213" sl="60" sc="21" el="60" ec="22" />
+                                <SequencePoint vc="1" uspid="731" ordinal="15" offset="214" sl="61" sc="25" el="61" ec="51" />
+                                <SequencePoint vc="1" uspid="732" ordinal="16" offset="229" sl="62" sc="21" el="62" ec="22" />
+                                <SequencePoint vc="4" uspid="733" ordinal="17" offset="230" sl="63" sc="17" el="63" ec="18" />
+                                <SequencePoint vc="12" uspid="734" ordinal="18" offset="231" sl="64" sc="17" el="64" ec="29" />
+                                <SequencePoint vc="4" uspid="735" ordinal="19" offset="236" sl="66" sc="13" el="66" ec="26" />
+                                <SequencePoint vc="16" uspid="736" ordinal="20" offset="241" sl="67" sc="9" el="67" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="14" uspid="738" ordinal="0" offset="19" path="0" />
+                                <BranchPoint vc="2" uspid="739" ordinal="1" offset="19" path="1" />
+                                <BranchPoint vc="12" uspid="740" ordinal="2" offset="47" path="0" />
+                                <BranchPoint vc="4" uspid="741" ordinal="3" offset="47" path="1" />
+                                <BranchPoint vc="4" uspid="742" ordinal="4" offset="94" path="0" />
+                                <BranchPoint vc="8" uspid="743" ordinal="5" offset="94" path="1" />
+                                <BranchPoint vc="2" uspid="744" ordinal="6" offset="108" path="0" />
+                                <BranchPoint vc="2" uspid="745" ordinal="7" offset="108" path="1" />
+                                <BranchPoint vc="4" uspid="746" ordinal="8" offset="128" path="0" />
+                                <BranchPoint vc="0" uspid="747" ordinal="9" offset="128" path="1" />
+                                <BranchPoint vc="3" uspid="748" ordinal="10" offset="164" path="0" />
+                                <BranchPoint vc="1" uspid="749" ordinal="11" offset="164" path="1" />
+                            </BranchPoints>
+                            <MethodPoint vc="16" uspid="737" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="5" visitedSequencePoints="5" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663404</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.InstrumentationPoint::.ctor()</Name>
+                            <FileRef uid="10" />
+                            <SequencePoints>
+                                <SequencePoint vc="10064" uspid="750" ordinal="0" offset="0" sl="74" sc="9" el="74" ec="38" />
+                                <SequencePoint vc="10064" uspid="751" ordinal="1" offset="7" sl="75" sc="9" el="75" ec="10" />
+                                <SequencePoint vc="10064" uspid="752" ordinal="2" offset="8" sl="76" sc="17" el="76" ec="89" />
+                                <SequencePoint vc="10064" uspid="753" ordinal="3" offset="25" sl="77" sc="17" el="77" ec="44" />
+                                <SequencePoint vc="10064" uspid="754" ordinal="4" offset="37" sl="78" sc="9" el="78" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="10064" uspid="750" ordinal="0" offset="0" sl="74" sc="9" el="74" ec="38" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                    <FullName>OpenCover.Framework.Model.InstrumentationPoint/&lt;&gt;c__DisplayClass4</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663733</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.InstrumentationPoint/&lt;&gt;c__DisplayClass4::.ctor()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="16" uspid="755" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663734</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Model.InstrumentationPoint/&lt;&gt;c__DisplayClass4::&lt;AddVisitCount&gt;b__2(OpenCover.Framework.Model.TrackedMethodRef)</Name>
+                            <FileRef uid="10" />
+                            <SequencePoints>
+                                <SequencePoint vc="3" uspid="756" ordinal="0" offset="0" sl="53" sc="60" el="53" ec="89" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="3" uspid="756" ordinal="0" offset="0" sl="53" sc="60" el="53" ec="89" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                    <FullName>OpenCover.Framework.Model.BranchPoint</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663417</MetadataToken>
+                            <Name>System.Int32 OpenCover.Framework.Model.BranchPoint::get_Path()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="105" uspid="757" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663418</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.BranchPoint::set_Path(System.Int32)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="10" uspid="758" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663419</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.BranchPoint::.ctor()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="16" uspid="759" ordinal="0" offset="0" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="12" visitedSequencePoints="12" numBranchPoints="2" visitedBranchPoints="2" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                    <FullName>OpenCover.Framework.Model.InstrumentationModelBuilderFactory</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="7" visitedSequencePoints="7" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663424</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.InstrumentationModelBuilderFactory::.ctor(OpenCover.Framework.ICommandLine,OpenCover.Framework.IFilter,log4net.ILog,OpenCover.Framework.Strategy.ITrackedMethodStrategy[])</Name>
+                            <FileRef uid="12" />
+                            <SequencePoints>
+                                <SequencePoint vc="3" uspid="760" ordinal="0" offset="0" sl="20" sc="9" el="20" ec="155" />
+                                <SequencePoint vc="3" uspid="761" ordinal="1" offset="7" sl="21" sc="9" el="21" ec="10" />
+                                <SequencePoint vc="3" uspid="762" ordinal="2" offset="8" sl="22" sc="13" el="22" ec="40" />
+                                <SequencePoint vc="3" uspid="763" ordinal="3" offset="15" sl="23" sc="13" el="23" ec="30" />
+                                <SequencePoint vc="3" uspid="764" ordinal="4" offset="22" sl="24" sc="13" el="24" ec="30" />
+                                <SequencePoint vc="3" uspid="765" ordinal="5" offset="29" sl="25" sc="13" el="25" ec="64" />
+                                <SequencePoint vc="3" uspid="766" ordinal="6" offset="37" sl="26" sc="9" el="26" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="3" uspid="760" ordinal="0" offset="0" sl="20" sc="9" el="20" ec="155" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="5" visitedSequencePoints="5" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663425</MetadataToken>
+                            <Name>OpenCover.Framework.Model.IInstrumentationModelBuilder OpenCover.Framework.Model.InstrumentationModelBuilderFactory::CreateModelBuilder(System.String,System.String)</Name>
+                            <FileRef uid="12" />
+                            <SequencePoints>
+                                <SequencePoint vc="1" uspid="767" ordinal="0" offset="0" sl="29" sc="9" el="29" ec="10" />
+                                <SequencePoint vc="1" uspid="768" ordinal="1" offset="1" sl="30" sc="13" el="30" ec="108" />
+                                <SequencePoint vc="1" uspid="769" ordinal="2" offset="31" sl="31" sc="13" el="31" ec="56" />
+                                <SequencePoint vc="1" uspid="770" ordinal="3" offset="40" sl="32" sc="13" el="32" ec="61" />
+                                <SequencePoint vc="1" uspid="771" ordinal="4" offset="49" sl="33" sc="9" el="33" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="1" uspid="767" ordinal="0" offset="0" sl="29" sc="9" el="29" ec="10" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="9" visitedSequencePoints="9" numBranchPoints="3" visitedBranchPoints="3" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                    <FullName>OpenCover.Framework.Model.SkippedEntity</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="3" visitedSequencePoints="3" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663426</MetadataToken>
+                            <Name>OpenCover.Framework.Model.SkippedMethod OpenCover.Framework.Model.SkippedEntity::get_SkippedDueTo()</Name>
+                            <FileRef uid="13" />
+                            <SequencePoints>
+                                <SequencePoint vc="32" uspid="772" ordinal="0" offset="0" sl="18" sc="17" el="18" ec="18" />
+                                <SequencePoint vc="32" uspid="773" ordinal="1" offset="1" sl="18" sc="19" el="18" ec="59" />
+                                <SequencePoint vc="32" uspid="774" ordinal="2" offset="15" sl="18" sc="60" el="18" ec="61" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="32" uspid="772" ordinal="0" offset="0" sl="18" sc="17" el="18" ec="18" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="3" visitedSequencePoints="3" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663427</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.SkippedEntity::set_SkippedDueTo(OpenCover.Framework.Model.SkippedMethod)</Name>
+                            <FileRef uid="13" />
+                            <SequencePoints>
+                                <SequencePoint vc="31" uspid="775" ordinal="0" offset="0" sl="19" sc="17" el="19" ec="18" />
+                                <SequencePoint vc="31" uspid="776" ordinal="1" offset="1" sl="19" sc="19" el="19" ec="40" />
+                                <SequencePoint vc="31" uspid="777" ordinal="2" offset="13" sl="19" sc="41" el="19" ec="42" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="31" uspid="775" ordinal="0" offset="0" sl="19" sc="17" el="19" ec="18" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="3" visitedSequencePoints="3" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663428</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Model.SkippedEntity::ShouldSerializeSkippedDueTo()</Name>
+                            <FileRef uid="13" />
+                            <SequencePoints>
+                                <SequencePoint vc="1825" uspid="778" ordinal="0" offset="0" sl="25" sc="51" el="25" ec="52" />
+                                <SequencePoint vc="1825" uspid="779" ordinal="1" offset="1" sl="25" sc="53" el="25" ec="82" />
+                                <SequencePoint vc="1825" uspid="780" ordinal="2" offset="15" sl="25" sc="83" el="25" ec="84" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="1825" uspid="778" ordinal="0" offset="0" sl="25" sc="51" el="25" ec="52" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663430</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.SkippedEntity::.ctor()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="1888" uspid="781" ordinal="0" offset="0" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                    <FullName>OpenCover.Framework.Model.Summary</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663431</MetadataToken>
+                            <Name>System.Int32 OpenCover.Framework.Model.Summary::get_NumSequencePoints()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="277" uspid="782" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663432</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.Summary::set_NumSequencePoints(System.Int32)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="86" uspid="783" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663433</MetadataToken>
+                            <Name>System.Int32 OpenCover.Framework.Model.Summary::get_VisitedSequencePoints()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="192" uspid="784" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663434</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.Summary::set_VisitedSequencePoints(System.Int32)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="86" uspid="785" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663435</MetadataToken>
+                            <Name>System.Int32 OpenCover.Framework.Model.Summary::get_NumBranchPoints()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="270" uspid="786" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663436</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.Summary::set_NumBranchPoints(System.Int32)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="97" uspid="787" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663437</MetadataToken>
+                            <Name>System.Int32 OpenCover.Framework.Model.Summary::get_VisitedBranchPoints()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="181" uspid="788" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663438</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.Summary::set_VisitedBranchPoints(System.Int32)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="93" uspid="789" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663439</MetadataToken>
+                            <Name>System.Decimal OpenCover.Framework.Model.Summary::get_SequenceCoverage()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="27" uspid="790" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663440</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.Summary::set_SequenceCoverage(System.Decimal)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="29" uspid="791" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663441</MetadataToken>
+                            <Name>System.Decimal OpenCover.Framework.Model.Summary::get_BranchCoverage()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="27" uspid="792" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663442</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.Summary::set_BranchCoverage(System.Decimal)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="33" uspid="793" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663443</MetadataToken>
+                            <Name>System.Int32 OpenCover.Framework.Model.Summary::get_MaxCyclomaticComplexity()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="121" uspid="794" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663444</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.Summary::set_MaxCyclomaticComplexity(System.Int32)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="86" uspid="795" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663445</MetadataToken>
+                            <Name>System.Int32 OpenCover.Framework.Model.Summary::get_MinCyclomaticComplexity()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="243" uspid="796" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663446</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.Summary::set_MinCyclomaticComplexity(System.Int32)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="144" uspid="797" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663447</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.Summary::.ctor()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="1930" uspid="798" ordinal="0" offset="0" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                    <FullName>OpenCover.Framework.Model.TrackedMethodRef</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663448</MetadataToken>
+                            <Name>System.UInt32 OpenCover.Framework.Model.TrackedMethodRef::get_UniqueId()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="4" uspid="799" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663449</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.TrackedMethodRef::set_UniqueId(System.UInt32)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="5" uspid="800" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663450</MetadataToken>
+                            <Name>System.Int32 OpenCover.Framework.Model.TrackedMethodRef::get_VisitCount()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="4" uspid="801" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663451</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.TrackedMethodRef::set_VisitCount(System.Int32)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="4" uspid="802" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663452</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.TrackedMethodRef::.ctor()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="5" uspid="803" ordinal="0" offset="0" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="4" visitedSequencePoints="4" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                    <FullName>OpenCover.Framework.Model.TrackedMethod</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663454</MetadataToken>
+                            <Name>System.UInt32 OpenCover.Framework.Model.TrackedMethod::get_UniqueId()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="1" uspid="804" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663455</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.TrackedMethod::set_UniqueId(System.UInt32)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="163" uspid="805" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663456</MetadataToken>
+                            <Name>System.Int32 OpenCover.Framework.Model.TrackedMethod::get_MetadataToken()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="2" uspid="806" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663457</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.TrackedMethod::set_MetadataToken(System.Int32)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="160" uspid="807" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663458</MetadataToken>
+                            <Name>System.String OpenCover.Framework.Model.TrackedMethod::get_Name()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="158" uspid="808" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663459</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.TrackedMethod::set_Name(System.String)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="160" uspid="809" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="false" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663460</MetadataToken>
+                            <Name>System.String OpenCover.Framework.Model.TrackedMethod::get_Strategy()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="0" uspid="810" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663461</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.TrackedMethod::set_Strategy(System.String)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="158" uspid="811" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="4" visitedSequencePoints="4" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663453</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.TrackedMethod::.ctor()</Name>
+                            <FileRef uid="14" />
+                            <SequencePoints>
+                                <SequencePoint vc="161" uspid="812" ordinal="0" offset="0" sl="38" sc="9" el="38" ec="31" />
+                                <SequencePoint vc="161" uspid="813" ordinal="1" offset="7" sl="39" sc="9" el="39" ec="10" />
+                                <SequencePoint vc="161" uspid="814" ordinal="2" offset="8" sl="40" sc="13" el="40" ec="67" />
+                                <SequencePoint vc="161" uspid="815" ordinal="3" offset="25" sl="41" sc="9" el="41" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="161" uspid="812" ordinal="0" offset="0" sl="38" sc="9" el="38" ec="31" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="317" visitedSequencePoints="306" numBranchPoints="232" visitedBranchPoints="203" sequenceCoverage="96.53" branchCoverage="87.5" maxCyclomaticComplexity="31" minCyclomaticComplexity="1" />
+                    <FullName>OpenCover.Framework.Persistance.BasePersistance</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663472</MetadataToken>
+                            <Name>OpenCover.Framework.Model.CoverageSession OpenCover.Framework.Persistance.BasePersistance::get_CoverageSession()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="477" uspid="816" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663473</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Persistance.BasePersistance::set_CoverageSession(OpenCover.Framework.Model.CoverageSession)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="42" uspid="817" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="8" visitedSequencePoints="8" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663471</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Persistance.BasePersistance::.ctor(OpenCover.Framework.ICommandLine,log4net.ILog)</Name>
+                            <FileRef uid="15" />
+                            <SequencePoints>
+                                <SequencePoint vc="42" uspid="818" ordinal="0" offset="0" sl="21" sc="9" el="21" ec="181" />
+                                <SequencePoint vc="42" uspid="819" ordinal="1" offset="11" sl="23" sc="9" el="23" ec="73" />
+                                <SequencePoint vc="42" uspid="820" ordinal="2" offset="18" sl="24" sc="9" el="24" ec="10" />
+                                <SequencePoint vc="42" uspid="821" ordinal="3" offset="19" sl="25" sc="13" el="25" ec="39" />
+                                <SequencePoint vc="42" uspid="822" ordinal="4" offset="26" sl="26" sc="13" el="26" ec="30" />
+                                <SequencePoint vc="42" uspid="823" ordinal="5" offset="33" sl="27" sc="13" el="27" ec="53" />
+                                <SequencePoint vc="42" uspid="824" ordinal="6" offset="45" sl="28" sc="13" el="28" ec="34" />
+                                <SequencePoint vc="42" uspid="825" ordinal="7" offset="52" sl="29" sc="9" el="29" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="42" uspid="818" ordinal="0" offset="0" sl="21" sc="9" el="21" ec="181" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="12" sequenceCoverage="100" branchCoverage="78.26" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="33" visitedSequencePoints="33" numBranchPoints="23" visitedBranchPoints="18" sequenceCoverage="100" branchCoverage="78.26" maxCyclomaticComplexity="12" minCyclomaticComplexity="12" />
+                            <MetadataToken>100663474</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Persistance.BasePersistance::PersistModule(OpenCover.Framework.Model.Module)</Name>
+                            <FileRef uid="15" />
+                            <SequencePoints>
+                                <SequencePoint vc="32" uspid="826" ordinal="0" offset="21" sl="34" sc="9" el="34" ec="10" />
+                                <SequencePoint vc="32" uspid="827" ordinal="1" offset="22" sl="35" sc="13" el="35" ec="32" />
+                                <SequencePoint vc="1" uspid="828" ordinal="2" offset="41" sl="35" sc="33" el="35" ec="40" />
+                                <SequencePoint vc="31" uspid="829" ordinal="3" offset="46" sl="36" sc="13" el="36" ec="61" />
+                                <SequencePoint vc="31" uspid="830" ordinal="4" offset="81" sl="37" sc="13" el="37" ec="41" />
+                                <SequencePoint vc="2" uspid="831" ordinal="5" offset="104" sl="38" sc="13" el="38" ec="14" />
+                                <SequencePoint vc="2" uspid="832" ordinal="6" offset="105" sl="39" sc="17" el="39" ec="72" />
+                                <SequencePoint vc="2" uspid="833" ordinal="7" offset="127" sl="40" sc="17" el="40" ec="101" />
+                                <SequencePoint vc="2" uspid="834" ordinal="8" offset="157" sl="41" sc="17" el="41" ec="42" />
+                                <SequencePoint vc="1" uspid="835" ordinal="9" offset="167" sl="42" sc="17" el="42" ec="18" />
+                                <SequencePoint vc="1" uspid="836" ordinal="10" offset="168" sl="43" sc="21" el="43" ec="128" />
+                                <SequencePoint vc="1" uspid="837" ordinal="11" offset="208" sl="44" sc="21" el="44" ec="22" />
+                                <SequencePoint vc="1" uspid="838" ordinal="12" offset="209" sl="45" sc="25" el="45" ec="69" />
+                                <SequencePoint vc="1" uspid="839" ordinal="13" offset="233" sl="46" sc="21" el="46" ec="22" />
+                                <SequencePoint vc="1" uspid="840" ordinal="14" offset="234" sl="47" sc="21" el="47" ec="28" />
+                                <SequencePoint vc="1" uspid="841" ordinal="15" offset="239" sl="49" sc="13" el="49" ec="14" />
+                                <SequencePoint vc="30" uspid="842" ordinal="16" offset="240" sl="50" sc="13" el="50" ec="91" />
+                                <SequencePoint vc="30" uspid="843" ordinal="17" offset="264" sl="51" sc="13" el="51" ec="20" />
+                                <SequencePoint vc="30" uspid="844" ordinal="18" offset="265" sl="51" sc="35" el="51" ec="49" />
+                                <SequencePoint vc="24" uspid="845" ordinal="19" offset="284" sl="51" sc="21" el="51" ec="31" />
+                                <SequencePoint vc="24" uspid="846" ordinal="20" offset="290" sl="52" sc="13" el="52" ec="14" />
+                                <SequencePoint vc="24" uspid="847" ordinal="21" offset="291" sl="53" sc="17" el="53" ec="24" />
+                                <SequencePoint vc="24" uspid="848" ordinal="22" offset="292" sl="53" sc="40" el="53" ec="54" />
+                                <SequencePoint vc="27" uspid="849" ordinal="23" offset="305" sl="53" sc="26" el="53" ec="36" />
+                                <SequencePoint vc="27" uspid="850" ordinal="24" offset="311" sl="54" sc="17" el="54" ec="18" />
+                                <SequencePoint vc="27" uspid="851" ordinal="25" offset="312" sl="55" sc="21" el="55" ec="118" />
+                                <SequencePoint vc="27" uspid="852" ordinal="26" offset="349" sl="56" sc="17" el="56" ec="18" />
+                                <SequencePoint vc="51" uspid="853" ordinal="27" offset="356" sl="53" sc="37" el="53" ec="39" />
+                                <SequencePoint vc="24" uspid="854" ordinal="28" offset="370" sl="57" sc="13" el="57" ec="14" />
+                                <SequencePoint vc="54" uspid="855" ordinal="29" offset="377" sl="51" sc="32" el="51" ec="34" />
+                                <SequencePoint vc="30" uspid="856" ordinal="30" offset="391" sl="58" sc="13" el="58" ec="94" />
+                                <SequencePoint vc="30" uspid="857" ordinal="31" offset="438" sl="59" sc="13" el="59" ec="54" />
+                                <SequencePoint vc="30" uspid="858" ordinal="32" offset="457" sl="60" sc="9" el="60" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="1" uspid="860" ordinal="0" offset="39" path="0" />
+                                <BranchPoint vc="31" uspid="861" ordinal="1" offset="39" path="1" />
+                                <BranchPoint vc="8" uspid="862" ordinal="2" offset="66" path="0" />
+                                <BranchPoint vc="23" uspid="863" ordinal="3" offset="66" path="1" />
+                                <BranchPoint vc="2" uspid="864" ordinal="4" offset="99" path="0" />
+                                <BranchPoint vc="29" uspid="865" ordinal="5" offset="99" path="1" />
+                                <BranchPoint vc="0" uspid="866" ordinal="6" offset="117" path="0" />
+                                <BranchPoint vc="2" uspid="867" ordinal="7" offset="117" path="1" />
+                                <BranchPoint vc="2" uspid="868" ordinal="8" offset="130" path="0" />
+                                <BranchPoint vc="0" uspid="869" ordinal="9" offset="130" path="1" />
+                                <BranchPoint vc="1" uspid="870" ordinal="10" offset="165" path="0" />
+                                <BranchPoint vc="1" uspid="871" ordinal="11" offset="165" path="1" />
+                                <BranchPoint vc="1" uspid="872" ordinal="12" offset="176" path="0" />
+                                <BranchPoint vc="0" uspid="873" ordinal="13" offset="176" path="1" />
+                                <BranchPoint vc="1" uspid="874" ordinal="14" offset="206" path="0" />
+                                <BranchPoint vc="0" uspid="875" ordinal="15" offset="206" path="1" />
+                                <BranchPoint vc="24" uspid="876" ordinal="16" offset="368" path="0" />
+                                <BranchPoint vc="27" uspid="877" ordinal="17" offset="368" path="1" />
+                                <BranchPoint vc="30" uspid="878" ordinal="18" offset="389" path="0" />
+                                <BranchPoint vc="24" uspid="879" ordinal="19" offset="389" path="1" />
+                                <BranchPoint vc="0" uspid="880" ordinal="20" offset="403" path="0" />
+                                <BranchPoint vc="30" uspid="881" ordinal="21" offset="403" path="1" />
+                            </BranchPoints>
+                            <MethodPoint vc="32" uspid="859" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="3" visitedSequencePoints="3" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663475</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Persistance.BasePersistance::IsTracking(System.String)</Name>
+                            <FileRef uid="15" />
+                            <SequencePoints>
+                                <SequencePoint vc="2" uspid="882" ordinal="0" offset="13" sl="63" sc="9" el="63" ec="10" />
+                                <SequencePoint vc="2" uspid="883" ordinal="1" offset="14" sl="64" sc="13" el="65" ec="55" />
+                                <SequencePoint vc="2" uspid="884" ordinal="2" offset="45" sl="66" sc="9" el="66" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint vc="2" uspid="885" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="11" sequenceCoverage="92.86" branchCoverage="81.25" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="28" visitedSequencePoints="26" numBranchPoints="16" visitedBranchPoints="13" sequenceCoverage="92.86" branchCoverage="81.25" maxCyclomaticComplexity="11" minCyclomaticComplexity="11" />
+                            <MetadataToken>100663476</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Persistance.BasePersistance::Commit()</Name>
+                            <FileRef uid="15" />
+                            <SequencePoints>
+                                <SequencePoint vc="22" uspid="886" ordinal="0" offset="0" sl="69" sc="9" el="69" ec="10" />
+                                <SequencePoint vc="22" uspid="887" ordinal="1" offset="1" sl="70" sc="13" el="70" ec="42" />
+                                <SequencePoint vc="22" uspid="888" ordinal="2" offset="8" sl="72" sc="13" el="72" ec="49" />
+                                <SequencePoint vc="13" uspid="889" ordinal="3" offset="29" sl="72" sc="50" el="72" ec="57" />
+                                <SequencePoint vc="9" uspid="890" ordinal="4" offset="34" sl="74" sc="13" el="74" ec="48" />
+                                <SequencePoint vc="0" uspid="891" ordinal="5" offset="54" sl="74" sc="49" el="74" ec="56" />
+                                <SequencePoint vc="9" uspid="892" ordinal="6" offset="59" sl="76" sc="13" el="76" ec="20" />
+                                <SequencePoint vc="9" uspid="893" ordinal="7" offset="60" sl="76" sc="43" el="76" ec="82" />
+                                <SequencePoint vc="9" uspid="894" ordinal="8" offset="115" sl="76" sc="22" el="76" ec="39" />
+                                <SequencePoint vc="9" uspid="895" ordinal="9" offset="122" sl="77" sc="13" el="77" ec="14" />
+                                <SequencePoint vc="9" uspid="896" ordinal="10" offset="123" sl="78" sc="17" el="78" ec="39" />
+                                <SequencePoint vc="4" uspid="897" ordinal="11" offset="151" sl="81" sc="25" el="81" ec="66" />
+                                <SequencePoint vc="4" uspid="898" ordinal="12" offset="159" sl="82" sc="25" el="82" ec="46" />
+                                <SequencePoint vc="4" uspid="899" ordinal="13" offset="166" sl="83" sc="25" el="83" ec="51" />
+                                <SequencePoint vc="4" uspid="900" ordinal="14" offset="173" sl="84" sc="25" el="84" ec="31" />
+                                <SequencePoint vc="2" uspid="901" ordinal="15" offset="175" sl="86" sc="25" el="86" ec="68" />
+                                <SequencePoint vc="2" uspid="902" ordinal="16" offset="183" sl="87" sc="25" el="87" ec="68" />
+                                <SequencePoint vc="2" uspid="903" ordinal="17" offset="191" sl="88" sc="25" el="88" ec="31" />
+                                <SequencePoint vc="1" uspid="904" ordinal="18" offset="193" sl="90" sc="25" el="90" ec="72" />
+                                <SequencePoint vc="1" uspid="905" ordinal="19" offset="201" sl="91" sc="25" el="91" ec="31" />
+                                <SequencePoint vc="2" uspid="906" ordinal="20" offset="203" sl="93" sc="25" el="93" ec="71" />
+                                <SequencePoint vc="2" uspid="907" ordinal="21" offset="211" sl="94" sc="25" el="94" ec="71" />
+                                <SequencePoint vc="2" uspid="908" ordinal="22" offset="219" sl="95" sc="25" el="95" ec="46" />
+                                <SequencePoint vc="2" uspid="909" ordinal="23" offset="226" sl="96" sc="25" el="96" ec="31" />
+                                <SequencePoint vc="0" uspid="910" ordinal="24" offset="228" sl="98" sc="25" el="98" ec="31" />
+                                <SequencePoint vc="9" uspid="911" ordinal="25" offset="230" sl="100" sc="13" el="100" ec="14" />
+                                <SequencePoint vc="18" uspid="912" ordinal="26" offset="231" sl="76" sc="40" el="76" ec="42" />
+                                <SequencePoint vc="22" uspid="913" ordinal="27" offset="260" sl="101" sc="9" el="101" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="13" uspid="914" ordinal="0" offset="27" path="0" />
+                                <BranchPoint vc="9" uspid="915" ordinal="1" offset="27" path="1" />
+                                <BranchPoint vc="0" uspid="916" ordinal="2" offset="52" path="0" />
+                                <BranchPoint vc="9" uspid="917" ordinal="3" offset="52" path="1" />
+                                <BranchPoint vc="1" uspid="918" ordinal="4" offset="76" path="0" />
+                                <BranchPoint vc="8" uspid="919" ordinal="5" offset="76" path="1" />
+                                <BranchPoint vc="0" uspid="920" ordinal="6" offset="128" path="0" />
+                                <BranchPoint vc="1" uspid="921" ordinal="7" offset="128" path="1" />
+                                <BranchPoint vc="2" uspid="922" ordinal="8" offset="128" path="2" />
+                                <BranchPoint vc="2" uspid="923" ordinal="9" offset="128" path="3" />
+                                <BranchPoint vc="4" uspid="924" ordinal="10" offset="128" path="4" />
+                                <BranchPoint vc="9" uspid="925" ordinal="11" offset="239" path="0" />
+                                <BranchPoint vc="9" uspid="926" ordinal="12" offset="239" path="1" />
+                                <BranchPoint vc="9" uspid="927" ordinal="13" offset="249" path="0" />
+                                <BranchPoint vc="0" uspid="928" ordinal="14" offset="249" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="22" uspid="886" ordinal="0" offset="0" sl="69" sc="9" el="69" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="2" sequenceCoverage="85.71" branchCoverage="66.67" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="7" visitedSequencePoints="6" numBranchPoints="3" visitedBranchPoints="2" sequenceCoverage="85.71" branchCoverage="66.67" maxCyclomaticComplexity="2" minCyclomaticComplexity="2" />
+                            <MetadataToken>100663477</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Persistance.BasePersistance::RemoveSkippedModules(OpenCover.Framework.Model.SkippedMethod)</Name>
+                            <FileRef uid="15" />
+                            <SequencePoints>
+                                <SequencePoint vc="3" uspid="929" ordinal="0" offset="13" sl="104" sc="9" el="104" ec="10" />
+                                <SequencePoint vc="3" uspid="930" ordinal="1" offset="14" sl="105" sc="13" el="105" ec="49" />
+                                <SequencePoint vc="0" uspid="931" ordinal="2" offset="35" sl="105" sc="50" el="105" ec="57" />
+                                <SequencePoint vc="3" uspid="932" ordinal="3" offset="37" sl="106" sc="13" el="106" ec="51" />
+                                <SequencePoint vc="3" uspid="933" ordinal="4" offset="49" sl="107" sc="13" el="107" ec="79" />
+                                <SequencePoint vc="3" uspid="934" ordinal="5" offset="73" sl="108" sc="13" el="108" ec="47" />
+                                <SequencePoint vc="3" uspid="935" ordinal="6" offset="86" sl="109" sc="9" el="109" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="0" uspid="937" ordinal="0" offset="33" path="0" />
+                                <BranchPoint vc="3" uspid="938" ordinal="1" offset="33" path="1" />
+                            </BranchPoints>
+                            <MethodPoint vc="3" uspid="936" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="5" sequenceCoverage="85.71" branchCoverage="66.67" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="14" visitedSequencePoints="12" numBranchPoints="9" visitedBranchPoints="6" sequenceCoverage="85.71" branchCoverage="66.67" maxCyclomaticComplexity="5" minCyclomaticComplexity="5" />
+                            <MetadataToken>100663478</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Persistance.BasePersistance::RemoveSkippedClasses(OpenCover.Framework.Model.SkippedMethod)</Name>
+                            <FileRef uid="15" />
+                            <SequencePoints>
+                                <SequencePoint vc="4" uspid="939" ordinal="0" offset="15" sl="112" sc="9" el="112" ec="10" />
+                                <SequencePoint vc="4" uspid="940" ordinal="1" offset="16" sl="113" sc="13" el="113" ec="49" />
+                                <SequencePoint vc="0" uspid="941" ordinal="2" offset="39" sl="113" sc="50" el="113" ec="57" />
+                                <SequencePoint vc="4" uspid="942" ordinal="3" offset="41" sl="114" sc="13" el="114" ec="20" />
+                                <SequencePoint vc="4" uspid="943" ordinal="4" offset="42" sl="114" sc="36" el="114" ec="59" />
+                                <SequencePoint vc="4" uspid="944" ordinal="5" offset="60" sl="114" sc="22" el="114" ec="32" />
+                                <SequencePoint vc="4" uspid="945" ordinal="6" offset="66" sl="115" sc="13" el="115" ec="14" />
+                                <SequencePoint vc="4" uspid="946" ordinal="7" offset="67" sl="116" sc="17" el="116" ec="44" />
+                                <SequencePoint vc="0" uspid="947" ordinal="8" offset="85" sl="116" sc="45" el="116" ec="54" />
+                                <SequencePoint vc="4" uspid="948" ordinal="9" offset="87" sl="117" sc="17" el="117" ec="94" />
+                                <SequencePoint vc="4" uspid="949" ordinal="10" offset="123" sl="118" sc="17" el="118" ec="42" />
+                                <SequencePoint vc="4" uspid="950" ordinal="11" offset="131" sl="119" sc="13" el="119" ec="14" />
+                                <SequencePoint vc="8" uspid="951" ordinal="12" offset="138" sl="114" sc="33" el="114" ec="35" />
+                                <SequencePoint vc="4" uspid="952" ordinal="13" offset="152" sl="120" sc="9" el="120" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="0" uspid="954" ordinal="0" offset="37" path="0" />
+                                <BranchPoint vc="4" uspid="955" ordinal="1" offset="37" path="1" />
+                                <BranchPoint vc="0" uspid="956" ordinal="2" offset="83" path="0" />
+                                <BranchPoint vc="4" uspid="957" ordinal="3" offset="83" path="1" />
+                                <BranchPoint vc="4" uspid="958" ordinal="4" offset="94" path="0" />
+                                <BranchPoint vc="0" uspid="959" ordinal="5" offset="94" path="1" />
+                                <BranchPoint vc="4" uspid="960" ordinal="6" offset="150" path="0" />
+                                <BranchPoint vc="4" uspid="961" ordinal="7" offset="150" path="1" />
+                            </BranchPoints>
+                            <MethodPoint vc="4" uspid="953" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="7" sequenceCoverage="86.36" branchCoverage="76.92" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="22" visitedSequencePoints="19" numBranchPoints="13" visitedBranchPoints="10" sequenceCoverage="86.36" branchCoverage="76.92" maxCyclomaticComplexity="7" minCyclomaticComplexity="7" />
+                            <MetadataToken>100663479</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Persistance.BasePersistance::RemoveSkippedMethods(OpenCover.Framework.Model.SkippedMethod)</Name>
+                            <FileRef uid="15" />
+                            <SequencePoints>
+                                <SequencePoint vc="6" uspid="962" ordinal="0" offset="17" sl="123" sc="9" el="123" ec="10" />
+                                <SequencePoint vc="6" uspid="963" ordinal="1" offset="18" sl="124" sc="13" el="124" ec="49" />
+                                <SequencePoint vc="0" uspid="964" ordinal="2" offset="41" sl="124" sc="50" el="124" ec="57" />
+                                <SequencePoint vc="6" uspid="965" ordinal="3" offset="46" sl="125" sc="13" el="125" ec="20" />
+                                <SequencePoint vc="6" uspid="966" ordinal="4" offset="47" sl="125" sc="36" el="125" ec="59" />
+                                <SequencePoint vc="6" uspid="967" ordinal="5" offset="68" sl="125" sc="22" el="125" ec="32" />
+                                <SequencePoint vc="6" uspid="968" ordinal="6" offset="74" sl="126" sc="13" el="126" ec="14" />
+                                <SequencePoint vc="6" uspid="969" ordinal="7" offset="75" sl="127" sc="17" el="127" ec="44" />
+                                <SequencePoint vc="0" uspid="970" ordinal="8" offset="93" sl="127" sc="45" el="127" ec="54" />
+                                <SequencePoint vc="6" uspid="971" ordinal="9" offset="95" sl="128" sc="17" el="128" ec="24" />
+                                <SequencePoint vc="6" uspid="972" ordinal="10" offset="96" sl="128" sc="40" el="128" ec="54" />
+                                <SequencePoint vc="10" uspid="973" ordinal="11" offset="109" sl="128" sc="26" el="128" ec="36" />
+                                <SequencePoint vc="10" uspid="974" ordinal="12" offset="115" sl="129" sc="17" el="129" ec="18" />
+                                <SequencePoint vc="10" uspid="975" ordinal="13" offset="116" sl="130" sc="21" el="130" ec="48" />
+                                <SequencePoint vc="0" uspid="976" ordinal="14" offset="134" sl="130" sc="49" el="130" ec="58" />
+                                <SequencePoint vc="10" uspid="977" ordinal="15" offset="136" sl="131" sc="21" el="131" ec="98" />
+                                <SequencePoint vc="10" uspid="978" ordinal="16" offset="173" sl="132" sc="21" el="132" ec="46" />
+                                <SequencePoint vc="10" uspid="979" ordinal="17" offset="181" sl="133" sc="17" el="133" ec="18" />
+                                <SequencePoint vc="16" uspid="980" ordinal="18" offset="188" sl="128" sc="37" el="128" ec="39" />
+                                <SequencePoint vc="6" uspid="981" ordinal="19" offset="202" sl="134" sc="13" el="134" ec="14" />
+                                <SequencePoint vc="12" uspid="982" ordinal="20" offset="209" sl="125" sc="33" el="125" ec="35" />
+                                <SequencePoint vc="6" uspid="983" ordinal="21" offset="226" sl="135" sc="9" el="135" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="0" uspid="985" ordinal="0" offset="39" path="0" />
+                                <BranchPoint vc="6" uspid="986" ordinal="1" offset="39" path="1" />
+                                <BranchPoint vc="0" uspid="987" ordinal="2" offset="91" path="0" />
+                                <BranchPoint vc="6" uspid="988" ordinal="3" offset="91" path="1" />
+                                <BranchPoint vc="0" uspid="989" ordinal="4" offset="132" path="0" />
+                                <BranchPoint vc="10" uspid="990" ordinal="5" offset="132" path="1" />
+                                <BranchPoint vc="6" uspid="991" ordinal="6" offset="143" path="0" />
+                                <BranchPoint vc="4" uspid="992" ordinal="7" offset="143" path="1" />
+                                <BranchPoint vc="6" uspid="993" ordinal="8" offset="200" path="0" />
+                                <BranchPoint vc="10" uspid="994" ordinal="9" offset="200" path="1" />
+                                <BranchPoint vc="6" uspid="995" ordinal="10" offset="221" path="0" />
+                                <BranchPoint vc="6" uspid="996" ordinal="11" offset="221" path="1" />
+                            </BranchPoints>
+                            <MethodPoint vc="6" uspid="984" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="5" sequenceCoverage="84.62" branchCoverage="77.78" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="13" visitedSequencePoints="11" numBranchPoints="9" visitedBranchPoints="7" sequenceCoverage="84.62" branchCoverage="77.78" maxCyclomaticComplexity="5" minCyclomaticComplexity="5" />
+                            <MetadataToken>100663480</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Persistance.BasePersistance::RemoveEmptyClasses()</Name>
+                            <FileRef uid="15" />
+                            <SequencePoints>
+                                <SequencePoint vc="6" uspid="997" ordinal="0" offset="0" sl="138" sc="9" el="138" ec="10" />
+                                <SequencePoint vc="6" uspid="998" ordinal="1" offset="1" sl="139" sc="13" el="139" ec="49" />
+                                <SequencePoint vc="0" uspid="999" ordinal="2" offset="22" sl="139" sc="50" el="139" ec="57" />
+                                <SequencePoint vc="6" uspid="1000" ordinal="3" offset="24" sl="140" sc="13" el="140" ec="20" />
+                                <SequencePoint vc="6" uspid="1001" ordinal="4" offset="25" sl="140" sc="36" el="140" ec="59" />
+                                <SequencePoint vc="6" uspid="1002" ordinal="5" offset="41" sl="140" sc="22" el="140" ec="32" />
+                                <SequencePoint vc="6" uspid="1003" ordinal="6" offset="45" sl="141" sc="13" el="141" ec="14" />
+                                <SequencePoint vc="6" uspid="1004" ordinal="7" offset="46" sl="142" sc="17" el="142" ec="44" />
+                                <SequencePoint vc="0" uspid="1005" ordinal="8" offset="62" sl="142" sc="45" el="142" ec="54" />
+                                <SequencePoint vc="6" uspid="1006" ordinal="9" offset="64" sl="143" sc="17" el="143" ec="123" />
+                                <SequencePoint vc="6" uspid="1007" ordinal="10" offset="118" sl="144" sc="13" el="144" ec="14" />
+                                <SequencePoint vc="12" uspid="1008" ordinal="11" offset="123" sl="140" sc="33" el="140" ec="35" />
+                                <SequencePoint vc="6" uspid="1009" ordinal="12" offset="133" sl="145" sc="9" el="145" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="0" uspid="1010" ordinal="0" offset="20" path="0" />
+                                <BranchPoint vc="6" uspid="1011" ordinal="1" offset="20" path="1" />
+                                <BranchPoint vc="0" uspid="1012" ordinal="2" offset="60" path="0" />
+                                <BranchPoint vc="6" uspid="1013" ordinal="3" offset="60" path="1" />
+                                <BranchPoint vc="1" uspid="1014" ordinal="4" offset="76" path="0" />
+                                <BranchPoint vc="5" uspid="1015" ordinal="5" offset="76" path="1" />
+                                <BranchPoint vc="6" uspid="1016" ordinal="6" offset="131" path="0" />
+                                <BranchPoint vc="6" uspid="1017" ordinal="7" offset="131" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="6" uspid="997" ordinal="0" offset="0" sl="138" sc="9" el="138" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="8" sequenceCoverage="90.91" branchCoverage="86.67" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="11" visitedSequencePoints="10" numBranchPoints="15" visitedBranchPoints="13" sequenceCoverage="90.91" branchCoverage="86.67" maxCyclomaticComplexity="8" minCyclomaticComplexity="8" />
+                            <MetadataToken>100663481</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Persistance.BasePersistance::RemoveUnreferencedFiles()</Name>
+                            <FileRef uid="15" />
+                            <SequencePoints>
+                                <SequencePoint vc="4" uspid="1018" ordinal="0" offset="0" sl="148" sc="9" el="148" ec="10" />
+                                <SequencePoint vc="4" uspid="1019" ordinal="1" offset="1" sl="149" sc="13" el="149" ec="49" />
+                                <SequencePoint vc="0" uspid="1020" ordinal="2" offset="22" sl="149" sc="50" el="149" ec="57" />
+                                <SequencePoint vc="4" uspid="1021" ordinal="3" offset="27" sl="150" sc="13" el="150" ec="20" />
+                                <SequencePoint vc="4" uspid="1022" ordinal="4" offset="28" sl="150" sc="36" el="150" ec="59" />
+                                <SequencePoint vc="4" uspid="1023" ordinal="5" offset="56" sl="150" sc="22" el="150" ec="32" />
+                                <SequencePoint vc="4" uspid="1024" ordinal="6" offset="66" sl="151" sc="13" el="151" ec="14" />
+                                <SequencePoint vc="4" uspid="1025" ordinal="7" offset="67" sl="152" sc="17" el="155" ec="67" />
+                                <SequencePoint vc="4" uspid="1026" ordinal="8" offset="237" sl="156" sc="13" el="156" ec="14" />
+                                <SequencePoint vc="8" uspid="1027" ordinal="9" offset="244" sl="150" sc="33" el="150" ec="35" />
+                                <SequencePoint vc="4" uspid="1028" ordinal="10" offset="258" sl="157" sc="9" el="157" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="0" uspid="1029" ordinal="0" offset="20" path="0" />
+                                <BranchPoint vc="4" uspid="1030" ordinal="1" offset="20" path="1" />
+                                <BranchPoint vc="3" uspid="1031" ordinal="2" offset="85" path="0" />
+                                <BranchPoint vc="1" uspid="1032" ordinal="3" offset="85" path="1" />
+                                <BranchPoint vc="4" uspid="1033" ordinal="4" offset="95" path="0" />
+                                <BranchPoint vc="0" uspid="1034" ordinal="5" offset="95" path="1" />
+                                <BranchPoint vc="1" uspid="1035" ordinal="6" offset="118" path="0" />
+                                <BranchPoint vc="3" uspid="1036" ordinal="7" offset="118" path="1" />
+                                <BranchPoint vc="1" uspid="1037" ordinal="8" offset="154" path="0" />
+                                <BranchPoint vc="3" uspid="1038" ordinal="9" offset="154" path="1" />
+                                <BranchPoint vc="1" uspid="1039" ordinal="10" offset="190" path="0" />
+                                <BranchPoint vc="3" uspid="1040" ordinal="11" offset="190" path="1" />
+                                <BranchPoint vc="4" uspid="1041" ordinal="12" offset="253" path="0" />
+                                <BranchPoint vc="4" uspid="1042" ordinal="13" offset="253" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="4" uspid="1018" ordinal="0" offset="0" sl="148" sc="9" el="148" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="31" sequenceCoverage="100" branchCoverage="91.80" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="65" visitedSequencePoints="65" numBranchPoints="61" visitedBranchPoints="56" sequenceCoverage="100" branchCoverage="91.80" maxCyclomaticComplexity="31" minCyclomaticComplexity="31" />
+                            <MetadataToken>100663482</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Persistance.BasePersistance::PopulateInstrumentedPoints()</Name>
+                            <FileRef uid="15" />
+                            <SequencePoints>
+                                <SequencePoint vc="22" uspid="1043" ordinal="0" offset="0" sl="160" sc="9" el="160" ec="10" />
+                                <SequencePoint vc="22" uspid="1044" ordinal="1" offset="1" sl="161" sc="13" el="161" ec="49" />
+                                <SequencePoint vc="1" uspid="1045" ordinal="2" offset="24" sl="161" sc="50" el="161" ec="57" />
+                                <SequencePoint vc="21" uspid="1046" ordinal="3" offset="29" sl="163" sc="13" el="163" ec="20" />
+                                <SequencePoint vc="21" uspid="1047" ordinal="4" offset="30" sl="163" sc="36" el="170" ec="49" />
+                                <SequencePoint vc="1" uspid="1048" ordinal="5" offset="256" sl="163" sc="22" el="163" ec="32" />
+                                <SequencePoint vc="1" uspid="1049" ordinal="6" offset="264" sl="171" sc="13" el="171" ec="14" />
+                                <SequencePoint vc="1" uspid="1050" ordinal="7" offset="265" sl="172" sc="17" el="172" ec="62" />
+                                <SequencePoint vc="1" uspid="1051" ordinal="8" offset="273" sl="173" sc="13" el="173" ec="14" />
+                                <SequencePoint vc="22" uspid="1052" ordinal="9" offset="274" sl="163" sc="33" el="163" ec="35" />
+                                <SequencePoint vc="21" uspid="1053" ordinal="10" offset="310" sl="175" sc="13" el="175" ec="20" />
+                                <SequencePoint vc="21" uspid="1054" ordinal="11" offset="311" sl="175" sc="36" el="175" ec="104" />
+                                <SequencePoint vc="22" uspid="1055" ordinal="12" offset="370" sl="175" sc="22" el="175" ec="32" />
+                                <SequencePoint vc="22" uspid="1056" ordinal="13" offset="378" sl="176" sc="13" el="176" ec="14" />
+                                <SequencePoint vc="22" uspid="1057" ordinal="14" offset="379" sl="177" sc="17" el="177" ec="24" />
+                                <SequencePoint vc="22" uspid="1058" ordinal="15" offset="380" sl="177" sc="40" el="177" ec="117" />
+                                <SequencePoint vc="20" uspid="1059" ordinal="16" offset="444" sl="177" sc="26" el="177" ec="36" />
+                                <SequencePoint vc="20" uspid="1060" ordinal="17" offset="452" sl="178" sc="17" el="178" ec="18" />
+                                <SequencePoint vc="20" uspid="1061" ordinal="18" offset="453" sl="180" sc="21" el="180" ec="28" />
+                                <SequencePoint vc="20" uspid="1062" ordinal="19" offset="454" sl="180" sc="44" el="180" ec="122" />
+                                <SequencePoint vc="22" uspid="1063" ordinal="20" offset="518" sl="180" sc="30" el="180" ec="40" />
+                                <SequencePoint vc="22" uspid="1064" ordinal="21" offset="526" sl="181" sc="21" el="181" ec="22" />
+                                <SequencePoint vc="22" uspid="1065" ordinal="22" offset="527" sl="182" sc="25" el="182" ec="92" />
+                                <SequencePoint vc="22" uspid="1066" ordinal="23" offset="544" sl="183" sc="25" el="183" ec="86" />
+                                <SequencePoint vc="22" uspid="1067" ordinal="24" offset="562" sl="185" sc="25" el="185" ec="56" />
+                                <SequencePoint vc="2" uspid="1068" ordinal="25" offset="577" sl="186" sc="25" el="186" ec="26" />
+                                <SequencePoint vc="2" uspid="1069" ordinal="26" offset="578" sl="187" sc="29" el="187" ec="82" />
+                                <SequencePoint vc="2" uspid="1070" ordinal="27" offset="599" sl="188" sc="25" el="188" ec="26" />
+                                <SequencePoint vc="22" uspid="1071" ordinal="28" offset="600" sl="190" sc="25" el="190" ec="79" />
+                                <SequencePoint vc="22" uspid="1072" ordinal="29" offset="619" sl="191" sc="25" el="191" ec="107" />
+                                <SequencePoint vc="22" uspid="1073" ordinal="30" offset="669" sl="192" sc="25" el="192" ec="83" />
+                                <SequencePoint vc="22" uspid="1074" ordinal="31" offset="687" sl="193" sc="25" el="193" ec="111" />
+                                <SequencePoint vc="22" uspid="1075" ordinal="32" offset="736" sl="195" sc="25" el="195" ec="66" />
+                                <SequencePoint vc="11" uspid="1076" ordinal="33" offset="759" sl="196" sc="29" el="196" ec="65" />
+                                <SequencePoint vc="22" uspid="1077" ordinal="34" offset="779" sl="198" sc="25" el="198" ec="70" />
+                                <SequencePoint vc="7" uspid="1078" ordinal="35" offset="802" sl="199" sc="29" el="199" ec="69" />
+                                <SequencePoint vc="22" uspid="1079" ordinal="36" offset="822" sl="201" sc="25" el="201" ec="67" />
+                                <SequencePoint vc="22" uspid="1080" ordinal="37" offset="840" sl="202" sc="25" el="202" ec="59" />
+                                <SequencePoint vc="22" uspid="1081" ordinal="38" offset="852" sl="204" sc="25" el="204" ec="83" />
+                                <SequencePoint vc="22" uspid="1082" ordinal="39" offset="870" sl="205" sc="25" el="205" ec="79" />
+                                <SequencePoint vc="22" uspid="1083" ordinal="40" offset="888" sl="207" sc="25" el="207" ec="148" />
+                                <SequencePoint vc="22" uspid="1084" ordinal="41" offset="929" sl="209" sc="25" el="209" ec="73" />
+                                <SequencePoint vc="18" uspid="1085" ordinal="42" offset="952" sl="210" sc="29" el="210" ec="109" />
+                                <SequencePoint vc="22" uspid="1086" ordinal="43" offset="975" sl="212" sc="25" el="212" ec="144" />
+                                <SequencePoint vc="22" uspid="1087" ordinal="44" offset="1009" sl="213" sc="25" el="213" ec="144" />
+                                <SequencePoint vc="22" uspid="1088" ordinal="45" offset="1043" sl="214" sc="21" el="214" ec="22" />
+                                <SequencePoint vc="42" uspid="1089" ordinal="46" offset="1044" sl="180" sc="41" el="180" ec="43" />
+                                <SequencePoint vc="20" uspid="1090" ordinal="47" offset="1083" sl="216" sc="21" el="216" ec="63" />
+                                <SequencePoint vc="20" uspid="1091" ordinal="48" offset="1101" sl="217" sc="21" el="217" ec="55" />
+                                <SequencePoint vc="20" uspid="1092" ordinal="49" offset="1113" sl="219" sc="21" el="219" ec="69" />
+                                <SequencePoint vc="19" uspid="1093" ordinal="50" offset="1136" sl="220" sc="25" el="220" ec="105" />
+                                <SequencePoint vc="20" uspid="1094" ordinal="51" offset="1159" sl="222" sc="21" el="222" ec="151" />
+                                <SequencePoint vc="20" uspid="1095" ordinal="52" offset="1198" sl="223" sc="21" el="223" ec="151" />
+                                <SequencePoint vc="20" uspid="1096" ordinal="53" offset="1237" sl="224" sc="17" el="224" ec="18" />
+                                <SequencePoint vc="42" uspid="1097" ordinal="54" offset="1238" sl="177" sc="37" el="177" ec="39" />
+                                <SequencePoint vc="22" uspid="1098" ordinal="55" offset="1277" sl="226" sc="17" el="226" ec="68" />
+                                <SequencePoint vc="22" uspid="1099" ordinal="56" offset="1300" sl="227" sc="17" el="227" ec="51" />
+                                <SequencePoint vc="22" uspid="1100" ordinal="57" offset="1312" sl="229" sc="17" el="229" ec="74" />
+                                <SequencePoint vc="21" uspid="1101" ordinal="58" offset="1340" sl="230" sc="21" el="230" ec="110" />
+                                <SequencePoint vc="22" uspid="1102" ordinal="59" offset="1368" sl="232" sc="17" el="232" ec="165" />
+                                <SequencePoint vc="22" uspid="1103" ordinal="60" offset="1417" sl="233" sc="17" el="233" ec="165" />
+                                <SequencePoint vc="22" uspid="1104" ordinal="61" offset="1466" sl="234" sc="13" el="234" ec="14" />
+                                <SequencePoint vc="43" uspid="1105" ordinal="62" offset="1467" sl="175" sc="33" el="175" ec="35" />
+                                <SequencePoint vc="21" uspid="1106" ordinal="63" offset="1506" sl="236" sc="13" el="236" ec="56" />
+                                <SequencePoint vc="22" uspid="1107" ordinal="64" offset="1523" sl="237" sc="9" el="237" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="1" uspid="1108" ordinal="0" offset="22" path="0" />
+                                <BranchPoint vc="21" uspid="1109" ordinal="1" offset="22" path="1" />
+                                <BranchPoint vc="1" uspid="1110" ordinal="2" offset="46" path="0" />
+                                <BranchPoint vc="20" uspid="1111" ordinal="3" offset="46" path="1" />
+                                <BranchPoint vc="1" uspid="1112" ordinal="4" offset="77" path="0" />
+                                <BranchPoint vc="20" uspid="1113" ordinal="5" offset="77" path="1" />
+                                <BranchPoint vc="1" uspid="1114" ordinal="6" offset="113" path="0" />
+                                <BranchPoint vc="20" uspid="1115" ordinal="7" offset="113" path="1" />
+                                <BranchPoint vc="1" uspid="1116" ordinal="8" offset="149" path="0" />
+                                <BranchPoint vc="20" uspid="1117" ordinal="9" offset="149" path="1" />
+                                <BranchPoint vc="1" uspid="1118" ordinal="10" offset="185" path="0" />
+                                <BranchPoint vc="20" uspid="1119" ordinal="11" offset="185" path="1" />
+                                <BranchPoint vc="1" uspid="1120" ordinal="12" offset="216" path="0" />
+                                <BranchPoint vc="20" uspid="1121" ordinal="13" offset="216" path="1" />
+                                <BranchPoint vc="21" uspid="1122" ordinal="14" offset="285" path="0" />
+                                <BranchPoint vc="1" uspid="1123" ordinal="15" offset="285" path="1" />
+                                <BranchPoint vc="21" uspid="1124" ordinal="16" offset="298" path="0" />
+                                <BranchPoint vc="0" uspid="1125" ordinal="17" offset="298" path="1" />
+                                <BranchPoint vc="1" uspid="1126" ordinal="18" offset="327" path="0" />
+                                <BranchPoint vc="20" uspid="1127" ordinal="19" offset="327" path="1" />
+                                <BranchPoint vc="1" uspid="1128" ordinal="20" offset="387" path="0" />
+                                <BranchPoint vc="21" uspid="1129" ordinal="21" offset="387" path="1" />
+                                <BranchPoint vc="1" uspid="1130" ordinal="22" offset="401" path="0" />
+                                <BranchPoint vc="21" uspid="1131" ordinal="23" offset="401" path="1" />
+                                <BranchPoint vc="0" uspid="1132" ordinal="24" offset="461" path="0" />
+                                <BranchPoint vc="20" uspid="1133" ordinal="25" offset="461" path="1" />
+                                <BranchPoint vc="1" uspid="1134" ordinal="26" offset="475" path="0" />
+                                <BranchPoint vc="19" uspid="1135" ordinal="27" offset="475" path="1" />
+                                <BranchPoint vc="11" uspid="1136" ordinal="28" offset="534" path="0" />
+                                <BranchPoint vc="11" uspid="1137" ordinal="29" offset="534" path="1" />
+                                <BranchPoint vc="21" uspid="1138" ordinal="30" offset="551" path="0" />
+                                <BranchPoint vc="1" uspid="1139" ordinal="31" offset="551" path="1" />
+                                <BranchPoint vc="2" uspid="1140" ordinal="32" offset="575" path="0" />
+                                <BranchPoint vc="20" uspid="1141" ordinal="33" offset="575" path="1" />
+                                <BranchPoint vc="1" uspid="1142" ordinal="34" offset="632" path="0" />
+                                <BranchPoint vc="21" uspid="1143" ordinal="35" offset="632" path="1" />
+                                <BranchPoint vc="1" uspid="1144" ordinal="36" offset="699" path="0" />
+                                <BranchPoint vc="21" uspid="1145" ordinal="37" offset="699" path="1" />
+                                <BranchPoint vc="11" uspid="1146" ordinal="38" offset="757" path="0" />
+                                <BranchPoint vc="11" uspid="1147" ordinal="39" offset="757" path="1" />
+                                <BranchPoint vc="7" uspid="1148" ordinal="40" offset="800" path="0" />
+                                <BranchPoint vc="15" uspid="1149" ordinal="41" offset="800" path="1" />
+                                <BranchPoint vc="18" uspid="1150" ordinal="42" offset="950" path="0" />
+                                <BranchPoint vc="4" uspid="1151" ordinal="43" offset="950" path="1" />
+                                <BranchPoint vc="20" uspid="1152" ordinal="44" offset="1055" path="0" />
+                                <BranchPoint vc="22" uspid="1153" ordinal="45" offset="1055" path="1" />
+                                <BranchPoint vc="20" uspid="1154" ordinal="46" offset="1071" path="0" />
+                                <BranchPoint vc="0" uspid="1155" ordinal="47" offset="1071" path="1" />
+                                <BranchPoint vc="19" uspid="1156" ordinal="48" offset="1134" path="0" />
+                                <BranchPoint vc="1" uspid="1157" ordinal="49" offset="1134" path="1" />
+                                <BranchPoint vc="22" uspid="1158" ordinal="50" offset="1249" path="0" />
+                                <BranchPoint vc="20" uspid="1159" ordinal="51" offset="1249" path="1" />
+                                <BranchPoint vc="22" uspid="1160" ordinal="52" offset="1265" path="0" />
+                                <BranchPoint vc="0" uspid="1161" ordinal="53" offset="1265" path="1" />
+                                <BranchPoint vc="21" uspid="1162" ordinal="54" offset="1338" path="0" />
+                                <BranchPoint vc="1" uspid="1163" ordinal="55" offset="1338" path="1" />
+                                <BranchPoint vc="21" uspid="1164" ordinal="56" offset="1478" path="0" />
+                                <BranchPoint vc="22" uspid="1165" ordinal="57" offset="1478" path="1" />
+                                <BranchPoint vc="21" uspid="1166" ordinal="58" offset="1494" path="0" />
+                                <BranchPoint vc="0" uspid="1167" ordinal="59" offset="1494" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="22" uspid="1043" ordinal="0" offset="0" sl="160" sc="9" el="160" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="3" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="6" visitedSequencePoints="6" numBranchPoints="5" visitedBranchPoints="5" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="3" minCyclomaticComplexity="3" />
+                            <MetadataToken>100663483</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Persistance.BasePersistance::CalculateCoverage(OpenCover.Framework.Model.Summary)</Name>
+                            <FileRef uid="15" />
+                            <SequencePoints>
+                                <SequencePoint vc="85" uspid="1168" ordinal="0" offset="0" sl="240" sc="9" el="240" ec="10" />
+                                <SequencePoint vc="85" uspid="1169" ordinal="1" offset="1" sl="241" sc="13" el="241" ec="47" />
+                                <SequencePoint vc="29" uspid="1170" ordinal="2" offset="17" sl="242" sc="17" el="242" ec="122" />
+                                <SequencePoint vc="85" uspid="1171" ordinal="3" offset="69" sl="244" sc="13" el="244" ec="45" />
+                                <SequencePoint vc="33" uspid="1172" ordinal="4" offset="85" sl="245" sc="17" el="245" ec="116" />
+                                <SequencePoint vc="85" uspid="1173" ordinal="5" offset="137" sl="246" sc="9" el="246" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="29" uspid="1174" ordinal="0" offset="15" path="0" />
+                                <BranchPoint vc="56" uspid="1175" ordinal="1" offset="15" path="1" />
+                                <BranchPoint vc="33" uspid="1176" ordinal="2" offset="83" path="0" />
+                                <BranchPoint vc="52" uspid="1177" ordinal="3" offset="83" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="85" uspid="1168" ordinal="0" offset="0" sl="240" sc="9" el="240" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="6" visitedSequencePoints="6" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663484</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Persistance.BasePersistance::AddPoints(OpenCover.Framework.Model.Summary,OpenCover.Framework.Model.Summary)</Name>
+                            <FileRef uid="15" />
+                            <SequencePoints>
+                                <SequencePoint vc="64" uspid="1178" ordinal="0" offset="0" sl="249" sc="9" el="249" ec="10" />
+                                <SequencePoint vc="64" uspid="1179" ordinal="1" offset="1" sl="250" sc="13" el="250" ec="61" />
+                                <SequencePoint vc="64" uspid="1180" ordinal="2" offset="21" sl="251" sc="13" el="251" ec="69" />
+                                <SequencePoint vc="64" uspid="1181" ordinal="3" offset="41" sl="252" sc="13" el="252" ec="65" />
+                                <SequencePoint vc="64" uspid="1182" ordinal="4" offset="61" sl="253" sc="13" el="253" ec="73" />
+                                <SequencePoint vc="64" uspid="1183" ordinal="5" offset="81" sl="254" sc="9" el="254" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="64" uspid="1178" ordinal="0" offset="0" sl="249" sc="9" el="249" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="4" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="14" visitedSequencePoints="14" numBranchPoints="7" visitedBranchPoints="7" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="4" minCyclomaticComplexity="4" />
+                            <MetadataToken>100663485</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Persistance.BasePersistance::GetSequencePointsForFunction(System.String,System.Int32,OpenCover.Framework.Model.InstrumentationPoint[]&amp;)</Name>
+                            <FileRef uid="15" />
+                            <SequencePoints>
+                                <SequencePoint vc="5" uspid="1184" ordinal="0" offset="0" sl="257" sc="9" el="257" ec="10" />
+                                <SequencePoint vc="5" uspid="1185" ordinal="1" offset="1" sl="258" sc="13" el="258" ec="58" />
+                                <SequencePoint vc="5" uspid="1186" ordinal="2" offset="9" sl="260" sc="13" el="260" ec="75" />
+                                <SequencePoint vc="5" uspid="1187" ordinal="3" offset="20" sl="261" sc="13" el="261" ec="64" />
+                                <SequencePoint vc="3" uspid="1188" ordinal="4" offset="42" sl="262" sc="13" el="262" ec="14" />
+                                <SequencePoint vc="3" uspid="1189" ordinal="5" offset="43" sl="263" sc="17" el="263" ec="127" />
+                                <SequencePoint vc="3" uspid="1190" ordinal="6" offset="89" sl="264" sc="17" el="264" ec="63" />
+                                <SequencePoint vc="3" uspid="1191" ordinal="7" offset="95" sl="265" sc="17" el="265" ec="60" />
+                                <SequencePoint vc="1" uspid="1192" ordinal="8" offset="115" sl="266" sc="21" el="266" ec="52" />
+                                <SequencePoint vc="3" uspid="1193" ordinal="9" offset="128" sl="267" sc="17" el="267" ec="56" />
+                                <SequencePoint vc="3" uspid="1194" ordinal="10" offset="141" sl="268" sc="17" el="268" ec="51" />
+                                <SequencePoint vc="3" uspid="1195" ordinal="11" offset="149" sl="269" sc="17" el="269" ec="29" />
+                                <SequencePoint vc="2" uspid="1196" ordinal="12" offset="153" sl="271" sc="13" el="271" ec="26" />
+                                <SequencePoint vc="5" uspid="1197" ordinal="13" offset="157" sl="272" sc="9" el="272" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="3" uspid="1198" ordinal="0" offset="21" path="0" />
+                                <BranchPoint vc="2" uspid="1199" ordinal="1" offset="21" path="1" />
+                                <BranchPoint vc="3" uspid="1200" ordinal="2" offset="40" path="0" />
+                                <BranchPoint vc="2" uspid="1201" ordinal="3" offset="40" path="1" />
+                                <BranchPoint vc="1" uspid="1202" ordinal="4" offset="113" path="0" />
+                                <BranchPoint vc="2" uspid="1203" ordinal="5" offset="113" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="5" uspid="1184" ordinal="0" offset="0" sl="257" sc="9" el="257" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="3" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="10" visitedSequencePoints="10" numBranchPoints="5" visitedBranchPoints="5" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="3" minCyclomaticComplexity="3" />
+                            <MetadataToken>100663486</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Persistance.BasePersistance::GetBranchPointsForFunction(System.String,System.Int32,OpenCover.Framework.Model.BranchPoint[]&amp;)</Name>
+                            <FileRef uid="15" />
+                            <SequencePoints>
+                                <SequencePoint vc="2" uspid="1204" ordinal="0" offset="0" sl="275" sc="9" el="275" ec="10" />
+                                <SequencePoint vc="2" uspid="1205" ordinal="1" offset="1" sl="276" sc="13" el="276" ec="47" />
+                                <SequencePoint vc="2" uspid="1206" ordinal="2" offset="9" sl="278" sc="13" el="278" ec="75" />
+                                <SequencePoint vc="2" uspid="1207" ordinal="3" offset="20" sl="279" sc="13" el="279" ec="63" />
+                                <SequencePoint vc="1" uspid="1208" ordinal="4" offset="40" sl="280" sc="13" el="280" ec="14" />
+                                <SequencePoint vc="1" uspid="1209" ordinal="5" offset="41" sl="281" sc="17" el="281" ec="125" />
+                                <SequencePoint vc="1" uspid="1210" ordinal="6" offset="87" sl="282" sc="17" el="282" ec="62" />
+                                <SequencePoint vc="1" uspid="1211" ordinal="7" offset="100" sl="283" sc="17" el="283" ec="29" />
+                                <SequencePoint vc="1" uspid="1212" ordinal="8" offset="104" sl="285" sc="13" el="285" ec="26" />
+                                <SequencePoint vc="2" uspid="1213" ordinal="9" offset="108" sl="286" sc="9" el="286" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="1" uspid="1214" ordinal="0" offset="21" path="0" />
+                                <BranchPoint vc="1" uspid="1215" ordinal="1" offset="21" path="1" />
+                                <BranchPoint vc="1" uspid="1216" ordinal="2" offset="38" path="0" />
+                                <BranchPoint vc="1" uspid="1217" ordinal="3" offset="38" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="2" uspid="1204" ordinal="0" offset="0" sl="275" sc="9" el="275" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="3" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="11" visitedSequencePoints="11" numBranchPoints="5" visitedBranchPoints="5" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="3" minCyclomaticComplexity="3" />
+                            <MetadataToken>100663487</MetadataToken>
+                            <Name>OpenCover.Framework.Model.Method OpenCover.Framework.Persistance.BasePersistance::GetMethod(System.String,System.Int32,OpenCover.Framework.Model.Class&amp;)</Name>
+                            <FileRef uid="15" />
+                            <SequencePoints>
+                                <SequencePoint vc="8" uspid="1218" ordinal="0" offset="13" sl="289" sc="9" el="289" ec="10" />
+                                <SequencePoint vc="8" uspid="1219" ordinal="1" offset="14" sl="290" sc="13" el="290" ec="27" />
+                                <SequencePoint vc="8" uspid="1220" ordinal="2" offset="17" sl="292" sc="13" el="292" ec="163" />
+                                <SequencePoint vc="8" uspid="1221" ordinal="3" offset="46" sl="293" sc="13" el="293" ec="32" />
+                                <SequencePoint vc="1" uspid="1222" ordinal="4" offset="59" sl="294" sc="17" el="294" ec="29" />
+                                <SequencePoint vc="7" uspid="1223" ordinal="5" offset="63" sl="295" sc="13" el="295" ec="70" />
+                                <SequencePoint vc="2" uspid="1224" ordinal="6" offset="87" sl="295" sc="71" el="295" ec="83" />
+                                <SequencePoint vc="5" uspid="1225" ordinal="7" offset="91" sl="296" sc="13" el="296" ec="64" />
+                                <SequencePoint vc="5" uspid="1226" ordinal="8" offset="110" sl="297" sc="13" el="297" ec="31" />
+                                <SequencePoint vc="5" uspid="1227" ordinal="9" offset="119" sl="298" sc="13" el="298" ec="31" />
+                                <SequencePoint vc="8" uspid="1228" ordinal="10" offset="129" sl="299" sc="9" el="299" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="1" uspid="1230" ordinal="0" offset="57" path="0" />
+                                <BranchPoint vc="7" uspid="1231" ordinal="1" offset="57" path="1" />
+                                <BranchPoint vc="2" uspid="1232" ordinal="2" offset="85" path="0" />
+                                <BranchPoint vc="5" uspid="1233" ordinal="3" offset="85" path="1" />
+                            </BranchPoints>
+                            <MethodPoint vc="8" uspid="1229" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="3" sequenceCoverage="100" branchCoverage="66.67" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="4" visitedSequencePoints="4" numBranchPoints="3" visitedBranchPoints="2" sequenceCoverage="100" branchCoverage="66.67" maxCyclomaticComplexity="3" minCyclomaticComplexity="3" />
+                            <MetadataToken>100663488</MetadataToken>
+                            <Name>System.String OpenCover.Framework.Persistance.BasePersistance::GetClassFullName(System.String,System.Int32)</Name>
+                            <FileRef uid="15" />
+                            <SequencePoints>
+                                <SequencePoint vc="1" uspid="1234" ordinal="0" offset="0" sl="302" sc="9" el="302" ec="10" />
+                                <SequencePoint vc="1" uspid="1235" ordinal="1" offset="1" sl="304" sc="13" el="304" ec="62" />
+                                <SequencePoint vc="1" uspid="1236" ordinal="2" offset="12" sl="305" sc="13" el="305" ec="60" />
+                                <SequencePoint vc="1" uspid="1237" ordinal="3" offset="28" sl="306" sc="9" el="306" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="0" uspid="1238" ordinal="0" offset="13" path="0" />
+                                <BranchPoint vc="1" uspid="1239" ordinal="1" offset="13" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="1" uspid="1234" ordinal="0" offset="0" sl="302" sc="9" el="302" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="6" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="21" visitedSequencePoints="21" numBranchPoints="9" visitedBranchPoints="9" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="6" minCyclomaticComplexity="6" />
+                            <MetadataToken>100663489</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Persistance.BasePersistance::SaveVisitData(System.Byte[])</Name>
+                            <FileRef uid="15" />
+                            <SequencePoints>
+                                <SequencePoint vc="4" uspid="1240" ordinal="0" offset="0" sl="309" sc="9" el="309" ec="10" />
+                                <SequencePoint vc="4" uspid="1241" ordinal="1" offset="1" sl="310" sc="13" el="310" ec="57" />
+                                <SequencePoint vc="4" uspid="1242" ordinal="2" offset="9" sl="311" sc="18" el="311" ec="28" />
+                                <SequencePoint vc="4" uspid="1243" ordinal="3" offset="11" sl="311" sc="29" el="311" ec="37" />
+                                <SequencePoint vc="14" uspid="1244" ordinal="4" offset="18" sl="312" sc="13" el="312" ec="14" />
+                                <SequencePoint vc="14" uspid="1245" ordinal="5" offset="19" sl="313" sc="17" el="313" ec="61" />
+                                <SequencePoint vc="14" uspid="1246" ordinal="6" offset="27" sl="314" sc="17" el="314" ec="60" />
+                                <SequencePoint vc="10" uspid="1247" ordinal="7" offset="44" sl="315" sc="17" el="315" ec="18" />
+                                <SequencePoint vc="10" uspid="1248" ordinal="8" offset="45" sl="316" sc="21" el="316" ec="85" />
+                                <SequencePoint vc="2" uspid="1249" ordinal="9" offset="64" sl="317" sc="21" el="317" ec="22" />
+                                <SequencePoint vc="2" uspid="1250" ordinal="10" offset="65" sl="318" sc="25" el="319" ec="81" />
+                                <SequencePoint vc="2" uspid="1251" ordinal="11" offset="109" sl="320" sc="21" el="320" ec="22" />
+                                <SequencePoint vc="10" uspid="1252" ordinal="12" offset="110" sl="321" sc="17" el="321" ec="18" />
+                                <SequencePoint vc="4" uspid="1253" ordinal="13" offset="113" sl="323" sc="17" el="323" ec="18" />
+                                <SequencePoint vc="4" uspid="1254" ordinal="14" offset="114" sl="324" sc="21" el="324" ec="64" />
+                                <SequencePoint vc="4" uspid="1255" ordinal="15" offset="123" sl="325" sc="21" el="325" ec="97" />
+                                <SequencePoint vc="4" uspid="1256" ordinal="16" offset="144" sl="326" sc="17" el="326" ec="18" />
+                                <SequencePoint vc="14" uspid="1257" ordinal="17" offset="145" sl="327" sc="13" el="327" ec="14" />
+                                <SequencePoint vc="14" uspid="1258" ordinal="18" offset="146" sl="311" sc="50" el="311" ec="63" />
+                                <SequencePoint vc="18" uspid="1259" ordinal="19" offset="154" sl="311" sc="38" el="311" ec="48" />
+                                <SequencePoint vc="4" uspid="1260" ordinal="20" offset="169" sl="328" sc="9" el="328" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="10" uspid="1261" ordinal="0" offset="42" path="0" />
+                                <BranchPoint vc="4" uspid="1262" ordinal="1" offset="42" path="1" />
+                                <BranchPoint vc="2" uspid="1263" ordinal="2" offset="62" path="0" />
+                                <BranchPoint vc="8" uspid="1264" ordinal="3" offset="62" path="1" />
+                                <BranchPoint vc="2" uspid="1265" ordinal="4" offset="131" path="0" />
+                                <BranchPoint vc="2" uspid="1266" ordinal="5" offset="131" path="1" />
+                                <BranchPoint vc="4" uspid="1267" ordinal="6" offset="164" path="0" />
+                                <BranchPoint vc="14" uspid="1268" ordinal="7" offset="164" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="4" uspid="1240" ordinal="0" offset="0" sl="309" sc="9" el="309" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="6" sequenceCoverage="100" branchCoverage="90.91" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="20" visitedSequencePoints="20" numBranchPoints="11" visitedBranchPoints="10" sequenceCoverage="100" branchCoverage="90.91" maxCyclomaticComplexity="6" minCyclomaticComplexity="6" />
+                            <MetadataToken>100663490</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Persistance.BasePersistance::GetTrackingMethod(System.String,System.String,System.Int32,System.UInt32&amp;)</Name>
+                            <FileRef uid="15" />
+                            <SequencePoints>
+                                <SequencePoint vc="2" uspid="1269" ordinal="0" offset="13" sl="331" sc="9" el="331" ec="10" />
+                                <SequencePoint vc="2" uspid="1270" ordinal="1" offset="14" sl="332" sc="13" el="332" ec="26" />
+                                <SequencePoint vc="2" uspid="1271" ordinal="2" offset="18" sl="333" sc="13" el="333" ec="20" />
+                                <SequencePoint vc="2" uspid="1272" ordinal="3" offset="19" sl="333" sc="36" el="335" ec="60" />
+                                <SequencePoint vc="2" uspid="1273" ordinal="4" offset="92" sl="333" sc="22" el="333" ec="32" />
+                                <SequencePoint vc="2" uspid="1274" ordinal="5" offset="100" sl="336" sc="13" el="336" ec="14" />
+                                <SequencePoint vc="2" uspid="1275" ordinal="6" offset="101" sl="337" sc="17" el="337" ec="24" />
+                                <SequencePoint vc="2" uspid="1276" ordinal="7" offset="102" sl="337" sc="47" el="337" ec="68" />
+                                <SequencePoint vc="2" uspid="1277" ordinal="8" offset="115" sl="337" sc="26" el="337" ec="43" />
+                                <SequencePoint vc="2" uspid="1278" ordinal="9" offset="121" sl="338" sc="17" el="338" ec="18" />
+                                <SequencePoint vc="2" uspid="1279" ordinal="10" offset="122" sl="339" sc="21" el="339" ec="70" />
+                                <SequencePoint vc="1" uspid="1280" ordinal="11" offset="140" sl="340" sc="21" el="340" ec="22" />
+                                <SequencePoint vc="1" uspid="1281" ordinal="12" offset="141" sl="341" sc="25" el="341" ec="59" />
+                                <SequencePoint vc="1" uspid="1282" ordinal="13" offset="150" sl="342" sc="25" el="342" ec="37" />
+                                <SequencePoint vc="1" uspid="1283" ordinal="14" offset="154" sl="344" sc="17" el="344" ec="18" />
+                                <SequencePoint vc="3" uspid="1284" ordinal="15" offset="161" sl="337" sc="44" el="337" ec="46" />
+                                <SequencePoint vc="1" uspid="1285" ordinal="16" offset="175" sl="345" sc="13" el="345" ec="14" />
+                                <SequencePoint vc="3" uspid="1286" ordinal="17" offset="176" sl="333" sc="33" el="333" ec="35" />
+                                <SequencePoint vc="1" uspid="1287" ordinal="18" offset="212" sl="347" sc="13" el="347" ec="26" />
+                                <SequencePoint vc="2" uspid="1288" ordinal="19" offset="217" sl="348" sc="9" el="348" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="1" uspid="1290" ordinal="0" offset="35" path="0" />
+                                <BranchPoint vc="1" uspid="1291" ordinal="1" offset="35" path="1" />
+                                <BranchPoint vc="1" uspid="1292" ordinal="2" offset="138" path="0" />
+                                <BranchPoint vc="1" uspid="1293" ordinal="3" offset="138" path="1" />
+                                <BranchPoint vc="1" uspid="1294" ordinal="4" offset="173" path="0" />
+                                <BranchPoint vc="2" uspid="1295" ordinal="5" offset="173" path="1" />
+                                <BranchPoint vc="1" uspid="1296" ordinal="6" offset="187" path="0" />
+                                <BranchPoint vc="2" uspid="1297" ordinal="7" offset="187" path="1" />
+                                <BranchPoint vc="2" uspid="1298" ordinal="8" offset="200" path="0" />
+                                <BranchPoint vc="0" uspid="1299" ordinal="9" offset="200" path="1" />
+                            </BranchPoints>
+                            <MethodPoint vc="2" uspid="1289" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663491</MetadataToken>
+                            <Name>OpenCover.Framework.Model.SkippedMethod OpenCover.Framework.Persistance.BasePersistance::&lt;Commit&gt;b__b(OpenCover.Framework.Model.SkippedMethod)</Name>
+                            <FileRef uid="15" />
+                            <SequencePoints>
+                                <SequencePoint vc="9" uspid="1300" ordinal="0" offset="0" sl="76" sc="80" el="76" ec="81" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="9" uspid="1300" ordinal="0" offset="0" sl="76" sc="80" el="76" ec="81" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="2" sequenceCoverage="100" branchCoverage="66.67" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="3" visitedBranchPoints="2" sequenceCoverage="100" branchCoverage="66.67" maxCyclomaticComplexity="2" minCyclomaticComplexity="2" />
+                            <MetadataToken>100663492</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Persistance.BasePersistance::&lt;RemoveEmptyClasses&gt;b__18(OpenCover.Framework.Model.Class)</Name>
+                            <FileRef uid="15" />
+                            <SequencePoints>
+                                <SequencePoint vc="10" uspid="1301" ordinal="0" offset="0" sl="143" sc="65" el="143" ec="111" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="10" uspid="1302" ordinal="0" offset="6" path="0" />
+                                <BranchPoint vc="0" uspid="1303" ordinal="1" offset="6" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="10" uspid="1301" ordinal="0" offset="0" sl="143" sc="65" el="143" ec="111" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663493</MetadataToken>
+                            <Name>&lt;&gt;f__AnonymousType0`2&lt;OpenCover.Framework.Model.File,OpenCover.Framework.Model.Class&gt; OpenCover.Framework.Persistance.BasePersistance::&lt;RemoveUnreferencedFiles&gt;b__1c(OpenCover.Framework.Model.File,OpenCover.Framework.Model.Class)</Name>
+                            <FileRef uid="15" />
+                            <SequencePoints>
+                                <SequencePoint vc="2" uspid="1304" ordinal="0" offset="0" sl="153" sc="48" el="153" ec="78" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="2" uspid="1304" ordinal="0" offset="0" sl="153" sc="48" el="153" ec="78" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="3" sequenceCoverage="100" branchCoverage="80" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="5" visitedBranchPoints="4" sequenceCoverage="100" branchCoverage="80" maxCyclomaticComplexity="3" minCyclomaticComplexity="3" />
+                            <MetadataToken>100663494</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Persistance.BasePersistance::&lt;RemoveUnreferencedFiles&gt;b__1d(&lt;&gt;f__AnonymousType0`2&lt;OpenCover.Framework.Model.File,OpenCover.Framework.Model.Class&gt;)</Name>
+                            <FileRef uid="15" />
+                            <SequencePoints>
+                                <SequencePoint vc="2" uspid="1305" ordinal="0" offset="13" sl="154" sc="39" el="154" ec="146" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="0" uspid="1307" ordinal="0" offset="30" path="0" />
+                                <BranchPoint vc="2" uspid="1308" ordinal="1" offset="30" path="1" />
+                                <BranchPoint vc="1" uspid="1309" ordinal="2" offset="44" path="0" />
+                                <BranchPoint vc="1" uspid="1310" ordinal="3" offset="44" path="1" />
+                            </BranchPoints>
+                            <MethodPoint vc="2" uspid="1306" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663495</MetadataToken>
+                            <Name>OpenCover.Framework.Model.File OpenCover.Framework.Persistance.BasePersistance::&lt;RemoveUnreferencedFiles&gt;b__20(&lt;&gt;f__AnonymousType0`2&lt;OpenCover.Framework.Model.File,OpenCover.Framework.Model.Class&gt;)</Name>
+                            <FileRef uid="15" />
+                            <SequencePoints>
+                                <SequencePoint vc="1" uspid="1311" ordinal="0" offset="0" sl="155" sc="40" el="155" ec="44" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="1" uspid="1311" ordinal="0" offset="0" sl="155" sc="40" el="155" ec="44" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663496</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Persistance.BasePersistance::&lt;RemoveUnreferencedFiles&gt;b__1e(OpenCover.Framework.Model.Method)</Name>
+                            <FileRef uid="15" />
+                            <SequencePoints>
+                                <SequencePoint vc="2" uspid="1312" ordinal="0" offset="0" sl="154" sc="82" el="154" ec="99" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="2" uspid="1312" ordinal="0" offset="0" sl="154" sc="82" el="154" ec="99" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="2" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="3" visitedBranchPoints="3" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="2" minCyclomaticComplexity="2" />
+                            <MetadataToken>100663497</MetadataToken>
+                            <Name>System.Collections.Generic.IEnumerable`1&lt;OpenCover.Framework.Model.Class&gt; OpenCover.Framework.Persistance.BasePersistance::&lt;PopulateInstrumentedPoints&gt;b__2c(OpenCover.Framework.Model.Module)</Name>
+                            <FileRef uid="15" />
+                            <SequencePoints>
+                                <SequencePoint vc="24" uspid="1313" ordinal="0" offset="0" sl="165" sc="56" el="165" ec="86" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="1" uspid="1314" ordinal="0" offset="7" path="0" />
+                                <BranchPoint vc="23" uspid="1315" ordinal="1" offset="7" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="24" uspid="1313" ordinal="0" offset="0" sl="165" sc="56" el="165" ec="86" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663498</MetadataToken>
+                            <Name>OpenCover.Framework.Model.Class OpenCover.Framework.Persistance.BasePersistance::&lt;PopulateInstrumentedPoints&gt;b__2d(OpenCover.Framework.Model.Module,OpenCover.Framework.Model.Class)</Name>
+                            <FileRef uid="15" />
+                            <SequencePoints>
+                                <SequencePoint vc="27" uspid="1316" ordinal="0" offset="0" sl="166" sc="48" el="166" ec="54" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="27" uspid="1316" ordinal="0" offset="0" sl="166" sc="48" el="166" ec="54" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="2" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="3" visitedBranchPoints="3" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="2" minCyclomaticComplexity="2" />
+                            <MetadataToken>100663499</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Persistance.BasePersistance::&lt;PopulateInstrumentedPoints&gt;b__2e(OpenCover.Framework.Model.Class)</Name>
+                            <FileRef uid="15" />
+                            <SequencePoints>
+                                <SequencePoint vc="27" uspid="1317" ordinal="0" offset="0" sl="167" sc="42" el="167" ec="98" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="1" uspid="1318" ordinal="0" offset="11" path="0" />
+                                <BranchPoint vc="26" uspid="1319" ordinal="1" offset="11" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="27" uspid="1317" ordinal="0" offset="0" sl="167" sc="42" el="167" ec="98" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="2" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="3" visitedBranchPoints="3" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="2" minCyclomaticComplexity="2" />
+                            <MetadataToken>100663500</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Persistance.BasePersistance::&lt;PopulateInstrumentedPoints&gt;b__30(OpenCover.Framework.Model.Class)</Name>
+                            <FileRef uid="15" />
+                            <SequencePoints>
+                                <SequencePoint vc="9" uspid="1320" ordinal="0" offset="0" sl="168" sc="42" el="168" ec="84" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="1" uspid="1321" ordinal="0" offset="11" path="0" />
+                                <BranchPoint vc="8" uspid="1322" ordinal="1" offset="11" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="9" uspid="1320" ordinal="0" offset="0" sl="168" sc="42" el="168" ec="84" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="2" sequenceCoverage="100" branchCoverage="66.67" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="3" visitedBranchPoints="2" sequenceCoverage="100" branchCoverage="66.67" maxCyclomaticComplexity="2" minCyclomaticComplexity="2" />
+                            <MetadataToken>100663501</MetadataToken>
+                            <Name>System.Collections.Generic.IEnumerable`1&lt;OpenCover.Framework.Model.Method&gt; OpenCover.Framework.Persistance.BasePersistance::&lt;PopulateInstrumentedPoints&gt;b__32(OpenCover.Framework.Model.Class)</Name>
+                            <FileRef uid="15" />
+                            <SequencePoints>
+                                <SequencePoint vc="1" uspid="1323" ordinal="0" offset="0" sl="169" sc="51" el="169" ec="110" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="1" uspid="1324" ordinal="0" offset="11" path="0" />
+                                <BranchPoint vc="0" uspid="1325" ordinal="1" offset="11" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="1" uspid="1323" ordinal="0" offset="0" sl="169" sc="51" el="169" ec="110" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663502</MetadataToken>
+                            <Name>OpenCover.Framework.Model.Method OpenCover.Framework.Persistance.BasePersistance::&lt;PopulateInstrumentedPoints&gt;b__34(OpenCover.Framework.Model.Class,OpenCover.Framework.Model.Method)</Name>
+                            <FileRef uid="15" />
+                            <SequencePoints>
+                                <SequencePoint vc="1" uspid="1326" ordinal="0" offset="0" sl="170" sc="43" el="170" ec="49" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="1" uspid="1326" ordinal="0" offset="0" sl="170" sc="43" el="170" ec="49" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663503</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Persistance.BasePersistance::&lt;PopulateInstrumentedPoints&gt;b__35(OpenCover.Framework.Model.Module)</Name>
+                            <FileRef uid="15" />
+                            <SequencePoints>
+                                <SequencePoint vc="24" uspid="1327" ordinal="0" offset="0" sl="175" sc="71" el="175" ec="103" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="24" uspid="1327" ordinal="0" offset="0" sl="175" sc="71" el="175" ec="103" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663504</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Persistance.BasePersistance::&lt;PopulateInstrumentedPoints&gt;b__36(OpenCover.Framework.Model.Class)</Name>
+                            <FileRef uid="15" />
+                            <SequencePoints>
+                                <SequencePoint vc="27" uspid="1328" ordinal="0" offset="0" sl="177" sc="84" el="177" ec="116" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="27" uspid="1328" ordinal="0" offset="0" sl="177" sc="84" el="177" ec="116" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663505</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Persistance.BasePersistance::&lt;PopulateInstrumentedPoints&gt;b__37(OpenCover.Framework.Model.Method)</Name>
+                            <FileRef uid="15" />
+                            <SequencePoints>
+                                <SequencePoint vc="29" uspid="1329" ordinal="0" offset="0" sl="180" sc="89" el="180" ec="121" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="29" uspid="1329" ordinal="0" offset="0" sl="180" sc="89" el="180" ec="121" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663506</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Persistance.BasePersistance::&lt;PopulateInstrumentedPoints&gt;b__38(OpenCover.Framework.Model.BranchPoint)</Name>
+                            <FileRef uid="15" />
+                            <SequencePoints>
+                                <SequencePoint vc="1" uspid="1330" ordinal="0" offset="0" sl="191" sc="87" el="191" ec="105" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="1" uspid="1330" ordinal="0" offset="0" sl="191" sc="87" el="191" ec="105" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663507</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Persistance.BasePersistance::&lt;PopulateInstrumentedPoints&gt;b__39(OpenCover.Framework.Model.SequencePoint)</Name>
+                            <FileRef uid="15" />
+                            <SequencePoints>
+                                <SequencePoint vc="14" uspid="1331" ordinal="0" offset="0" sl="193" sc="91" el="193" ec="109" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="14" uspid="1331" ordinal="0" offset="0" sl="193" sc="91" el="193" ec="109" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663508</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Persistance.BasePersistance::&lt;PopulateInstrumentedPoints&gt;b__2f(OpenCover.Framework.Model.Method)</Name>
+                            <FileRef uid="15" />
+                            <SequencePoints>
+                                <SequencePoint vc="29" uspid="1332" ordinal="0" offset="0" sl="167" sc="66" el="167" ec="97" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="29" uspid="1332" ordinal="0" offset="0" sl="167" sc="66" el="167" ec="97" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663509</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Persistance.BasePersistance::&lt;PopulateInstrumentedPoints&gt;b__31(OpenCover.Framework.Model.Method)</Name>
+                            <FileRef uid="15" />
+                            <SequencePoints>
+                                <SequencePoint vc="10" uspid="1333" ordinal="0" offset="0" sl="168" sc="66" el="168" ec="83" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="10" uspid="1333" ordinal="0" offset="0" sl="168" sc="66" el="168" ec="83" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663510</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Persistance.BasePersistance::&lt;PopulateInstrumentedPoints&gt;b__33(OpenCover.Framework.Model.Method)</Name>
+                            <FileRef uid="15" />
+                            <SequencePoints>
+                                <SequencePoint vc="2" uspid="1334" ordinal="0" offset="0" sl="169" sc="77" el="169" ec="109" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="2" uspid="1334" ordinal="0" offset="0" sl="169" sc="77" el="169" ec="109" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663511</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Persistance.BasePersistance::&lt;GetTrackingMethod&gt;b__4c(OpenCover.Framework.Model.Module)</Name>
+                            <FileRef uid="15" />
+                            <SequencePoints>
+                                <SequencePoint vc="2" uspid="1335" ordinal="0" offset="0" sl="334" sc="29" el="334" ec="53" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="2" uspid="1335" ordinal="0" offset="0" sl="334" sc="29" el="334" ec="53" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="2" visitedSequencePoints="2" numBranchPoints="2" visitedBranchPoints="2" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                    <FullName>OpenCover.Framework.Persistance.BasePersistance/&lt;&gt;c__DisplayClass5</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663735</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Persistance.BasePersistance/&lt;&gt;c__DisplayClass5::.ctor()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="32" uspid="1336" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663736</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Persistance.BasePersistance/&lt;&gt;c__DisplayClass5::&lt;PersistModule&gt;b__1(OpenCover.Framework.Model.Module)</Name>
+                            <FileRef uid="15" />
+                            <SequencePoints>
+                                <SequencePoint vc="1" uspid="1337" ordinal="0" offset="0" sl="40" sc="66" el="40" ec="99" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="1" uspid="1337" ordinal="0" offset="0" sl="40" sc="66" el="40" ec="99" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663737</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Persistance.BasePersistance/&lt;&gt;c__DisplayClass5::&lt;PersistModule&gt;b__2(System.String)</Name>
+                            <FileRef uid="15" />
+                            <SequencePoints>
+                                <SequencePoint vc="1" uspid="1338" ordinal="0" offset="0" sl="43" sc="56" el="43" ec="126" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="1" uspid="1338" ordinal="0" offset="0" sl="43" sc="56" el="43" ec="126" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="2" visitedSequencePoints="2" numBranchPoints="4" visitedBranchPoints="3" sequenceCoverage="100" branchCoverage="75" maxCyclomaticComplexity="2" minCyclomaticComplexity="1" />
+                    <FullName>OpenCover.Framework.Persistance.BasePersistance/&lt;&gt;c__DisplayClass9</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663738</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Persistance.BasePersistance/&lt;&gt;c__DisplayClass9::.ctor()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="2" uspid="1339" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="2" sequenceCoverage="100" branchCoverage="66.67" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="3" visitedBranchPoints="2" sequenceCoverage="100" branchCoverage="66.67" maxCyclomaticComplexity="2" minCyclomaticComplexity="2" />
+                            <MetadataToken>100663739</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Persistance.BasePersistance/&lt;&gt;c__DisplayClass9::&lt;IsTracking&gt;b__7(OpenCover.Framework.Model.Module)</Name>
+                            <FileRef uid="15" />
+                            <SequencePoints>
+                                <SequencePoint vc="2" uspid="1340" ordinal="0" offset="0" sl="64" sc="53" el="65" ec="53" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="2" uspid="1341" ordinal="0" offset="23" path="0" />
+                                <BranchPoint vc="0" uspid="1342" ordinal="1" offset="23" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="2" uspid="1340" ordinal="0" offset="0" sl="64" sc="53" el="65" ec="53" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663740</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Persistance.BasePersistance/&lt;&gt;c__DisplayClass9::&lt;IsTracking&gt;b__8(System.String)</Name>
+                            <FileRef uid="15" />
+                            <SequencePoints>
+                                <SequencePoint vc="2" uspid="1343" ordinal="0" offset="0" sl="64" sc="75" el="64" ec="143" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="2" uspid="1343" ordinal="0" offset="0" sl="64" sc="75" el="64" ec="143" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                    <FullName>OpenCover.Framework.Persistance.BasePersistance/&lt;&gt;c__DisplayClasse</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663741</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Persistance.BasePersistance/&lt;&gt;c__DisplayClasse::.ctor()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="3" uspid="1344" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663742</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Persistance.BasePersistance/&lt;&gt;c__DisplayClasse::&lt;RemoveSkippedModules&gt;b__d(OpenCover.Framework.Model.Module)</Name>
+                            <FileRef uid="15" />
+                            <SequencePoints>
+                                <SequencePoint vc="5" uspid="1345" ordinal="0" offset="0" sl="107" sc="42" el="107" ec="67" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="5" uspid="1345" ordinal="0" offset="0" sl="107" sc="42" el="107" ec="67" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                    <FullName>OpenCover.Framework.Persistance.BasePersistance/&lt;&gt;c__DisplayClass12</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663743</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Persistance.BasePersistance/&lt;&gt;c__DisplayClass12::.ctor()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="4" uspid="1346" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663744</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Persistance.BasePersistance/&lt;&gt;c__DisplayClass12::&lt;RemoveSkippedClasses&gt;b__10(OpenCover.Framework.Model.Class)</Name>
+                            <FileRef uid="15" />
+                            <SequencePoints>
+                                <SequencePoint vc="6" uspid="1347" ordinal="0" offset="0" sl="117" sc="57" el="117" ec="82" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="6" uspid="1347" ordinal="0" offset="0" sl="117" sc="57" el="117" ec="82" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                    <FullName>OpenCover.Framework.Persistance.BasePersistance/&lt;&gt;c__DisplayClass16</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663745</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Persistance.BasePersistance/&lt;&gt;c__DisplayClass16::.ctor()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="6" uspid="1348" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663746</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Persistance.BasePersistance/&lt;&gt;c__DisplayClass16::&lt;RemoveSkippedMethods&gt;b__14(OpenCover.Framework.Model.Method)</Name>
+                            <FileRef uid="15" />
+                            <SequencePoints>
+                                <SequencePoint vc="13" uspid="1349" ordinal="0" offset="0" sl="131" sc="61" el="131" ec="86" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="13" uspid="1349" ordinal="0" offset="0" sl="131" sc="61" el="131" ec="86" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="3" visitedBranchPoints="2" sequenceCoverage="100" branchCoverage="66.67" maxCyclomaticComplexity="2" minCyclomaticComplexity="1" />
+                    <FullName>OpenCover.Framework.Persistance.BasePersistance/&lt;&gt;c__DisplayClass25</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663753</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Persistance.BasePersistance/&lt;&gt;c__DisplayClass25::.ctor()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="4" uspid="1350" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="2" sequenceCoverage="100" branchCoverage="66.67" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="3" visitedBranchPoints="2" sequenceCoverage="100" branchCoverage="66.67" maxCyclomaticComplexity="2" minCyclomaticComplexity="2" />
+                            <MetadataToken>100663754</MetadataToken>
+                            <Name>System.Collections.Generic.IEnumerable`1&lt;OpenCover.Framework.Model.Class&gt; OpenCover.Framework.Persistance.BasePersistance/&lt;&gt;c__DisplayClass25::&lt;RemoveUnreferencedFiles&gt;b__1b(OpenCover.Framework.Model.File)</Name>
+                            <FileRef uid="15" />
+                            <SequencePoints>
+                                <SequencePoint vc="2" uspid="1351" ordinal="0" offset="0" sl="153" sc="48" el="153" ec="78" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="0" uspid="1352" ordinal="0" offset="12" path="0" />
+                                <BranchPoint vc="2" uspid="1353" ordinal="1" offset="12" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="2" uspid="1351" ordinal="0" offset="0" sl="153" sc="48" el="153" ec="78" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                    <FullName>OpenCover.Framework.Persistance.BasePersistance/&lt;&gt;c__DisplayClass28</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663755</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Persistance.BasePersistance/&lt;&gt;c__DisplayClass28::.ctor()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="2" uspid="1354" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663756</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Persistance.BasePersistance/&lt;&gt;c__DisplayClass28::&lt;RemoveUnreferencedFiles&gt;b__1f(OpenCover.Framework.Model.Method)</Name>
+                            <FileRef uid="15" />
+                            <SequencePoints>
+                                <SequencePoint vc="2" uspid="1355" ordinal="0" offset="0" sl="154" sc="110" el="154" ec="145" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="2" uspid="1355" ordinal="0" offset="0" sl="154" sc="110" el="154" ec="145" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="2" visitedSequencePoints="2" numBranchPoints="2" visitedBranchPoints="2" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                    <FullName>OpenCover.Framework.Persistance.BasePersistance/&lt;&gt;c__DisplayClass4a</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663757</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Persistance.BasePersistance/&lt;&gt;c__DisplayClass4a::.ctor()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="8" uspid="1356" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663758</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Persistance.BasePersistance/&lt;&gt;c__DisplayClass4a::&lt;GetMethod&gt;b__48(OpenCover.Framework.Model.Module)</Name>
+                            <FileRef uid="15" />
+                            <SequencePoints>
+                                <SequencePoint vc="8" uspid="1357" ordinal="0" offset="0" sl="292" sc="70" el="292" ec="161" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="8" uspid="1357" ordinal="0" offset="0" sl="292" sc="70" el="292" ec="161" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663759</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Persistance.BasePersistance/&lt;&gt;c__DisplayClass4a::&lt;GetMethod&gt;b__49(System.String)</Name>
+                            <FileRef uid="15" />
+                            <SequencePoints>
+                                <SequencePoint vc="7" uspid="1358" ordinal="0" offset="0" sl="292" sc="92" el="292" ec="160" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="7" uspid="1358" ordinal="0" offset="0" sl="292" sc="92" el="292" ec="160" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                    <FullName>OpenCover.Framework.Persistance.BasePersistance/&lt;&gt;c__DisplayClass4f</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663760</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Persistance.BasePersistance/&lt;&gt;c__DisplayClass4f::.ctor()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="2" uspid="1359" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663761</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Persistance.BasePersistance/&lt;&gt;c__DisplayClass4f::&lt;GetTrackingMethod&gt;b__4d(OpenCover.Framework.Model.Module)</Name>
+                            <FileRef uid="15" />
+                            <SequencePoints>
+                                <SequencePoint vc="2" uspid="1360" ordinal="0" offset="0" sl="335" sc="29" el="335" ec="59" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="2" uspid="1360" ordinal="0" offset="0" sl="335" sc="29" el="335" ec="59" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                    <FullName>OpenCover.Framework.ExcludeFromCoverageAttribute</FullName>
+                    <Methods>
+                        <Method visited="false" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663512</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.ExcludeFromCoverageAttribute::.ctor()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="0" uspid="1361" ordinal="0" offset="0" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="29" visitedSequencePoints="21" numBranchPoints="6" visitedBranchPoints="5" sequenceCoverage="72.41" branchCoverage="83.33" maxCyclomaticComplexity="2" minCyclomaticComplexity="1" />
+                    <FullName>OpenCover.Framework.Persistance.FilePersistance</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="4" visitedSequencePoints="4" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663513</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Persistance.FilePersistance::.ctor(OpenCover.Framework.ICommandLine,log4net.ILog)</Name>
+                            <FileRef uid="25" />
+                            <SequencePoints>
+                                <SequencePoint vc="1" uspid="1362" ordinal="0" offset="0" sl="30" sc="9" el="30" ec="98" />
+                                <SequencePoint vc="1" uspid="1363" ordinal="1" offset="9" sl="31" sc="9" el="31" ec="10" />
+                                <SequencePoint vc="1" uspid="1364" ordinal="2" offset="10" sl="32" sc="13" el="32" ec="30" />
+                                <SequencePoint vc="1" uspid="1365" ordinal="3" offset="17" sl="33" sc="9" el="33" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="1" uspid="1362" ordinal="0" offset="0" sl="30" sc="9" el="30" ec="98" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="3" visitedSequencePoints="3" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663514</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Persistance.FilePersistance::Initialise(System.String)</Name>
+                            <FileRef uid="25" />
+                            <SequencePoints>
+                                <SequencePoint vc="1" uspid="1366" ordinal="0" offset="0" sl="42" sc="9" el="42" ec="10" />
+                                <SequencePoint vc="1" uspid="1367" ordinal="1" offset="1" sl="43" sc="13" el="43" ec="34" />
+                                <SequencePoint vc="1" uspid="1368" ordinal="2" offset="8" sl="44" sc="9" el="44" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="1" uspid="1366" ordinal="0" offset="0" sl="42" sc="9" el="42" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="2" sequenceCoverage="46.67" branchCoverage="66.67" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="15" visitedSequencePoints="7" numBranchPoints="3" visitedBranchPoints="2" sequenceCoverage="46.67" branchCoverage="66.67" maxCyclomaticComplexity="2" minCyclomaticComplexity="2" />
+                            <MetadataToken>100663515</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Persistance.FilePersistance::Commit()</Name>
+                            <FileRef uid="25" />
+                            <SequencePoints>
+                                <SequencePoint vc="1" uspid="1369" ordinal="0" offset="0" sl="47" sc="9" el="47" ec="10" />
+                                <SequencePoint vc="1" uspid="1370" ordinal="1" offset="1" sl="48" sc="13" el="48" ec="39" />
+                                <SequencePoint vc="0" uspid="1371" ordinal="2" offset="19" sl="49" sc="13" el="49" ec="14" />
+                                <SequencePoint vc="0" uspid="1372" ordinal="3" offset="20" sl="50" sc="17" el="50" ec="47" />
+                                <SequencePoint vc="0" uspid="1373" ordinal="4" offset="37" sl="51" sc="13" el="51" ec="14" />
+                                <SequencePoint vc="1" uspid="1374" ordinal="5" offset="38" sl="54" sc="13" el="54" ec="14" />
+                                <SequencePoint vc="1" uspid="1375" ordinal="6" offset="39" sl="55" sc="17" el="55" ec="31" />
+                                <SequencePoint vc="1" uspid="1376" ordinal="7" offset="46" sl="56" sc="17" el="56" ec="36" />
+                                <SequencePoint vc="1" uspid="1377" ordinal="8" offset="53" sl="57" sc="13" el="57" ec="14" />
+                                <SequencePoint vc="0" uspid="1378" ordinal="9" offset="56" sl="58" sc="13" el="58" ec="33" />
+                                <SequencePoint vc="0" uspid="1379" ordinal="10" offset="57" sl="59" sc="13" el="59" ec="14" />
+                                <SequencePoint vc="0" uspid="1380" ordinal="11" offset="58" sl="60" sc="17" el="60" ec="45" />
+                                <SequencePoint vc="0" uspid="1381" ordinal="12" offset="70" sl="61" sc="17" el="61" ec="48" />
+                                <SequencePoint vc="0" uspid="1382" ordinal="13" offset="82" sl="62" sc="13" el="62" ec="14" />
+                                <SequencePoint vc="1" uspid="1383" ordinal="14" offset="86" sl="63" sc="9" el="63" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="0" uspid="1384" ordinal="0" offset="17" path="0" />
+                                <BranchPoint vc="1" uspid="1385" ordinal="1" offset="17" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="1" uspid="1369" ordinal="0" offset="0" sl="47" sc="9" el="47" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="7" visitedSequencePoints="7" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663516</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Persistance.FilePersistance::SaveCoverageFile()</Name>
+                            <FileRef uid="25" />
+                            <SequencePoints>
+                                <SequencePoint vc="1" uspid="1386" ordinal="0" offset="0" sl="66" sc="9" el="66" ec="10" />
+                                <SequencePoint vc="1" uspid="1387" ordinal="1" offset="1" sl="67" sc="13" el="68" ec="110" />
+                                <SequencePoint vc="1" uspid="1388" ordinal="2" offset="64" sl="69" sc="13" el="69" ec="65" />
+                                <SequencePoint vc="1" uspid="1389" ordinal="3" offset="77" sl="70" sc="13" el="70" ec="67" />
+                                <SequencePoint vc="1" uspid="1390" ordinal="4" offset="89" sl="71" sc="13" el="71" ec="59" />
+                                <SequencePoint vc="1" uspid="1391" ordinal="5" offset="103" sl="72" sc="13" el="72" ec="28" />
+                                <SequencePoint vc="1" uspid="1392" ordinal="6" offset="110" sl="73" sc="9" el="73" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="1" uspid="1386" ordinal="0" offset="0" sl="66" sc="9" el="66" ec="10" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="11" visitedSequencePoints="11" numBranchPoints="4" visitedBranchPoints="4" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="2" minCyclomaticComplexity="1" />
+                    <FullName>OpenCover.Framework.FilterHelper</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="3" visitedSequencePoints="3" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663526</MetadataToken>
+                            <Name>System.String OpenCover.Framework.FilterHelper::WrapWithAnchors(System.String)</Name>
+                            <FileRef uid="26" />
+                            <SequencePoints>
+                                <SequencePoint vc="44" uspid="1393" ordinal="0" offset="0" sl="88" sc="9" el="88" ec="10" />
+                                <SequencePoint vc="44" uspid="1394" ordinal="1" offset="1" sl="89" sc="13" el="89" ec="49" />
+                                <SequencePoint vc="44" uspid="1395" ordinal="2" offset="15" sl="90" sc="9" el="90" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="44" uspid="1393" ordinal="0" offset="0" sl="88" sc="9" el="88" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="2" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="8" visitedSequencePoints="8" numBranchPoints="3" visitedBranchPoints="3" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="2" minCyclomaticComplexity="2" />
+                            <MetadataToken>100663527</MetadataToken>
+                            <Name>System.String OpenCover.Framework.FilterHelper::ValidateAndEscape(System.String,System.String)</Name>
+                            <FileRef uid="26" />
+                            <SequencePoints>
+                                <SequencePoint vc="79" uspid="1396" ordinal="0" offset="0" sl="93" sc="9" el="93" ec="10" />
+                                <SequencePoint vc="79" uspid="1397" ordinal="1" offset="1" sl="94" sc="13" el="94" ec="65" />
+                                <SequencePoint vc="5" uspid="1398" ordinal="2" offset="20" sl="94" sc="66" el="94" ec="172" />
+                                <SequencePoint vc="74" uspid="1399" ordinal="3" offset="37" sl="95" sc="13" el="95" ec="48" />
+                                <SequencePoint vc="74" uspid="1400" ordinal="4" offset="55" sl="96" sc="13" el="96" ec="48" />
+                                <SequencePoint vc="74" uspid="1401" ordinal="5" offset="73" sl="97" sc="13" el="97" ec="48" />
+                                <SequencePoint vc="74" uspid="1402" ordinal="6" offset="91" sl="98" sc="13" el="98" ec="26" />
+                                <SequencePoint vc="74" uspid="1403" ordinal="7" offset="95" sl="99" sc="9" el="99" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="5" uspid="1404" ordinal="0" offset="18" path="0" />
+                                <BranchPoint vc="74" uspid="1405" ordinal="1" offset="18" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="79" uspid="1396" ordinal="0" offset="0" sl="93" sc="9" el="93" ec="10" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="170" visitedSequencePoints="165" numBranchPoints="116" visitedBranchPoints="101" sequenceCoverage="97.06" branchCoverage="87.07" maxCyclomaticComplexity="17" minCyclomaticComplexity="1" />
+                    <FullName>OpenCover.Framework.Filter</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663528</MetadataToken>
+                            <Name>System.Collections.Generic.IList`1&lt;System.Collections.Generic.KeyValuePair`2&lt;System.String,System.String&gt;&gt; OpenCover.Framework.Filter::get_InclusionFilter()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="41" uspid="1406" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663529</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Filter::set_InclusionFilter(System.Collections.Generic.IList`1&lt;System.Collections.Generic.KeyValuePair`2&lt;System.String,System.String&gt;&gt;)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="59" uspid="1407" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663530</MetadataToken>
+                            <Name>System.Collections.Generic.IList`1&lt;System.Collections.Generic.KeyValuePair`2&lt;System.String,System.String&gt;&gt; OpenCover.Framework.Filter::get_ExclusionFilter()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="52" uspid="1408" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663531</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Filter::set_ExclusionFilter(System.Collections.Generic.IList`1&lt;System.Collections.Generic.KeyValuePair`2&lt;System.String,System.String&gt;&gt;)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="59" uspid="1409" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663532</MetadataToken>
+                            <Name>System.Collections.Generic.IList`1&lt;System.Lazy`1&lt;System.Text.RegularExpressions.Regex&gt;&gt; OpenCover.Framework.Filter::get_ExcludedAttributes()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="43" uspid="1410" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663533</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Filter::set_ExcludedAttributes(System.Collections.Generic.IList`1&lt;System.Lazy`1&lt;System.Text.RegularExpressions.Regex&gt;&gt;)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="59" uspid="1411" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663534</MetadataToken>
+                            <Name>System.Collections.Generic.IList`1&lt;System.Lazy`1&lt;System.Text.RegularExpressions.Regex&gt;&gt; OpenCover.Framework.Filter::get_ExcludedFiles()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="13" uspid="1412" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663535</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Filter::set_ExcludedFiles(System.Collections.Generic.IList`1&lt;System.Lazy`1&lt;System.Text.RegularExpressions.Regex&gt;&gt;)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="59" uspid="1413" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663536</MetadataToken>
+                            <Name>System.Collections.Generic.IList`1&lt;System.Lazy`1&lt;System.Text.RegularExpressions.Regex&gt;&gt; OpenCover.Framework.Filter::get_TestFiles()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="10" uspid="1414" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663537</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Filter::set_TestFiles(System.Collections.Generic.IList`1&lt;System.Lazy`1&lt;System.Text.RegularExpressions.Regex&gt;&gt;)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="59" uspid="1415" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="8" visitedSequencePoints="8" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663538</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Filter::.ctor()</Name>
+                            <FileRef uid="26" />
+                            <SequencePoints>
+                                <SequencePoint vc="59" uspid="1416" ordinal="0" offset="0" sl="134" sc="9" el="134" ec="24" />
+                                <SequencePoint vc="59" uspid="1417" ordinal="1" offset="7" sl="135" sc="9" el="135" ec="10" />
+                                <SequencePoint vc="59" uspid="1418" ordinal="2" offset="8" sl="136" sc="13" el="136" ec="72" />
+                                <SequencePoint vc="59" uspid="1419" ordinal="3" offset="20" sl="137" sc="13" el="137" ec="72" />
+                                <SequencePoint vc="59" uspid="1420" ordinal="4" offset="32" sl="138" sc="13" el="138" ec="58" />
+                                <SequencePoint vc="59" uspid="1421" ordinal="5" offset="44" sl="139" sc="13" el="139" ec="53" />
+                                <SequencePoint vc="59" uspid="1422" ordinal="6" offset="56" sl="140" sc="13" el="140" ec="49" />
+                                <SequencePoint vc="59" uspid="1423" ordinal="7" offset="68" sl="141" sc="9" el="141" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="59" uspid="1416" ordinal="0" offset="0" sl="134" sc="9" el="134" ec="24" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="4" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="12" visitedSequencePoints="12" numBranchPoints="7" visitedBranchPoints="7" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="4" minCyclomaticComplexity="4" />
+                            <MetadataToken>100663539</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Filter::UseAssembly(System.String)</Name>
+                            <FileRef uid="26" />
+                            <SequencePoints>
+                                <SequencePoint vc="7" uspid="1424" ordinal="0" offset="13" sl="144" sc="9" el="144" ec="10" />
+                                <SequencePoint vc="7" uspid="1425" ordinal="1" offset="14" sl="145" sc="13" el="145" ec="154" />
+                                <SequencePoint vc="2" uspid="1426" ordinal="2" offset="44" sl="146" sc="13" el="146" ec="14" />
+                                <SequencePoint vc="2" uspid="1427" ordinal="3" offset="45" sl="147" sc="17" el="147" ec="30" />
+                                <SequencePoint vc="5" uspid="1428" ordinal="4" offset="49" sl="150" sc="13" el="150" ec="154" />
+                                <SequencePoint vc="1" uspid="1429" ordinal="5" offset="79" sl="151" sc="13" el="151" ec="14" />
+                                <SequencePoint vc="1" uspid="1430" ordinal="6" offset="80" sl="152" sc="17" el="152" ec="29" />
+                                <SequencePoint vc="4" uspid="1431" ordinal="7" offset="84" sl="155" sc="13" el="155" ec="124" />
+                                <SequencePoint vc="2" uspid="1432" ordinal="8" offset="114" sl="156" sc="13" el="156" ec="14" />
+                                <SequencePoint vc="2" uspid="1433" ordinal="9" offset="115" sl="157" sc="17" el="157" ec="29" />
+                                <SequencePoint vc="2" uspid="1434" ordinal="10" offset="119" sl="160" sc="13" el="160" ec="26" />
+                                <SequencePoint vc="7" uspid="1435" ordinal="11" offset="123" sl="161" sc="9" el="161" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="2" uspid="1437" ordinal="0" offset="42" path="0" />
+                                <BranchPoint vc="5" uspid="1438" ordinal="1" offset="42" path="1" />
+                                <BranchPoint vc="1" uspid="1439" ordinal="2" offset="77" path="0" />
+                                <BranchPoint vc="4" uspid="1440" ordinal="3" offset="77" path="1" />
+                                <BranchPoint vc="2" uspid="1441" ordinal="4" offset="112" path="0" />
+                                <BranchPoint vc="2" uspid="1442" ordinal="5" offset="112" path="1" />
+                            </BranchPoints>
+                            <MethodPoint vc="7" uspid="1436" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="6" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="15" visitedSequencePoints="15" numBranchPoints="11" visitedBranchPoints="11" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="6" minCyclomaticComplexity="6" />
+                            <MetadataToken>100663540</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Filter::InstrumentClass(System.String,System.String)</Name>
+                            <FileRef uid="26" />
+                            <SequencePoints>
+                                <SequencePoint vc="15" uspid="1443" ordinal="0" offset="20" sl="164" sc="9" el="164" ec="10" />
+                                <SequencePoint vc="15" uspid="1444" ordinal="1" offset="21" sl="165" sc="13" el="165" ec="87" />
+                                <SequencePoint vc="2" uspid="1445" ordinal="2" offset="56" sl="166" sc="13" el="166" ec="14" />
+                                <SequencePoint vc="2" uspid="1446" ordinal="3" offset="57" sl="167" sc="17" el="167" ec="30" />
+                                <SequencePoint vc="13" uspid="1447" ordinal="4" offset="64" sl="170" sc="13" el="171" ec="139" />
+                                <SequencePoint vc="4" uspid="1448" ordinal="5" offset="94" sl="172" sc="13" el="172" ec="14" />
+                                <SequencePoint vc="4" uspid="1449" ordinal="6" offset="95" sl="173" sc="17" el="173" ec="30" />
+                                <SequencePoint vc="9" uspid="1450" ordinal="7" offset="99" sl="176" sc="13" el="178" ec="108" />
+                                <SequencePoint vc="1" uspid="1451" ordinal="8" offset="146" sl="179" sc="13" el="179" ec="14" />
+                                <SequencePoint vc="1" uspid="1452" ordinal="9" offset="147" sl="180" sc="17" el="180" ec="30" />
+                                <SequencePoint vc="8" uspid="1453" ordinal="10" offset="151" sl="183" sc="13" el="185" ec="108" />
+                                <SequencePoint vc="3" uspid="1454" ordinal="11" offset="198" sl="186" sc="13" el="186" ec="14" />
+                                <SequencePoint vc="3" uspid="1455" ordinal="12" offset="199" sl="187" sc="17" el="187" ec="29" />
+                                <SequencePoint vc="5" uspid="1456" ordinal="13" offset="203" sl="190" sc="13" el="190" ec="26" />
+                                <SequencePoint vc="15" uspid="1457" ordinal="14" offset="207" sl="191" sc="9" el="191" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="14" uspid="1459" ordinal="0" offset="32" path="0" />
+                                <BranchPoint vc="1" uspid="1460" ordinal="1" offset="32" path="1" />
+                                <BranchPoint vc="2" uspid="1461" ordinal="2" offset="54" path="0" />
+                                <BranchPoint vc="13" uspid="1462" ordinal="3" offset="54" path="1" />
+                                <BranchPoint vc="4" uspid="1463" ordinal="4" offset="92" path="0" />
+                                <BranchPoint vc="9" uspid="1464" ordinal="5" offset="92" path="1" />
+                                <BranchPoint vc="1" uspid="1465" ordinal="6" offset="144" path="0" />
+                                <BranchPoint vc="8" uspid="1466" ordinal="7" offset="144" path="1" />
+                                <BranchPoint vc="3" uspid="1467" ordinal="8" offset="196" path="0" />
+                                <BranchPoint vc="5" uspid="1468" ordinal="9" offset="196" path="1" />
+                            </BranchPoints>
+                            <MethodPoint vc="15" uspid="1458" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="3" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="9" visitedSequencePoints="9" numBranchPoints="5" visitedBranchPoints="5" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="3" minCyclomaticComplexity="3" />
+                            <MetadataToken>100663541</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Filter::AddFilter(System.String)</Name>
+                            <FileRef uid="26" />
+                            <SequencePoints>
+                                <SequencePoint vc="40" uspid="1469" ordinal="0" offset="0" sl="194" sc="9" el="194" ec="10" />
+                                <SequencePoint vc="40" uspid="1470" ordinal="1" offset="1" sl="198" sc="13" el="198" ec="102" />
+                                <SequencePoint vc="34" uspid="1471" ordinal="2" offset="14" sl="200" sc="13" el="200" ec="61" />
+                                <SequencePoint vc="31" uspid="1472" ordinal="3" offset="26" sl="201" sc="13" el="201" ec="55" />
+                                <SequencePoint vc="29" uspid="1473" ordinal="4" offset="38" sl="203" sc="13" el="203" ec="52" />
+                                <SequencePoint vc="17" uspid="1474" ordinal="5" offset="49" sl="204" sc="17" el="204" ec="96" />
+                                <SequencePoint vc="29" uspid="1475" ordinal="6" offset="68" sl="206" sc="13" el="206" ec="52" />
+                                <SequencePoint vc="12" uspid="1476" ordinal="7" offset="79" sl="207" sc="17" el="207" ec="96" />
+                                <SequencePoint vc="29" uspid="1477" ordinal="8" offset="98" sl="208" sc="9" el="208" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="17" uspid="1478" ordinal="0" offset="47" path="0" />
+                                <BranchPoint vc="12" uspid="1479" ordinal="1" offset="47" path="1" />
+                                <BranchPoint vc="12" uspid="1480" ordinal="2" offset="77" path="0" />
+                                <BranchPoint vc="17" uspid="1481" ordinal="3" offset="77" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="40" uspid="1469" ordinal="0" offset="0" sl="194" sc="9" el="194" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="5" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="16" visitedSequencePoints="16" numBranchPoints="7" visitedBranchPoints="7" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="5" minCyclomaticComplexity="5" />
+                            <MetadataToken>100663542</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Filter::GetAssemblyClassName(System.String,OpenCover.Framework.FilterType&amp;,System.String&amp;,System.String&amp;)</Name>
+                            <FileRef uid="26" />
+                            <SequencePoints>
+                                <SequencePoint vc="40" uspid="1482" ordinal="0" offset="0" sl="211" sc="9" el="211" ec="10" />
+                                <SequencePoint vc="40" uspid="1483" ordinal="1" offset="1" sl="212" sc="13" el="212" ec="38" />
+                                <SequencePoint vc="40" uspid="1484" ordinal="2" offset="8" sl="213" sc="13" el="213" ec="41" />
+                                <SequencePoint vc="40" uspid="1485" ordinal="3" offset="15" sl="214" sc="13" el="214" ec="95" />
+                                <SequencePoint vc="40" uspid="1486" ordinal="4" offset="26" sl="215" sc="13" el="215" ec="56" />
+                                <SequencePoint vc="40" uspid="1487" ordinal="5" offset="34" sl="216" sc="13" el="216" ec="31" />
+                                <SequencePoint vc="35" uspid="1488" ordinal="6" offset="47" sl="217" sc="13" el="217" ec="14" />
+                                <SequencePoint vc="35" uspid="1489" ordinal="7" offset="48" sl="218" sc="17" el="218" ec="110" />
+                                <SequencePoint vc="35" uspid="1490" ordinal="8" offset="88" sl="219" sc="17" el="219" ec="63" />
+                                <SequencePoint vc="35" uspid="1491" ordinal="9" offset="111" sl="220" sc="17" el="220" ec="57" />
+                                <SequencePoint vc="35" uspid="1492" ordinal="10" offset="134" sl="222" sc="17" el="222" ec="61" />
+                                <SequencePoint vc="1" uspid="1493" ordinal="11" offset="148" sl="223" sc="21" el="223" ec="193" />
+                                <SequencePoint vc="34" uspid="1494" ordinal="12" offset="165" sl="224" sc="13" el="224" ec="14" />
+                                <SequencePoint vc="5" uspid="1495" ordinal="13" offset="168" sl="226" sc="13" el="226" ec="14" />
+                                <SequencePoint vc="5" uspid="1496" ordinal="14" offset="169" sl="227" sc="17" el="227" ec="189" />
+                                <SequencePoint vc="34" uspid="1497" ordinal="15" offset="186" sl="229" sc="9" el="229" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="35" uspid="1498" ordinal="0" offset="45" path="0" />
+                                <BranchPoint vc="5" uspid="1499" ordinal="1" offset="45" path="1" />
+                                <BranchPoint vc="15" uspid="1500" ordinal="2" offset="80" path="0" />
+                                <BranchPoint vc="20" uspid="1501" ordinal="3" offset="80" path="1" />
+                                <BranchPoint vc="1" uspid="1502" ordinal="4" offset="146" path="0" />
+                                <BranchPoint vc="34" uspid="1503" ordinal="5" offset="146" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="40" uspid="1482" ordinal="0" offset="0" sl="211" sc="9" el="211" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="5" sequenceCoverage="100" branchCoverage="88.89" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="12" visitedSequencePoints="12" numBranchPoints="9" visitedBranchPoints="8" sequenceCoverage="100" branchCoverage="88.89" maxCyclomaticComplexity="5" minCyclomaticComplexity="5" />
+                            <MetadataToken>100663543</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Filter::AddAttributeExclusionFilters(System.String[])</Name>
+                            <FileRef uid="26" />
+                            <SequencePoints>
+                                <SequencePoint vc="8" uspid="1504" ordinal="0" offset="0" sl="232" sc="9" el="232" ec="10" />
+                                <SequencePoint vc="8" uspid="1505" ordinal="1" offset="1" sl="233" sc="13" el="233" ec="42" />
+                                <SequencePoint vc="1" uspid="1506" ordinal="2" offset="12" sl="234" sc="17" el="234" ec="24" />
+                                <SequencePoint vc="7" uspid="1507" ordinal="3" offset="17" sl="235" sc="13" el="235" ec="20" />
+                                <SequencePoint vc="7" uspid="1508" ordinal="4" offset="18" sl="235" sc="44" el="235" ec="82" />
+                                <SequencePoint vc="7" uspid="1509" ordinal="5" offset="63" sl="235" sc="22" el="235" ec="40" />
+                                <SequencePoint vc="7" uspid="1510" ordinal="6" offset="76" sl="236" sc="13" el="236" ec="14" />
+                                <SequencePoint vc="7" uspid="1511" ordinal="7" offset="77" sl="237" sc="17" el="237" ec="83" />
+                                <SequencePoint vc="7" uspid="1512" ordinal="8" offset="99" sl="238" sc="17" el="238" ec="82" />
+                                <SequencePoint vc="7" uspid="1513" ordinal="9" offset="128" sl="239" sc="13" el="239" ec="14" />
+                                <SequencePoint vc="14" uspid="1514" ordinal="10" offset="129" sl="235" sc="41" el="235" ec="43" />
+                                <SequencePoint vc="8" uspid="1515" ordinal="11" offset="158" sl="240" sc="9" el="240" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="1" uspid="1516" ordinal="0" offset="10" path="0" />
+                                <BranchPoint vc="7" uspid="1517" ordinal="1" offset="10" path="1" />
+                                <BranchPoint vc="1" uspid="1518" ordinal="2" offset="24" path="0" />
+                                <BranchPoint vc="6" uspid="1519" ordinal="3" offset="24" path="1" />
+                                <BranchPoint vc="7" uspid="1520" ordinal="4" offset="137" path="0" />
+                                <BranchPoint vc="7" uspid="1521" ordinal="5" offset="137" path="1" />
+                                <BranchPoint vc="7" uspid="1522" ordinal="6" offset="147" path="0" />
+                                <BranchPoint vc="0" uspid="1523" ordinal="7" offset="147" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="8" uspid="1504" ordinal="0" offset="0" sl="232" sc="9" el="232" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="17" sequenceCoverage="91.11" branchCoverage="75.76" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="45" visitedSequencePoints="41" numBranchPoints="33" visitedBranchPoints="25" sequenceCoverage="91.11" branchCoverage="75.76" maxCyclomaticComplexity="17" minCyclomaticComplexity="17" />
+                            <MetadataToken>100663544</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Filter::ExcludeByAttribute(Mono.Cecil.IMemberDefinition)</Name>
+                            <FileRef uid="26" />
+                            <SequencePoints>
+                                <SequencePoint vc="19" uspid="1524" ordinal="0" offset="0" sl="249" sc="9" el="249" ec="10" />
+                                <SequencePoint vc="19" uspid="1525" ordinal="1" offset="1" sl="250" sc="13" el="250" ec="47" />
+                                <SequencePoint vc="1" uspid="1526" ordinal="2" offset="24" sl="251" sc="17" el="251" ec="30" />
+                                <SequencePoint vc="18" uspid="1527" ordinal="3" offset="32" sl="252" sc="13" el="252" ec="45" />
+                                <SequencePoint vc="4" uspid="1528" ordinal="4" offset="44" sl="253" sc="17" el="253" ec="30" />
+                                <SequencePoint vc="14" uspid="1529" ordinal="5" offset="52" sl="254" sc="13" el="254" ec="20" />
+                                <SequencePoint vc="14" uspid="1530" ordinal="6" offset="53" sl="254" sc="46" el="254" ec="64" />
+                                <SequencePoint vc="14" uspid="1531" ordinal="7" offset="68" sl="254" sc="22" el="254" ec="42" />
+                                <SequencePoint vc="14" uspid="1532" ordinal="8" offset="76" sl="255" sc="13" el="255" ec="14" />
+                                <SequencePoint vc="14" uspid="1533" ordinal="9" offset="77" sl="256" sc="17" el="256" ec="24" />
+                                <SequencePoint vc="14" uspid="1534" ordinal="10" offset="78" sl="256" sc="49" el="256" ec="72" />
+                                <SequencePoint vc="13" uspid="1535" ordinal="11" offset="93" sl="256" sc="26" el="256" ec="45" />
+                                <SequencePoint vc="13" uspid="1536" ordinal="12" offset="101" sl="257" sc="17" el="257" ec="18" />
+                                <SequencePoint vc="13" uspid="1537" ordinal="13" offset="102" sl="258" sc="21" el="258" ec="102" />
+                                <SequencePoint vc="7" uspid="1538" ordinal="14" offset="138" sl="259" sc="25" el="259" ec="37" />
+                                <SequencePoint vc="6" uspid="1539" ordinal="15" offset="146" sl="260" sc="17" el="260" ec="18" />
+                                <SequencePoint vc="20" uspid="1540" ordinal="16" offset="147" sl="256" sc="46" el="256" ec="48" />
+                                <SequencePoint vc="7" uspid="1541" ordinal="17" offset="178" sl="261" sc="13" el="261" ec="14" />
+                                <SequencePoint vc="21" uspid="1542" ordinal="18" offset="179" sl="254" sc="43" el="254" ec="45" />
+                                <SequencePoint vc="7" uspid="1543" ordinal="19" offset="215" sl="262" sc="13" el="262" ec="77" />
+                                <SequencePoint vc="7" uspid="1544" ordinal="20" offset="268" sl="263" sc="13" el="263" ec="14" />
+                                <SequencePoint vc="7" uspid="1545" ordinal="21" offset="269" sl="264" sc="17" el="264" ec="76" />
+                                <SequencePoint vc="7" uspid="1546" ordinal="22" offset="286" sl="265" sc="17" el="265" ec="50" />
+                                <SequencePoint vc="0" uspid="1547" ordinal="23" offset="314" sl="265" sc="51" el="265" ec="64" />
+                                <SequencePoint vc="7" uspid="1548" ordinal="24" offset="322" sl="266" sc="17" el="266" ec="55" />
+                                <SequencePoint vc="7" uspid="1549" ordinal="25" offset="350" sl="267" sc="17" el="267" ec="95" />
+                                <SequencePoint vc="7" uspid="1550" ordinal="26" offset="386" sl="268" sc="17" el="268" ec="36" />
+                                <SequencePoint vc="6" uspid="1551" ordinal="27" offset="405" sl="269" sc="17" el="269" ec="18" />
+                                <SequencePoint vc="6" uspid="1552" ordinal="28" offset="406" sl="270" sc="21" el="270" ec="41" />
+                                <SequencePoint vc="2" uspid="1553" ordinal="29" offset="427" sl="271" sc="21" el="271" ec="22" />
+                                <SequencePoint vc="2" uspid="1554" ordinal="30" offset="428" sl="272" sc="25" el="272" ec="116" />
+                                <SequencePoint vc="2" uspid="1555" ordinal="31" offset="468" sl="273" sc="25" el="273" ec="47" />
+                                <SequencePoint vc="2" uspid="1556" ordinal="32" offset="478" sl="273" sc="48" el="273" ec="85" />
+                                <SequencePoint vc="0" uspid="1557" ordinal="33" offset="489" sl="274" sc="21" el="274" ec="22" />
+                                <SequencePoint vc="4" uspid="1558" ordinal="34" offset="492" sl="275" sc="26" el="275" ec="46" />
+                                <SequencePoint vc="2" uspid="1559" ordinal="35" offset="513" sl="276" sc="21" el="276" ec="22" />
+                                <SequencePoint vc="2" uspid="1560" ordinal="36" offset="514" sl="277" sc="25" el="277" ec="116" />
+                                <SequencePoint vc="2" uspid="1561" ordinal="37" offset="555" sl="278" sc="25" el="278" ec="47" />
+                                <SequencePoint vc="2" uspid="1562" ordinal="38" offset="566" sl="278" sc="48" el="278" ec="85" />
+                                <SequencePoint vc="0" uspid="1563" ordinal="39" offset="578" sl="279" sc="21" el="279" ec="22" />
+                                <SequencePoint vc="2" uspid="1564" ordinal="40" offset="581" sl="280" sc="26" el="280" ec="60" />
+                                <SequencePoint vc="0" uspid="1565" ordinal="41" offset="598" sl="281" sc="17" el="281" ec="18" />
+                                <SequencePoint vc="1" uspid="1566" ordinal="42" offset="599" sl="282" sc="13" el="282" ec="14" />
+                                <SequencePoint vc="1" uspid="1567" ordinal="43" offset="600" sl="283" sc="13" el="283" ec="26" />
+                                <SequencePoint vc="19" uspid="1568" ordinal="44" offset="606" sl="284" sc="9" el="284" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="1" uspid="1569" ordinal="0" offset="22" path="0" />
+                                <BranchPoint vc="18" uspid="1570" ordinal="1" offset="22" path="1" />
+                                <BranchPoint vc="4" uspid="1571" ordinal="2" offset="42" path="0" />
+                                <BranchPoint vc="14" uspid="1572" ordinal="3" offset="42" path="1" />
+                                <BranchPoint vc="7" uspid="1573" ordinal="4" offset="136" path="0" />
+                                <BranchPoint vc="6" uspid="1574" ordinal="5" offset="136" path="1" />
+                                <BranchPoint vc="7" uspid="1575" ordinal="6" offset="158" path="0" />
+                                <BranchPoint vc="13" uspid="1576" ordinal="7" offset="158" path="1" />
+                                <BranchPoint vc="7" uspid="1577" ordinal="8" offset="190" path="0" />
+                                <BranchPoint vc="14" uspid="1578" ordinal="9" offset="190" path="1" />
+                                <BranchPoint vc="14" uspid="1579" ordinal="10" offset="203" path="0" />
+                                <BranchPoint vc="0" uspid="1580" ordinal="11" offset="203" path="1" />
+                                <BranchPoint vc="7" uspid="1581" ordinal="12" offset="221" path="0" />
+                                <BranchPoint vc="0" uspid="1582" ordinal="13" offset="221" path="1" />
+                                <BranchPoint vc="7" uspid="1583" ordinal="14" offset="250" path="0" />
+                                <BranchPoint vc="0" uspid="1584" ordinal="15" offset="250" path="1" />
+                                <BranchPoint vc="0" uspid="1585" ordinal="16" offset="312" path="0" />
+                                <BranchPoint vc="7" uspid="1586" ordinal="17" offset="312" path="1" />
+                                <BranchPoint vc="6" uspid="1587" ordinal="18" offset="400" path="0" />
+                                <BranchPoint vc="1" uspid="1588" ordinal="19" offset="400" path="1" />
+                                <BranchPoint vc="2" uspid="1589" ordinal="20" offset="425" path="0" />
+                                <BranchPoint vc="4" uspid="1590" ordinal="21" offset="425" path="1" />
+                                <BranchPoint vc="2" uspid="1591" ordinal="22" offset="441" path="0" />
+                                <BranchPoint vc="0" uspid="1592" ordinal="23" offset="441" path="1" />
+                                <BranchPoint vc="2" uspid="1593" ordinal="24" offset="476" path="0" />
+                                <BranchPoint vc="0" uspid="1594" ordinal="25" offset="476" path="1" />
+                                <BranchPoint vc="2" uspid="1595" ordinal="26" offset="511" path="0" />
+                                <BranchPoint vc="2" uspid="1596" ordinal="27" offset="511" path="1" />
+                                <BranchPoint vc="2" uspid="1597" ordinal="28" offset="527" path="0" />
+                                <BranchPoint vc="0" uspid="1598" ordinal="29" offset="527" path="1" />
+                                <BranchPoint vc="2" uspid="1599" ordinal="30" offset="564" path="0" />
+                                <BranchPoint vc="0" uspid="1600" ordinal="31" offset="564" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="19" uspid="1524" ordinal="0" offset="0" sl="249" sc="9" el="249" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="6" sequenceCoverage="100" branchCoverage="90.91" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="13" visitedSequencePoints="13" numBranchPoints="11" visitedBranchPoints="10" sequenceCoverage="100" branchCoverage="90.91" maxCyclomaticComplexity="6" minCyclomaticComplexity="6" />
+                            <MetadataToken>100663545</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Filter::ExcludeByFile(System.String)</Name>
+                            <FileRef uid="26" />
+                            <SequencePoints>
+                                <SequencePoint vc="4" uspid="1601" ordinal="0" offset="0" sl="287" sc="9" el="287" ec="10" />
+                                <SequencePoint vc="4" uspid="1602" ordinal="1" offset="1" sl="288" sc="13" el="288" ec="81" />
+                                <SequencePoint vc="2" uspid="1603" ordinal="2" offset="31" sl="289" sc="17" el="289" ec="30" />
+                                <SequencePoint vc="2" uspid="1604" ordinal="3" offset="35" sl="290" sc="13" el="290" ec="20" />
+                                <SequencePoint vc="2" uspid="1605" ordinal="4" offset="36" sl="290" sc="41" el="290" ec="54" />
+                                <SequencePoint vc="2" uspid="1606" ordinal="5" offset="50" sl="290" sc="22" el="290" ec="37" />
+                                <SequencePoint vc="2" uspid="1607" ordinal="6" offset="57" sl="291" sc="13" el="291" ec="14" />
+                                <SequencePoint vc="2" uspid="1608" ordinal="7" offset="58" sl="292" sc="17" el="292" ec="63" />
+                                <SequencePoint vc="1" uspid="1609" ordinal="8" offset="82" sl="293" sc="21" el="293" ec="33" />
+                                <SequencePoint vc="1" uspid="1610" ordinal="9" offset="86" sl="294" sc="13" el="294" ec="14" />
+                                <SequencePoint vc="3" uspid="1611" ordinal="10" offset="87" sl="290" sc="38" el="290" ec="40" />
+                                <SequencePoint vc="1" uspid="1612" ordinal="11" offset="116" sl="295" sc="13" el="295" ec="26" />
+                                <SequencePoint vc="4" uspid="1613" ordinal="12" offset="121" sl="296" sc="9" el="296" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="2" uspid="1614" ordinal="0" offset="12" path="0" />
+                                <BranchPoint vc="2" uspid="1615" ordinal="1" offset="12" path="1" />
+                                <BranchPoint vc="2" uspid="1616" ordinal="2" offset="29" path="0" />
+                                <BranchPoint vc="2" uspid="1617" ordinal="3" offset="29" path="1" />
+                                <BranchPoint vc="1" uspid="1618" ordinal="4" offset="80" path="0" />
+                                <BranchPoint vc="1" uspid="1619" ordinal="5" offset="80" path="1" />
+                                <BranchPoint vc="1" uspid="1620" ordinal="6" offset="95" path="0" />
+                                <BranchPoint vc="2" uspid="1621" ordinal="7" offset="95" path="1" />
+                                <BranchPoint vc="2" uspid="1622" ordinal="8" offset="105" path="0" />
+                                <BranchPoint vc="0" uspid="1623" ordinal="9" offset="105" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="4" uspid="1601" ordinal="0" offset="0" sl="287" sc="9" el="287" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="5" sequenceCoverage="100" branchCoverage="88.89" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="12" visitedSequencePoints="12" numBranchPoints="9" visitedBranchPoints="8" sequenceCoverage="100" branchCoverage="88.89" maxCyclomaticComplexity="5" minCyclomaticComplexity="5" />
+                            <MetadataToken>100663546</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Filter::AddFileExclusionFilters(System.String[])</Name>
+                            <FileRef uid="26" />
+                            <SequencePoints>
+                                <SequencePoint vc="5" uspid="1624" ordinal="0" offset="0" sl="299" sc="9" el="299" ec="10" />
+                                <SequencePoint vc="5" uspid="1625" ordinal="1" offset="1" sl="300" sc="13" el="300" ec="42" />
+                                <SequencePoint vc="1" uspid="1626" ordinal="2" offset="12" sl="301" sc="17" el="301" ec="24" />
+                                <SequencePoint vc="4" uspid="1627" ordinal="3" offset="17" sl="302" sc="13" el="302" ec="20" />
+                                <SequencePoint vc="4" uspid="1628" ordinal="4" offset="18" sl="302" sc="44" el="302" ec="82" />
+                                <SequencePoint vc="4" uspid="1629" ordinal="5" offset="63" sl="302" sc="22" el="302" ec="40" />
+                                <SequencePoint vc="4" uspid="1630" ordinal="6" offset="76" sl="303" sc="13" el="303" ec="14" />
+                                <SequencePoint vc="4" uspid="1631" ordinal="7" offset="77" sl="304" sc="17" el="304" ec="88" />
+                                <SequencePoint vc="4" uspid="1632" ordinal="8" offset="99" sl="305" sc="17" el="305" ec="77" />
+                                <SequencePoint vc="4" uspid="1633" ordinal="9" offset="128" sl="306" sc="13" el="306" ec="14" />
+                                <SequencePoint vc="8" uspid="1634" ordinal="10" offset="129" sl="302" sc="41" el="302" ec="43" />
+                                <SequencePoint vc="5" uspid="1635" ordinal="11" offset="158" sl="307" sc="9" el="307" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="1" uspid="1636" ordinal="0" offset="10" path="0" />
+                                <BranchPoint vc="4" uspid="1637" ordinal="1" offset="10" path="1" />
+                                <BranchPoint vc="1" uspid="1638" ordinal="2" offset="24" path="0" />
+                                <BranchPoint vc="3" uspid="1639" ordinal="3" offset="24" path="1" />
+                                <BranchPoint vc="4" uspid="1640" ordinal="4" offset="137" path="0" />
+                                <BranchPoint vc="4" uspid="1641" ordinal="5" offset="137" path="1" />
+                                <BranchPoint vc="4" uspid="1642" ordinal="6" offset="147" path="0" />
+                                <BranchPoint vc="0" uspid="1643" ordinal="7" offset="147" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="5" uspid="1624" ordinal="0" offset="0" sl="299" sc="9" el="299" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="6" sequenceCoverage="92.31" branchCoverage="72.73" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="13" visitedSequencePoints="12" numBranchPoints="11" visitedBranchPoints="8" sequenceCoverage="92.31" branchCoverage="72.73" maxCyclomaticComplexity="6" minCyclomaticComplexity="6" />
+                            <MetadataToken>100663547</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Filter::UseTestAssembly(System.String)</Name>
+                            <FileRef uid="26" />
+                            <SequencePoints>
+                                <SequencePoint vc="2" uspid="1644" ordinal="0" offset="0" sl="310" sc="9" el="310" ec="10" />
+                                <SequencePoint vc="2" uspid="1645" ordinal="1" offset="1" sl="311" sc="13" el="311" ec="81" />
+                                <SequencePoint vc="0" uspid="1646" ordinal="2" offset="31" sl="312" sc="17" el="312" ec="30" />
+                                <SequencePoint vc="2" uspid="1647" ordinal="3" offset="35" sl="313" sc="13" el="313" ec="20" />
+                                <SequencePoint vc="2" uspid="1648" ordinal="4" offset="36" sl="313" sc="34" el="313" ec="43" />
+                                <SequencePoint vc="2" uspid="1649" ordinal="5" offset="50" sl="313" sc="22" el="313" ec="30" />
+                                <SequencePoint vc="2" uspid="1650" ordinal="6" offset="57" sl="314" sc="13" el="314" ec="14" />
+                                <SequencePoint vc="2" uspid="1651" ordinal="7" offset="58" sl="315" sc="17" el="315" ec="60" />
+                                <SequencePoint vc="1" uspid="1652" ordinal="8" offset="82" sl="316" sc="21" el="316" ec="33" />
+                                <SequencePoint vc="1" uspid="1653" ordinal="9" offset="86" sl="317" sc="13" el="317" ec="14" />
+                                <SequencePoint vc="3" uspid="1654" ordinal="10" offset="87" sl="313" sc="31" el="313" ec="33" />
+                                <SequencePoint vc="1" uspid="1655" ordinal="11" offset="116" sl="318" sc="13" el="318" ec="26" />
+                                <SequencePoint vc="2" uspid="1656" ordinal="12" offset="121" sl="319" sc="9" el="319" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="2" uspid="1657" ordinal="0" offset="12" path="0" />
+                                <BranchPoint vc="0" uspid="1658" ordinal="1" offset="12" path="1" />
+                                <BranchPoint vc="0" uspid="1659" ordinal="2" offset="29" path="0" />
+                                <BranchPoint vc="2" uspid="1660" ordinal="3" offset="29" path="1" />
+                                <BranchPoint vc="1" uspid="1661" ordinal="4" offset="80" path="0" />
+                                <BranchPoint vc="1" uspid="1662" ordinal="5" offset="80" path="1" />
+                                <BranchPoint vc="1" uspid="1663" ordinal="6" offset="95" path="0" />
+                                <BranchPoint vc="2" uspid="1664" ordinal="7" offset="95" path="1" />
+                                <BranchPoint vc="2" uspid="1665" ordinal="8" offset="105" path="0" />
+                                <BranchPoint vc="0" uspid="1666" ordinal="9" offset="105" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="2" uspid="1644" ordinal="0" offset="0" sl="310" sc="9" el="310" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="5" sequenceCoverage="100" branchCoverage="88.89" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="12" visitedSequencePoints="12" numBranchPoints="9" visitedBranchPoints="8" sequenceCoverage="100" branchCoverage="88.89" maxCyclomaticComplexity="5" minCyclomaticComplexity="5" />
+                            <MetadataToken>100663548</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Filter::AddTestFileFilters(System.String[])</Name>
+                            <FileRef uid="26" />
+                            <SequencePoints>
+                                <SequencePoint vc="4" uspid="1667" ordinal="0" offset="0" sl="322" sc="9" el="322" ec="10" />
+                                <SequencePoint vc="4" uspid="1668" ordinal="1" offset="1" sl="323" sc="13" el="323" ec="37" />
+                                <SequencePoint vc="1" uspid="1669" ordinal="2" offset="12" sl="324" sc="17" el="324" ec="24" />
+                                <SequencePoint vc="3" uspid="1670" ordinal="3" offset="17" sl="325" sc="13" el="325" ec="20" />
+                                <SequencePoint vc="3" uspid="1671" ordinal="4" offset="18" sl="325" sc="40" el="325" ec="73" />
+                                <SequencePoint vc="3" uspid="1672" ordinal="5" offset="63" sl="325" sc="22" el="325" ec="36" />
+                                <SequencePoint vc="3" uspid="1673" ordinal="6" offset="76" sl="326" sc="13" el="326" ec="14" />
+                                <SequencePoint vc="3" uspid="1674" ordinal="7" offset="77" sl="327" sc="17" el="327" ec="84" />
+                                <SequencePoint vc="3" uspid="1675" ordinal="8" offset="99" sl="328" sc="17" el="328" ec="73" />
+                                <SequencePoint vc="3" uspid="1676" ordinal="9" offset="128" sl="329" sc="13" el="329" ec="14" />
+                                <SequencePoint vc="6" uspid="1677" ordinal="10" offset="129" sl="325" sc="37" el="325" ec="39" />
+                                <SequencePoint vc="4" uspid="1678" ordinal="11" offset="158" sl="330" sc="9" el="330" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="1" uspid="1679" ordinal="0" offset="10" path="0" />
+                                <BranchPoint vc="3" uspid="1680" ordinal="1" offset="10" path="1" />
+                                <BranchPoint vc="1" uspid="1681" ordinal="2" offset="24" path="0" />
+                                <BranchPoint vc="2" uspid="1682" ordinal="3" offset="24" path="1" />
+                                <BranchPoint vc="3" uspid="1683" ordinal="4" offset="137" path="0" />
+                                <BranchPoint vc="3" uspid="1684" ordinal="5" offset="137" path="1" />
+                                <BranchPoint vc="3" uspid="1685" ordinal="6" offset="147" path="0" />
+                                <BranchPoint vc="0" uspid="1686" ordinal="7" offset="147" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="4" uspid="1667" ordinal="0" offset="0" sl="322" sc="9" el="322" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663549</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Filter::&lt;AddAttributeExclusionFilters&gt;b__c(System.String)</Name>
+                            <FileRef uid="26" />
+                            <SequencePoints>
+                                <SequencePoint vc="8" uspid="1687" ordinal="0" offset="0" sl="235" sc="72" el="235" ec="81" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="8" uspid="1687" ordinal="0" offset="0" sl="235" sc="72" el="235" ec="81" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663550</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Filter::&lt;AddFileExclusionFilters&gt;b__18(System.String)</Name>
+                            <FileRef uid="26" />
+                            <SequencePoints>
+                                <SequencePoint vc="5" uspid="1688" ordinal="0" offset="0" sl="302" sc="72" el="302" ec="81" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="5" uspid="1688" ordinal="0" offset="0" sl="302" sc="72" el="302" ec="81" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663551</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Filter::&lt;AddTestFileFilters&gt;b__1d(System.String)</Name>
+                            <FileRef uid="26" />
+                            <SequencePoints>
+                                <SequencePoint vc="4" uspid="1689" ordinal="0" offset="0" sl="325" sc="63" el="325" ec="72" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="4" uspid="1689" ordinal="0" offset="0" sl="325" sc="63" el="325" ec="72" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="3" visitedSequencePoints="3" numBranchPoints="7" visitedBranchPoints="5" sequenceCoverage="100" branchCoverage="71.43" maxCyclomaticComplexity="2" minCyclomaticComplexity="1" />
+                    <FullName>OpenCover.Framework.Filter/&lt;&gt;c__DisplayClass3</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663762</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Filter/&lt;&gt;c__DisplayClass3::.ctor()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="7" uspid="1690" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="2" sequenceCoverage="100" branchCoverage="66.67" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="3" visitedBranchPoints="2" sequenceCoverage="100" branchCoverage="66.67" maxCyclomaticComplexity="2" minCyclomaticComplexity="2" />
+                            <MetadataToken>100663763</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Filter/&lt;&gt;c__DisplayClass3::&lt;UseAssembly&gt;b__0(System.Collections.Generic.KeyValuePair`2&lt;System.String,System.String&gt;)</Name>
+                            <FileRef uid="26" />
+                            <SequencePoints>
+                                <SequencePoint vc="3" uspid="1691" ordinal="0" offset="0" sl="145" sc="53" el="145" ec="152" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="3" uspid="1692" ordinal="0" offset="28" path="0" />
+                                <BranchPoint vc="0" uspid="1693" ordinal="1" offset="28" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="3" uspid="1691" ordinal="0" offset="0" sl="145" sc="53" el="145" ec="152" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="2" sequenceCoverage="100" branchCoverage="66.67" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="3" visitedBranchPoints="2" sequenceCoverage="100" branchCoverage="66.67" maxCyclomaticComplexity="2" minCyclomaticComplexity="2" />
+                            <MetadataToken>100663764</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Filter/&lt;&gt;c__DisplayClass3::&lt;UseAssembly&gt;b__1(System.Collections.Generic.KeyValuePair`2&lt;System.String,System.String&gt;)</Name>
+                            <FileRef uid="26" />
+                            <SequencePoints>
+                                <SequencePoint vc="1" uspid="1694" ordinal="0" offset="0" sl="150" sc="53" el="150" ec="152" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="1" uspid="1695" ordinal="0" offset="28" path="0" />
+                                <BranchPoint vc="0" uspid="1696" ordinal="1" offset="28" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="1" uspid="1694" ordinal="0" offset="0" sl="150" sc="53" el="150" ec="152" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663765</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Filter/&lt;&gt;c__DisplayClass3::&lt;UseAssembly&gt;b__2(System.Collections.Generic.KeyValuePair`2&lt;System.String,System.String&gt;)</Name>
+                            <FileRef uid="26" />
+                            <SequencePoints>
+                                <SequencePoint vc="3" uspid="1697" ordinal="0" offset="0" sl="155" sc="53" el="155" ec="122" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="3" uspid="1697" ordinal="0" offset="0" sl="155" sc="53" el="155" ec="122" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="5" visitedSequencePoints="5" numBranchPoints="9" visitedBranchPoints="7" sequenceCoverage="100" branchCoverage="77.78" maxCyclomaticComplexity="2" minCyclomaticComplexity="1" />
+                    <FullName>OpenCover.Framework.Filter/&lt;&gt;c__DisplayClassa</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663766</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Filter/&lt;&gt;c__DisplayClassa::.ctor()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="15" uspid="1698" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="2" sequenceCoverage="100" branchCoverage="66.67" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="3" visitedBranchPoints="2" sequenceCoverage="100" branchCoverage="66.67" maxCyclomaticComplexity="2" minCyclomaticComplexity="2" />
+                            <MetadataToken>100663767</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Filter/&lt;&gt;c__DisplayClassa::&lt;InstrumentClass&gt;b__5(System.Collections.Generic.KeyValuePair`2&lt;System.String,System.String&gt;)</Name>
+                            <FileRef uid="26" />
+                            <SequencePoints>
+                                <SequencePoint vc="6" uspid="1699" ordinal="0" offset="0" sl="171" sc="38" el="171" ec="137" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="6" uspid="1700" ordinal="0" offset="28" path="0" />
+                                <BranchPoint vc="0" uspid="1701" ordinal="1" offset="28" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="6" uspid="1699" ordinal="0" offset="0" sl="171" sc="38" el="171" ec="137" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="2" sequenceCoverage="100" branchCoverage="66.67" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="3" visitedBranchPoints="2" sequenceCoverage="100" branchCoverage="66.67" maxCyclomaticComplexity="2" minCyclomaticComplexity="2" />
+                            <MetadataToken>100663768</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Filter/&lt;&gt;c__DisplayClassa::&lt;InstrumentClass&gt;b__6(System.Collections.Generic.KeyValuePair`2&lt;System.String,System.String&gt;)</Name>
+                            <FileRef uid="26" />
+                            <SequencePoints>
+                                <SequencePoint vc="2" uspid="1702" ordinal="0" offset="0" sl="177" sc="40" el="177" ec="139" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="2" uspid="1703" ordinal="0" offset="28" path="0" />
+                                <BranchPoint vc="0" uspid="1704" ordinal="1" offset="28" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="2" uspid="1702" ordinal="0" offset="0" sl="177" sc="40" el="177" ec="139" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663769</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Filter/&lt;&gt;c__DisplayClassa::&lt;InstrumentClass&gt;b__7(System.Collections.Generic.KeyValuePair`2&lt;System.String,System.String&gt;)</Name>
+                            <FileRef uid="26" />
+                            <SequencePoints>
+                                <SequencePoint vc="2" uspid="1705" ordinal="0" offset="0" sl="178" sc="38" el="178" ec="106" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="2" uspid="1705" ordinal="0" offset="0" sl="178" sc="38" el="178" ec="106" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663770</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Filter/&lt;&gt;c__DisplayClassa::&lt;InstrumentClass&gt;b__8(System.Collections.Generic.KeyValuePair`2&lt;System.String,System.String&gt;)</Name>
+                            <FileRef uid="26" />
+                            <SequencePoints>
+                                <SequencePoint vc="7" uspid="1706" ordinal="0" offset="0" sl="184" sc="40" el="184" ec="109" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="7" uspid="1706" ordinal="0" offset="0" sl="184" sc="40" el="184" ec="109" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663771</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Filter/&lt;&gt;c__DisplayClassa::&lt;InstrumentClass&gt;b__9(System.Collections.Generic.KeyValuePair`2&lt;System.String,System.String&gt;)</Name>
+                            <FileRef uid="26" />
+                            <SequencePoints>
+                                <SequencePoint vc="6" uspid="1707" ordinal="0" offset="0" sl="185" sc="38" el="185" ec="106" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="6" uspid="1707" ordinal="0" offset="0" sl="185" sc="38" el="185" ec="106" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                    <FullName>OpenCover.Framework.Filter/&lt;&gt;c__DisplayClassf</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663772</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Filter/&lt;&gt;c__DisplayClassf::.ctor()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="7" uspid="1708" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663773</MetadataToken>
+                            <Name>System.Text.RegularExpressions.Regex OpenCover.Framework.Filter/&lt;&gt;c__DisplayClassf::&lt;AddAttributeExclusionFilters&gt;b__d()</Name>
+                            <FileRef uid="26" />
+                            <SequencePoints>
+                                <SequencePoint vc="5" uspid="1709" ordinal="0" offset="0" sl="238" sc="62" el="238" ec="79" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="5" uspid="1709" ordinal="0" offset="0" sl="238" sc="62" el="238" ec="79" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="3" visitedSequencePoints="3" numBranchPoints="3" visitedBranchPoints="3" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                    <FullName>OpenCover.Framework.Filter/&lt;&gt;c__DisplayClass16</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663774</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Filter/&lt;&gt;c__DisplayClass16::.ctor()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="7" uspid="1710" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663775</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Filter/&lt;&gt;c__DisplayClass16::&lt;ExcludeByAttribute&gt;b__11(Mono.Cecil.MethodDefinition)</Name>
+                            <FileRef uid="26" />
+                            <SequencePoints>
+                                <SequencePoint vc="21" uspid="1711" ordinal="0" offset="0" sl="267" sc="79" el="267" ec="93" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="21" uspid="1711" ordinal="0" offset="0" sl="267" sc="79" el="267" ec="93" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663776</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Filter/&lt;&gt;c__DisplayClass16::&lt;ExcludeByAttribute&gt;b__12(Mono.Cecil.PropertyDefinition)</Name>
+                            <FileRef uid="26" />
+                            <SequencePoints>
+                                <SequencePoint vc="3" uspid="1712" ordinal="0" offset="0" sl="272" sc="93" el="272" ec="114" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="3" uspid="1712" ordinal="0" offset="0" sl="272" sc="93" el="272" ec="114" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663777</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Filter/&lt;&gt;c__DisplayClass16::&lt;ExcludeByAttribute&gt;b__13(Mono.Cecil.PropertyDefinition)</Name>
+                            <FileRef uid="26" />
+                            <SequencePoints>
+                                <SequencePoint vc="3" uspid="1713" ordinal="0" offset="0" sl="277" sc="93" el="277" ec="114" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="3" uspid="1713" ordinal="0" offset="0" sl="277" sc="93" el="277" ec="114" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                    <FullName>OpenCover.Framework.Filter/&lt;&gt;c__DisplayClass1b</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663778</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Filter/&lt;&gt;c__DisplayClass1b::.ctor()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="4" uspid="1714" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663779</MetadataToken>
+                            <Name>System.Text.RegularExpressions.Regex OpenCover.Framework.Filter/&lt;&gt;c__DisplayClass1b::&lt;AddFileExclusionFilters&gt;b__19()</Name>
+                            <FileRef uid="26" />
+                            <SequencePoints>
+                                <SequencePoint vc="3" uspid="1715" ordinal="0" offset="0" sl="305" sc="57" el="305" ec="74" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="3" uspid="1715" ordinal="0" offset="0" sl="305" sc="57" el="305" ec="74" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                    <FullName>OpenCover.Framework.Filter/&lt;&gt;c__DisplayClass20</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663780</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Filter/&lt;&gt;c__DisplayClass20::.ctor()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="3" uspid="1716" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663781</MetadataToken>
+                            <Name>System.Text.RegularExpressions.Regex OpenCover.Framework.Filter/&lt;&gt;c__DisplayClass20::&lt;AddTestFileFilters&gt;b__1e()</Name>
+                            <FileRef uid="26" />
+                            <SequencePoints>
+                                <SequencePoint vc="2" uspid="1717" ordinal="0" offset="0" sl="328" sc="53" el="328" ec="70" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="2" uspid="1717" ordinal="0" offset="0" sl="328" sc="53" el="328" ec="70" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="65" visitedSequencePoints="65" numBranchPoints="32" visitedBranchPoints="27" sequenceCoverage="100" branchCoverage="84.38" maxCyclomaticComplexity="8" minCyclomaticComplexity="1" />
+                    <FullName>OpenCover.Framework.Model.InstrumentationModelBuilder</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="3" visitedSequencePoints="3" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663557</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Model.InstrumentationModelBuilder::get_CanInstrument()</Name>
+                            <FileRef uid="34" />
+                            <SequencePoints>
+                                <SequencePoint vc="2" uspid="1718" ordinal="0" offset="0" sl="79" sc="17" el="79" ec="18" />
+                                <SequencePoint vc="2" uspid="1719" ordinal="1" offset="1" sl="79" sc="19" el="79" ec="64" />
+                                <SequencePoint vc="2" uspid="1720" ordinal="2" offset="21" sl="79" sc="65" el="79" ec="66" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="2" uspid="1718" ordinal="0" offset="0" sl="79" sc="17" el="79" ec="18" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="4" visitedSequencePoints="4" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663552</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.InstrumentationModelBuilder::.ctor(OpenCover.Framework.Symbols.ISymbolManager)</Name>
+                            <FileRef uid="34" />
+                            <SequencePoints>
+                                <SequencePoint vc="11" uspid="1721" ordinal="0" offset="0" sl="23" sc="9" el="23" ec="73" />
+                                <SequencePoint vc="11" uspid="1722" ordinal="1" offset="7" sl="24" sc="9" el="24" ec="10" />
+                                <SequencePoint vc="11" uspid="1723" ordinal="2" offset="8" sl="25" sc="13" el="25" ec="44" />
+                                <SequencePoint vc="11" uspid="1724" ordinal="3" offset="15" sl="26" sc="9" el="26" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="11" uspid="1721" ordinal="0" offset="0" sl="23" sc="9" el="23" ec="73" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="4" visitedSequencePoints="4" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663553</MetadataToken>
+                            <Name>OpenCover.Framework.Model.Module OpenCover.Framework.Model.InstrumentationModelBuilder::BuildModuleModel(System.Boolean)</Name>
+                            <FileRef uid="34" />
+                            <SequencePoints>
+                                <SequencePoint vc="7" uspid="1725" ordinal="0" offset="0" sl="29" sc="9" el="29" ec="10" />
+                                <SequencePoint vc="7" uspid="1726" ordinal="1" offset="1" sl="30" sc="13" el="30" ec="45" />
+                                <SequencePoint vc="7" uspid="1727" ordinal="2" offset="9" sl="31" sc="13" el="31" ec="27" />
+                                <SequencePoint vc="7" uspid="1728" ordinal="3" offset="13" sl="32" sc="9" el="32" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="7" uspid="1725" ordinal="0" offset="0" sl="29" sc="9" el="29" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="4" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="22" visitedSequencePoints="22" numBranchPoints="7" visitedBranchPoints="7" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="4" minCyclomaticComplexity="4" />
+                            <MetadataToken>100663554</MetadataToken>
+                            <Name>OpenCover.Framework.Model.Module OpenCover.Framework.Model.InstrumentationModelBuilder::CreateModule(System.Boolean)</Name>
+                            <FileRef uid="34" />
+                            <SequencePoints>
+                                <SequencePoint vc="8" uspid="1729" ordinal="0" offset="0" sl="35" sc="9" el="35" ec="10" />
+                                <SequencePoint vc="8" uspid="1730" ordinal="1" offset="1" sl="36" sc="13" el="36" ec="37" />
+                                <SequencePoint vc="8" uspid="1731" ordinal="2" offset="7" sl="37" sc="13" el="37" ec="66" />
+                                <SequencePoint vc="1" uspid="1732" ordinal="3" offset="32" sl="38" sc="13" el="38" ec="14" />
+                                <SequencePoint vc="1" uspid="1733" ordinal="4" offset="33" sl="39" sc="17" el="39" ec="60" />
+                                <SequencePoint vc="1" uspid="1734" ordinal="5" offset="51" sl="40" sc="13" el="40" ec="14" />
+                                <SequencePoint vc="8" uspid="1735" ordinal="6" offset="52" sl="41" sc="13" el="46" ec="32" />
+                                <SequencePoint vc="8" uspid="1736" ordinal="7" offset="104" sl="47" sc="13" el="47" ec="59" />
+                                <SequencePoint vc="8" uspid="1737" ordinal="8" offset="127" sl="49" sc="13" el="49" ec="22" />
+                                <SequencePoint vc="6" uspid="1738" ordinal="9" offset="137" sl="50" sc="13" el="50" ec="14" />
+                                <SequencePoint vc="6" uspid="1739" ordinal="10" offset="138" sl="51" sc="17" el="51" ec="58" />
+                                <SequencePoint vc="6" uspid="1740" ordinal="11" offset="156" sl="52" sc="17" el="52" ec="74" />
+                                <SequencePoint vc="6" uspid="1741" ordinal="12" offset="174" sl="53" sc="17" el="53" ec="24" />
+                                <SequencePoint vc="6" uspid="1742" ordinal="13" offset="175" sl="53" sc="40" el="53" ec="54" />
+                                <SequencePoint vc="4" uspid="1743" ordinal="14" offset="188" sl="53" sc="26" el="53" ec="36" />
+                                <SequencePoint vc="4" uspid="1744" ordinal="15" offset="194" sl="54" sc="17" el="54" ec="18" />
+                                <SequencePoint vc="4" uspid="1745" ordinal="16" offset="195" sl="55" sc="21" el="55" ec="59" />
+                                <SequencePoint vc="4" uspid="1746" ordinal="17" offset="209" sl="56" sc="17" el="56" ec="18" />
+                                <SequencePoint vc="10" uspid="1747" ordinal="18" offset="216" sl="53" sc="37" el="53" ec="39" />
+                                <SequencePoint vc="6" uspid="1748" ordinal="19" offset="230" sl="57" sc="13" el="57" ec="14" />
+                                <SequencePoint vc="8" uspid="1749" ordinal="20" offset="231" sl="58" sc="13" el="58" ec="27" />
+                                <SequencePoint vc="8" uspid="1750" ordinal="21" offset="236" sl="59" sc="9" el="59" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="1" uspid="1751" ordinal="0" offset="30" path="0" />
+                                <BranchPoint vc="7" uspid="1752" ordinal="1" offset="30" path="1" />
+                                <BranchPoint vc="6" uspid="1753" ordinal="2" offset="135" path="0" />
+                                <BranchPoint vc="2" uspid="1754" ordinal="3" offset="135" path="1" />
+                                <BranchPoint vc="6" uspid="1755" ordinal="4" offset="228" path="0" />
+                                <BranchPoint vc="4" uspid="1756" ordinal="5" offset="228" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="8" uspid="1729" ordinal="0" offset="0" sl="35" sc="9" el="35" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="2" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="5" visitedSequencePoints="5" numBranchPoints="3" visitedBranchPoints="3" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="2" minCyclomaticComplexity="2" />
+                            <MetadataToken>100663555</MetadataToken>
+                            <Name>OpenCover.Framework.Model.Module OpenCover.Framework.Model.InstrumentationModelBuilder::BuildModuleTestModel(OpenCover.Framework.Model.Module,System.Boolean)</Name>
+                            <FileRef uid="34" />
+                            <SequencePoints>
+                                <SequencePoint vc="2" uspid="1757" ordinal="0" offset="0" sl="62" sc="9" el="62" ec="10" />
+                                <SequencePoint vc="2" uspid="1758" ordinal="1" offset="1" sl="63" sc="13" el="63" ec="51" />
+                                <SequencePoint vc="2" uspid="1759" ordinal="2" offset="15" sl="64" sc="13" el="64" ec="72" />
+                                <SequencePoint vc="2" uspid="1760" ordinal="3" offset="33" sl="65" sc="13" el="65" ec="27" />
+                                <SequencePoint vc="2" uspid="1761" ordinal="4" offset="37" sl="66" sc="9" el="66" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="1" uspid="1762" ordinal="0" offset="3" path="0" />
+                                <BranchPoint vc="1" uspid="1763" ordinal="1" offset="3" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="2" uspid="1757" ordinal="0" offset="0" sl="62" sc="9" el="62" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="3" sequenceCoverage="100" branchCoverage="60" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="6" visitedSequencePoints="6" numBranchPoints="5" visitedBranchPoints="3" sequenceCoverage="100" branchCoverage="60" maxCyclomaticComplexity="3" minCyclomaticComplexity="3" />
+                            <MetadataToken>100663556</MetadataToken>
+                            <Name>System.String OpenCover.Framework.Model.InstrumentationModelBuilder::HashFile(System.String)</Name>
+                            <FileRef uid="34" />
+                            <SequencePoints>
+                                <SequencePoint vc="1" uspid="1764" ordinal="0" offset="0" sl="69" sc="9" el="69" ec="10" />
+                                <SequencePoint vc="1" uspid="1765" ordinal="1" offset="1" sl="70" sc="20" el="70" ec="52" />
+                                <SequencePoint vc="1" uspid="1766" ordinal="2" offset="8" sl="71" sc="20" el="71" ec="62" />
+                                <SequencePoint vc="1" uspid="1767" ordinal="3" offset="14" sl="72" sc="13" el="72" ec="14" />
+                                <SequencePoint vc="1" uspid="1768" ordinal="4" offset="15" sl="73" sc="17" el="73" ec="79" />
+                                <SequencePoint vc="1" uspid="1769" ordinal="5" offset="68" sl="75" sc="9" el="75" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="1" uspid="1770" ordinal="0" offset="41" path="0" />
+                                <BranchPoint vc="0" uspid="1771" ordinal="1" offset="41" path="1" />
+                                <BranchPoint vc="1" uspid="1772" ordinal="2" offset="57" path="0" />
+                                <BranchPoint vc="0" uspid="1773" ordinal="3" offset="57" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="1" uspid="1764" ordinal="0" offset="0" sl="69" sc="9" el="69" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="8" sequenceCoverage="100" branchCoverage="76.92" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="20" visitedSequencePoints="20" numBranchPoints="13" visitedBranchPoints="10" sequenceCoverage="100" branchCoverage="76.92" maxCyclomaticComplexity="8" minCyclomaticComplexity="8" />
+                            <MetadataToken>100663558</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.InstrumentationModelBuilder::BuildClassModel(OpenCover.Framework.Model.Class,OpenCover.Framework.Model.File[])</Name>
+                            <FileRef uid="34" />
+                            <SequencePoints>
+                                <SequencePoint vc="4" uspid="1774" ordinal="0" offset="0" sl="83" sc="9" el="83" ec="10" />
+                                <SequencePoint vc="4" uspid="1775" ordinal="1" offset="1" sl="84" sc="13" el="84" ec="54" />
+                                <SequencePoint vc="1" uspid="1776" ordinal="2" offset="14" sl="85" sc="17" el="85" ec="24" />
+                                <SequencePoint vc="3" uspid="1777" ordinal="3" offset="19" sl="86" sc="13" el="86" ec="75" />
+                                <SequencePoint vc="3" uspid="1778" ordinal="4" offset="33" sl="88" sc="13" el="88" ec="20" />
+                                <SequencePoint vc="3" uspid="1779" ordinal="5" offset="34" sl="88" sc="36" el="88" ec="43" />
+                                <SequencePoint vc="2" uspid="1780" ordinal="6" offset="44" sl="88" sc="22" el="88" ec="32" />
+                                <SequencePoint vc="2" uspid="1781" ordinal="7" offset="49" sl="89" sc="13" el="89" ec="14" />
+                                <SequencePoint vc="2" uspid="1782" ordinal="8" offset="50" sl="90" sc="17" el="90" ec="59" />
+                                <SequencePoint vc="2" uspid="1783" ordinal="9" offset="63" sl="91" sc="17" el="91" ec="18" />
+                                <SequencePoint vc="2" uspid="1784" ordinal="10" offset="64" sl="92" sc="21" el="92" ec="108" />
+                                <SequencePoint vc="2" uspid="1785" ordinal="11" offset="88" sl="93" sc="21" el="95" ec="53" />
+                                <SequencePoint vc="2" uspid="1786" ordinal="12" offset="149" sl="96" sc="21" el="96" ec="91" />
+                                <SequencePoint vc="2" uspid="1787" ordinal="13" offset="171" sl="97" sc="21" el="97" ec="104" />
+                                <SequencePoint vc="2" uspid="1788" ordinal="14" offset="195" sl="98" sc="17" el="98" ec="18" />
+                                <SequencePoint vc="2" uspid="1789" ordinal="15" offset="196" sl="99" sc="17" el="99" ec="116" />
+                                <SequencePoint vc="2" uspid="1790" ordinal="16" offset="220" sl="100" sc="13" el="100" ec="14" />
+                                <SequencePoint vc="5" uspid="1791" ordinal="17" offset="227" sl="88" sc="33" el="88" ec="35" />
+                                <SequencePoint vc="3" uspid="1792" ordinal="18" offset="241" sl="102" sc="13" el="102" ec="38" />
+                                <SequencePoint vc="4" uspid="1793" ordinal="19" offset="249" sl="103" sc="9" el="103" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="1" uspid="1794" ordinal="0" offset="12" path="0" />
+                                <BranchPoint vc="3" uspid="1795" ordinal="1" offset="12" path="1" />
+                                <BranchPoint vc="2" uspid="1796" ordinal="2" offset="58" path="0" />
+                                <BranchPoint vc="0" uspid="1797" ordinal="3" offset="58" path="1" />
+                                <BranchPoint vc="0" uspid="1798" ordinal="4" offset="95" path="0" />
+                                <BranchPoint vc="2" uspid="1799" ordinal="5" offset="95" path="1" />
+                                <BranchPoint vc="1" uspid="1800" ordinal="6" offset="111" path="0" />
+                                <BranchPoint vc="1" uspid="1801" ordinal="7" offset="111" path="1" />
+                                <BranchPoint vc="0" uspid="1802" ordinal="8" offset="157" path="0" />
+                                <BranchPoint vc="2" uspid="1803" ordinal="9" offset="157" path="1" />
+                                <BranchPoint vc="3" uspid="1804" ordinal="10" offset="236" path="0" />
+                                <BranchPoint vc="2" uspid="1805" ordinal="11" offset="236" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="4" uspid="1774" ordinal="0" offset="0" sl="83" sc="9" el="83" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663559</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Model.InstrumentationModelBuilder::&lt;BuildClassModel&gt;b__1(OpenCover.Framework.Model.SequencePoint)</Name>
+                            <FileRef uid="34" />
+                            <SequencePoints>
+                                <SequencePoint vc="2" uspid="1806" ordinal="0" offset="0" sl="94" sc="91" el="94" ec="105" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="2" uspid="1806" ordinal="0" offset="0" sl="94" sc="91" el="94" ec="105" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="11" visitedSequencePoints="8" numBranchPoints="3" visitedBranchPoints="2" sequenceCoverage="72.73" branchCoverage="66.67" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                    <FullName>OpenCover.Framework.Model.Class</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663561</MetadataToken>
+                            <Name>OpenCover.Framework.Model.Summary OpenCover.Framework.Model.Class::get_Summary()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="267" uspid="1807" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663562</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.Class::set_Summary(OpenCover.Framework.Model.Summary)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="1739" uspid="1808" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663564</MetadataToken>
+                            <Name>System.String OpenCover.Framework.Model.Class::get_FullName()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="3058" uspid="1809" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663565</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.Class::set_FullName(System.String)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="1717" uspid="1810" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663566</MetadataToken>
+                            <Name>OpenCover.Framework.Model.File[] OpenCover.Framework.Model.Class::get_Files()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="83" uspid="1811" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663567</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.Class::set_Files(OpenCover.Framework.Model.File[])</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="1660" uspid="1812" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663568</MetadataToken>
+                            <Name>OpenCover.Framework.Model.Method[] OpenCover.Framework.Model.Class::get_Methods()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="165" uspid="1813" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663569</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.Class::set_Methods(OpenCover.Framework.Model.Method[])</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="1783" uspid="1814" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="5" visitedSequencePoints="5" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663560</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.Class::.ctor()</Name>
+                            <FileRef uid="35" />
+                            <SequencePoints>
+                                <SequencePoint vc="1739" uspid="1815" ordinal="0" offset="0" sl="19" sc="9" el="19" ec="23" />
+                                <SequencePoint vc="1739" uspid="1816" ordinal="1" offset="7" sl="20" sc="9" el="20" ec="10" />
+                                <SequencePoint vc="1739" uspid="1817" ordinal="2" offset="8" sl="21" sc="13" el="21" ec="37" />
+                                <SequencePoint vc="1739" uspid="1818" ordinal="3" offset="21" sl="22" sc="13" el="22" ec="37" />
+                                <SequencePoint vc="1739" uspid="1819" ordinal="4" offset="33" sl="23" sc="9" el="23" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="1739" uspid="1815" ordinal="0" offset="0" sl="19" sc="9" el="19" ec="23" />
+                        </Method>
+                        <Method visited="false" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="3" visitedSequencePoints="0" numBranchPoints="1" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663563</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Model.Class::ShouldSerializeSummary()</Name>
+                            <FileRef uid="35" />
+                            <SequencePoints>
+                                <SequencePoint vc="0" uspid="1820" ordinal="0" offset="0" sl="34" sc="46" el="34" ec="47" />
+                                <SequencePoint vc="0" uspid="1821" ordinal="1" offset="1" sl="34" sc="48" el="34" ec="86" />
+                                <SequencePoint vc="0" uspid="1822" ordinal="2" offset="13" sl="34" sc="87" el="34" ec="88" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="0" uspid="1820" ordinal="0" offset="0" sl="34" sc="46" el="34" ec="47" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="3" visitedSequencePoints="3" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663570</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.Class::MarkAsSkipped(OpenCover.Framework.Model.SkippedMethod)</Name>
+                            <FileRef uid="35" />
+                            <SequencePoints>
+                                <SequencePoint vc="10" uspid="1823" ordinal="0" offset="0" sl="50" sc="9" el="50" ec="10" />
+                                <SequencePoint vc="10" uspid="1824" ordinal="1" offset="1" sl="51" sc="13" el="51" ec="35" />
+                                <SequencePoint vc="10" uspid="1825" ordinal="2" offset="9" sl="52" sc="9" el="52" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="10" uspid="1823" ordinal="0" offset="0" sl="50" sc="9" el="50" ec="10" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="5" visitedSequencePoints="5" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                    <FullName>OpenCover.Framework.Model.CoverageSession</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663572</MetadataToken>
+                            <Name>System.String OpenCover.Framework.Model.CoverageSession::get_SessionId()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="1" uspid="1826" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="false" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663573</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.CoverageSession::set_SessionId(System.String)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="0" uspid="1827" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663574</MetadataToken>
+                            <Name>OpenCover.Framework.Model.Summary OpenCover.Framework.Model.CoverageSession::get_Summary()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="189" uspid="1828" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663575</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.CoverageSession::set_Summary(OpenCover.Framework.Model.Summary)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="42" uspid="1829" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663576</MetadataToken>
+                            <Name>OpenCover.Framework.Model.Module[] OpenCover.Framework.Model.CoverageSession::get_Modules()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="245" uspid="1830" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663577</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.CoverageSession::set_Modules(OpenCover.Framework.Model.Module[])</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="86" uspid="1831" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="5" visitedSequencePoints="5" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663571</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.CoverageSession::.ctor()</Name>
+                            <FileRef uid="36" />
+                            <SequencePoints>
+                                <SequencePoint vc="42" uspid="1832" ordinal="0" offset="0" sl="21" sc="9" el="21" ec="33" />
+                                <SequencePoint vc="42" uspid="1833" ordinal="1" offset="7" sl="22" sc="9" el="22" ec="10" />
+                                <SequencePoint vc="42" uspid="1834" ordinal="2" offset="8" sl="23" sc="13" el="23" ec="37" />
+                                <SequencePoint vc="42" uspid="1835" ordinal="3" offset="21" sl="24" sc="13" el="24" ec="37" />
+                                <SequencePoint vc="42" uspid="1836" ordinal="4" offset="33" sl="25" sc="9" el="25" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="42" uspid="1832" ordinal="0" offset="0" sl="21" sc="9" el="21" ec="33" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                    <FullName>OpenCover.Framework.Model.FileRef</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663578</MetadataToken>
+                            <Name>System.UInt32 OpenCover.Framework.Model.FileRef::get_UniqueId()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="4" uspid="1837" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663579</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.FileRef::set_UniqueId(System.UInt32)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="1044" uspid="1838" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663580</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.FileRef::.ctor()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="1051" uspid="1839" ordinal="0" offset="0" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="4" visitedSequencePoints="4" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                    <FullName>OpenCover.Framework.Model.File</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663582</MetadataToken>
+                            <Name>System.String OpenCover.Framework.Model.File::get_FullPath()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="655" uspid="1840" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663583</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.File::set_FullPath(System.String)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="1039" uspid="1841" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="4" visitedSequencePoints="4" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663581</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.File::.ctor()</Name>
+                            <FileRef uid="37" />
+                            <SequencePoints>
+                                <SequencePoint vc="1040" uspid="1842" ordinal="0" offset="0" sl="34" sc="9" el="34" ec="22" />
+                                <SequencePoint vc="1040" uspid="1843" ordinal="1" offset="7" sl="35" sc="9" el="35" ec="10" />
+                                <SequencePoint vc="1040" uspid="1844" ordinal="2" offset="8" sl="36" sc="13" el="36" ec="64" />
+                                <SequencePoint vc="1040" uspid="1845" ordinal="3" offset="25" sl="37" sc="9" el="37" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="1040" uspid="1842" ordinal="0" offset="0" sl="34" sc="9" el="34" ec="22" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="6" visitedSequencePoints="6" numBranchPoints="2" visitedBranchPoints="2" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                    <FullName>OpenCover.Framework.Model.FileEqualityComparer</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="3" visitedSequencePoints="3" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663584</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Model.FileEqualityComparer::Equals(OpenCover.Framework.Model.File,OpenCover.Framework.Model.File)</Name>
+                            <FileRef uid="37" />
+                            <SequencePoints>
+                                <SequencePoint vc="327" uspid="1846" ordinal="0" offset="0" sl="49" sc="9" el="49" ec="10" />
+                                <SequencePoint vc="327" uspid="1847" ordinal="1" offset="1" sl="50" sc="13" el="50" ec="45" />
+                                <SequencePoint vc="327" uspid="1848" ordinal="2" offset="21" sl="51" sc="9" el="51" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="327" uspid="1846" ordinal="0" offset="0" sl="49" sc="9" el="49" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="3" visitedSequencePoints="3" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663585</MetadataToken>
+                            <Name>System.Int32 OpenCover.Framework.Model.FileEqualityComparer::GetHashCode(OpenCover.Framework.Model.File)</Name>
+                            <FileRef uid="37" />
+                            <SequencePoints>
+                                <SequencePoint vc="52" uspid="1849" ordinal="0" offset="0" sl="54" sc="9" el="54" ec="10" />
+                                <SequencePoint vc="52" uspid="1850" ordinal="1" offset="1" sl="55" sc="13" el="55" ec="22" />
+                                <SequencePoint vc="52" uspid="1851" ordinal="2" offset="5" sl="56" sc="9" el="56" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="52" uspid="1849" ordinal="0" offset="0" sl="54" sc="9" el="54" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663586</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.FileEqualityComparer::.ctor()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="1" uspid="1852" ordinal="0" offset="0" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="15" visitedSequencePoints="12" numBranchPoints="5" visitedBranchPoints="4" sequenceCoverage="80" branchCoverage="80" maxCyclomaticComplexity="2" minCyclomaticComplexity="1" />
+                    <FullName>OpenCover.Framework.Model.Method</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663588</MetadataToken>
+                            <Name>OpenCover.Framework.Model.Summary OpenCover.Framework.Model.Method::get_Summary()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="326" uspid="1853" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663589</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.Method::set_Summary(OpenCover.Framework.Model.Summary)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="94" uspid="1854" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663591</MetadataToken>
+                            <Name>System.Int32 OpenCover.Framework.Model.Method::get_MetadataToken()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="43" uspid="1855" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663592</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.Method::set_MetadataToken(System.Int32)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="62" uspid="1856" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663593</MetadataToken>
+                            <Name>System.String OpenCover.Framework.Model.Method::get_Name()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="31" uspid="1857" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663594</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.Method::set_Name(System.String)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="62" uspid="1858" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663595</MetadataToken>
+                            <Name>OpenCover.Framework.Model.FileRef OpenCover.Framework.Model.Method::get_FileRef()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="14" uspid="1859" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663596</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.Method::set_FileRef(OpenCover.Framework.Model.FileRef)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="64" uspid="1860" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663597</MetadataToken>
+                            <Name>OpenCover.Framework.Model.SequencePoint[] OpenCover.Framework.Model.Method::get_SequencePoints()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="34" uspid="1861" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663598</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.Method::set_SequencePoints(OpenCover.Framework.Model.SequencePoint[])</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="33" uspid="1862" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663599</MetadataToken>
+                            <Name>OpenCover.Framework.Model.BranchPoint[] OpenCover.Framework.Model.Method::get_BranchPoints()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="24" uspid="1863" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663600</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.Method::set_BranchPoints(OpenCover.Framework.Model.BranchPoint[])</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="20" uspid="1864" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663601</MetadataToken>
+                            <Name>OpenCover.Framework.Model.InstrumentationPoint OpenCover.Framework.Model.Method::get_MethodPoint()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="48" uspid="1865" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663602</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.Method::set_MethodPoint(OpenCover.Framework.Model.InstrumentationPoint)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="25" uspid="1866" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="false" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663603</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Model.Method::get_Visited()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="0" uspid="1867" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663604</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.Method::set_Visited(System.Boolean)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="2" uspid="1868" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663605</MetadataToken>
+                            <Name>System.Int32 OpenCover.Framework.Model.Method::get_CyclomaticComplexity()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="66" uspid="1869" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663606</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.Method::set_CyclomaticComplexity(System.Int32)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="11" uspid="1870" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="false" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663607</MetadataToken>
+                            <Name>System.Decimal OpenCover.Framework.Model.Method::get_SequenceCoverage()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="0" uspid="1871" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663608</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.Method::set_SequenceCoverage(System.Decimal)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="22" uspid="1872" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="false" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663609</MetadataToken>
+                            <Name>System.Decimal OpenCover.Framework.Model.Method::get_BranchCoverage()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="0" uspid="1873" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663610</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.Method::set_BranchCoverage(System.Decimal)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="22" uspid="1874" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663611</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Model.Method::get_IsConstructor()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="1" uspid="1875" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663612</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.Method::set_IsConstructor(System.Boolean)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="53" uspid="1876" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="false" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663613</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Model.Method::get_IsStatic()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="0" uspid="1877" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663614</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.Method::set_IsStatic(System.Boolean)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="53" uspid="1878" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663615</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Model.Method::get_IsGetter()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="3" uspid="1879" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663616</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.Method::set_IsGetter(System.Boolean)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="53" uspid="1880" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663617</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Model.Method::get_IsSetter()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="2" uspid="1881" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663618</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.Method::set_IsSetter(System.Boolean)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="53" uspid="1882" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="4" visitedSequencePoints="4" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663587</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.Method::.ctor()</Name>
+                            <FileRef uid="39" />
+                            <SequencePoints>
+                                <SequencePoint vc="94" uspid="1883" ordinal="0" offset="0" sl="19" sc="9" el="19" ec="24" />
+                                <SequencePoint vc="94" uspid="1884" ordinal="1" offset="7" sl="20" sc="9" el="20" ec="10" />
+                                <SequencePoint vc="94" uspid="1885" ordinal="2" offset="8" sl="21" sc="13" el="21" ec="37" />
+                                <SequencePoint vc="94" uspid="1886" ordinal="3" offset="20" sl="22" sc="9" el="22" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="94" uspid="1883" ordinal="0" offset="0" sl="19" sc="9" el="19" ec="24" />
+                        </Method>
+                        <Method visited="false" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="3" visitedSequencePoints="0" numBranchPoints="1" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663590</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Model.Method::ShouldSerializeSummary()</Name>
+                            <FileRef uid="39" />
+                            <SequencePoints>
+                                <SequencePoint vc="0" uspid="1887" ordinal="0" offset="0" sl="33" sc="46" el="33" ec="47" />
+                                <SequencePoint vc="0" uspid="1888" ordinal="1" offset="1" sl="33" sc="48" el="33" ec="86" />
+                                <SequencePoint vc="0" uspid="1889" ordinal="2" offset="13" sl="33" sc="87" el="33" ec="88" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="0" uspid="1887" ordinal="0" offset="0" sl="33" sc="46" el="33" ec="47" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="2" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="8" visitedSequencePoints="8" numBranchPoints="3" visitedBranchPoints="3" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="2" minCyclomaticComplexity="2" />
+                            <MetadataToken>100663619</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.Method::MarkAsSkipped(OpenCover.Framework.Model.SkippedMethod)</Name>
+                            <FileRef uid="39" />
+                            <SequencePoints>
+                                <SequencePoint vc="15" uspid="1890" ordinal="0" offset="0" sl="117" sc="9" el="117" ec="10" />
+                                <SequencePoint vc="15" uspid="1891" ordinal="1" offset="1" sl="118" sc="13" el="118" ec="35" />
+                                <SequencePoint vc="15" uspid="1892" ordinal="2" offset="9" sl="119" sc="13" el="119" ec="37" />
+                                <SequencePoint vc="1" uspid="1893" ordinal="3" offset="22" sl="119" sc="38" el="119" ec="67" />
+                                <SequencePoint vc="15" uspid="1894" ordinal="4" offset="35" sl="120" sc="13" el="120" ec="32" />
+                                <SequencePoint vc="15" uspid="1895" ordinal="5" offset="43" sl="121" sc="13" el="121" ec="35" />
+                                <SequencePoint vc="15" uspid="1896" ordinal="6" offset="51" sl="122" sc="13" el="122" ec="33" />
+                                <SequencePoint vc="15" uspid="1897" ordinal="7" offset="59" sl="123" sc="9" el="123" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="1" uspid="1898" ordinal="0" offset="20" path="0" />
+                                <BranchPoint vc="14" uspid="1899" ordinal="1" offset="20" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="15" uspid="1890" ordinal="0" offset="0" sl="117" sc="9" el="117" ec="10" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="11" visitedSequencePoints="11" numBranchPoints="3" visitedBranchPoints="3" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                    <FullName>OpenCover.Framework.Model.Module</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663621</MetadataToken>
+                            <Name>OpenCover.Framework.Model.Summary OpenCover.Framework.Model.Module::get_Summary()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="267" uspid="1900" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663622</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.Module::set_Summary(OpenCover.Framework.Model.Summary)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="55" uspid="1901" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663624</MetadataToken>
+                            <Name>System.String OpenCover.Framework.Model.Module::get_FullName()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="6" uspid="1902" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663625</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.Module::set_FullName(System.String)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="34" uspid="1903" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663626</MetadataToken>
+                            <Name>System.Collections.Generic.IList`1&lt;System.String&gt; OpenCover.Framework.Model.Module::get_Aliases()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="38" uspid="1904" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663627</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.Module::set_Aliases(System.Collections.Generic.IList`1&lt;System.String&gt;)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="55" uspid="1905" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663628</MetadataToken>
+                            <Name>System.String OpenCover.Framework.Model.Module::get_ModuleName()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="2" uspid="1906" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663629</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.Module::set_ModuleName(System.String)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="8" uspid="1907" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663630</MetadataToken>
+                            <Name>OpenCover.Framework.Model.File[] OpenCover.Framework.Model.Module::get_Files()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="12" uspid="1908" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663631</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.Module::set_Files(OpenCover.Framework.Model.File[])</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="11" uspid="1909" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663632</MetadataToken>
+                            <Name>OpenCover.Framework.Model.Class[] OpenCover.Framework.Model.Module::get_Classes()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="224" uspid="1910" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663633</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.Module::set_Classes(OpenCover.Framework.Model.Class[])</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="81" uspid="1911" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663634</MetadataToken>
+                            <Name>OpenCover.Framework.Model.TrackedMethod[] OpenCover.Framework.Model.Module::get_TrackedMethods()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="7" uspid="1912" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663635</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.Module::set_TrackedMethods(OpenCover.Framework.Model.TrackedMethod[])</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="5" uspid="1913" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663636</MetadataToken>
+                            <Name>System.String OpenCover.Framework.Model.Module::get_ModuleHash()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="4" uspid="1914" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663637</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.Module::set_ModuleHash(System.String)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="12" uspid="1915" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="5" visitedSequencePoints="5" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663620</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.Module::.ctor()</Name>
+                            <FileRef uid="40" />
+                            <SequencePoints>
+                                <SequencePoint vc="55" uspid="1916" ordinal="0" offset="0" sl="22" sc="9" el="22" ec="24" />
+                                <SequencePoint vc="55" uspid="1917" ordinal="1" offset="7" sl="23" sc="9" el="23" ec="10" />
+                                <SequencePoint vc="55" uspid="1918" ordinal="2" offset="8" sl="24" sc="13" el="24" ec="42" />
+                                <SequencePoint vc="55" uspid="1919" ordinal="3" offset="20" sl="25" sc="13" el="25" ec="37" />
+                                <SequencePoint vc="55" uspid="1920" ordinal="4" offset="32" sl="26" sc="9" el="26" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="55" uspid="1916" ordinal="0" offset="0" sl="22" sc="9" el="22" ec="24" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="3" visitedSequencePoints="3" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663623</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Model.Module::ShouldSerializeSummary()</Name>
+                            <FileRef uid="40" />
+                            <SequencePoints>
+                                <SequencePoint vc="1" uspid="1921" ordinal="0" offset="0" sl="37" sc="46" el="37" ec="47" />
+                                <SequencePoint vc="1" uspid="1922" ordinal="1" offset="1" sl="37" sc="48" el="37" ec="86" />
+                                <SequencePoint vc="1" uspid="1923" ordinal="2" offset="13" sl="37" sc="87" el="37" ec="88" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="1" uspid="1921" ordinal="0" offset="0" sl="37" sc="46" el="37" ec="47" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="3" visitedSequencePoints="3" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663638</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.Module::MarkAsSkipped(OpenCover.Framework.Model.SkippedMethod)</Name>
+                            <FileRef uid="40" />
+                            <SequencePoints>
+                                <SequencePoint vc="6" uspid="1924" ordinal="0" offset="0" sl="77" sc="9" el="77" ec="10" />
+                                <SequencePoint vc="6" uspid="1925" ordinal="1" offset="1" sl="78" sc="13" el="78" ec="35" />
+                                <SequencePoint vc="6" uspid="1926" ordinal="2" offset="9" sl="79" sc="9" el="79" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="6" uspid="1924" ordinal="0" offset="0" sl="77" sc="9" el="77" ec="10" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                    <FullName>OpenCover.Framework.Model.SequencePoint</FullName>
+                    <Methods>
+                        <Method visited="false" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663639</MetadataToken>
+                            <Name>System.Int32 OpenCover.Framework.Model.SequencePoint::get_StartLine()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="0" uspid="1927" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663640</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.SequencePoint::set_StartLine(System.Int32)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="3" uspid="1928" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="false" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663641</MetadataToken>
+                            <Name>System.Int32 OpenCover.Framework.Model.SequencePoint::get_StartColumn()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="0" uspid="1929" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663642</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.SequencePoint::set_StartColumn(System.Int32)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="3" uspid="1930" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="false" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663643</MetadataToken>
+                            <Name>System.Int32 OpenCover.Framework.Model.SequencePoint::get_EndLine()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="0" uspid="1931" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663644</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.SequencePoint::set_EndLine(System.Int32)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="3" uspid="1932" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="false" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663645</MetadataToken>
+                            <Name>System.Int32 OpenCover.Framework.Model.SequencePoint::get_EndColumn()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="0" uspid="1933" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="true">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663646</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.SequencePoint::set_EndColumn(System.Int32)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="3" uspid="1934" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663647</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Model.SequencePoint::.ctor()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="10039" uspid="1935" ordinal="0" offset="0" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="27" visitedSequencePoints="0" numBranchPoints="20" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="7" minCyclomaticComplexity="1" />
+                    <FullName>OpenCover.Framework.ProfilerRegistration</FullName>
+                    <Methods>
+                        <Method visited="false" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="3" visitedSequencePoints="0" numBranchPoints="1" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663648</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.ProfilerRegistration::Register(System.Boolean)</Name>
+                            <FileRef uid="41" />
+                            <SequencePoints>
+                                <SequencePoint vc="0" uspid="1936" ordinal="0" offset="0" sl="30" sc="9" el="30" ec="10" />
+                                <SequencePoint vc="0" uspid="1937" ordinal="1" offset="1" sl="31" sc="13" el="31" ec="53" />
+                                <SequencePoint vc="0" uspid="1938" ordinal="2" offset="9" sl="32" sc="9" el="32" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="0" uspid="1936" ordinal="0" offset="0" sl="30" sc="9" el="30" ec="10" />
+                        </Method>
+                        <Method visited="false" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="3" visitedSequencePoints="0" numBranchPoints="1" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663649</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.ProfilerRegistration::Unregister(System.Boolean)</Name>
+                            <FileRef uid="41" />
+                            <SequencePoints>
+                                <SequencePoint vc="0" uspid="1939" ordinal="0" offset="0" sl="39" sc="9" el="39" ec="10" />
+                                <SequencePoint vc="0" uspid="1940" ordinal="1" offset="1" sl="40" sc="13" el="40" ec="54" />
+                                <SequencePoint vc="0" uspid="1941" ordinal="2" offset="9" sl="41" sc="9" el="41" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="0" uspid="1939" ordinal="0" offset="0" sl="39" sc="9" el="39" ec="10" />
+                        </Method>
+                        <Method visited="false" cyclomaticComplexity="2" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="7" visitedSequencePoints="0" numBranchPoints="3" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="2" minCyclomaticComplexity="2" />
+                            <MetadataToken>100663650</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.ProfilerRegistration::ExecuteRegsvr32(System.Boolean,System.Boolean)</Name>
+                            <FileRef uid="41" />
+                            <SequencePoints>
+                                <SequencePoint vc="0" uspid="1942" ordinal="0" offset="0" sl="44" sc="9" el="44" ec="10" />
+                                <SequencePoint vc="0" uspid="1943" ordinal="1" offset="1" sl="45" sc="13" el="45" ec="64" />
+                                <SequencePoint vc="0" uspid="1944" ordinal="2" offset="10" sl="46" sc="13" el="46" ec="52" />
+                                <SequencePoint vc="0" uspid="1945" ordinal="3" offset="22" sl="46" sc="53" el="46" ec="54" />
+                                <SequencePoint vc="0" uspid="1946" ordinal="4" offset="23" sl="46" sc="55" el="46" ec="105" />
+                                <SequencePoint vc="0" uspid="1947" ordinal="5" offset="32" sl="46" sc="106" el="46" ec="107" />
+                                <SequencePoint vc="0" uspid="1948" ordinal="6" offset="33" sl="47" sc="9" el="47" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="0" uspid="1949" ordinal="0" offset="20" path="0" />
+                                <BranchPoint vc="0" uspid="1950" ordinal="1" offset="20" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="0" uspid="1942" ordinal="0" offset="0" sl="44" sc="9" el="44" ec="10" />
+                        </Method>
+                        <Method visited="false" cyclomaticComplexity="7" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="8" visitedSequencePoints="0" numBranchPoints="9" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="7" minCyclomaticComplexity="7" />
+                            <MetadataToken>100663651</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.ProfilerRegistration::ExecuteRegsvr32(System.Boolean,System.Boolean,System.Boolean)</Name>
+                            <FileRef uid="41" />
+                            <SequencePoints>
+                                <SequencePoint vc="0" uspid="1951" ordinal="0" offset="0" sl="50" sc="9" el="50" ec="10" />
+                                <SequencePoint vc="0" uspid="1952" ordinal="1" offset="1" sl="51" sc="13" el="53" ec="118" />
+                                <SequencePoint vc="0" uspid="1953" ordinal="2" offset="82" sl="55" sc="13" el="55" ec="52" />
+                                <SequencePoint vc="0" uspid="1954" ordinal="3" offset="89" sl="56" sc="13" el="56" ec="35" />
+                                <SequencePoint vc="0" uspid="1955" ordinal="4" offset="96" sl="57" sc="13" el="57" ec="51" />
+                                <SequencePoint vc="0" uspid="1956" ordinal="5" offset="116" sl="58" sc="13" el="58" ec="14" />
+                                <SequencePoint vc="0" uspid="1957" ordinal="6" offset="117" sl="59" sc="17" el="61" ec="135" />
+                                <SequencePoint vc="0" uspid="1958" ordinal="7" offset="218" sl="63" sc="9" el="63" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="0" uspid="1959" ordinal="0" offset="24" path="0" />
+                                <BranchPoint vc="0" uspid="1960" ordinal="1" offset="24" path="1" />
+                                <BranchPoint vc="0" uspid="1961" ordinal="2" offset="46" path="0" />
+                                <BranchPoint vc="0" uspid="1962" ordinal="3" offset="46" path="1" />
+                                <BranchPoint vc="0" uspid="1963" ordinal="4" offset="97" path="0" />
+                                <BranchPoint vc="0" uspid="1964" ordinal="5" offset="97" path="1" />
+                                <BranchPoint vc="0" uspid="1965" ordinal="6" offset="114" path="0" />
+                                <BranchPoint vc="0" uspid="1966" ordinal="7" offset="114" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="0" uspid="1951" ordinal="0" offset="0" sl="50" sc="9" el="50" ec="10" />
+                        </Method>
+                        <Method visited="false" cyclomaticComplexity="2" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="3" visitedSequencePoints="0" numBranchPoints="3" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="2" minCyclomaticComplexity="2" />
+                            <MetadataToken>100663652</MetadataToken>
+                            <Name>System.String OpenCover.Framework.ProfilerRegistration::GetAssemblyLocation()</Name>
+                            <FileRef uid="41" />
+                            <SequencePoints>
+                                <SequencePoint vc="0" uspid="1967" ordinal="0" offset="0" sl="70" sc="9" el="70" ec="10" />
+                                <SequencePoint vc="0" uspid="1968" ordinal="1" offset="1" sl="71" sc="13" el="71" ec="106" />
+                                <SequencePoint vc="0" uspid="1969" ordinal="2" offset="38" sl="72" sc="9" el="72" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="0" uspid="1970" ordinal="0" offset="22" path="0" />
+                                <BranchPoint vc="0" uspid="1971" ordinal="1" offset="22" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="0" uspid="1967" ordinal="0" offset="0" sl="70" sc="9" el="70" ec="10" />
+                        </Method>
+                        <Method visited="false" cyclomaticComplexity="3" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="3" visitedSequencePoints="0" numBranchPoints="3" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="3" minCyclomaticComplexity="3" />
+                            <MetadataToken>100663653</MetadataToken>
+                            <Name>System.String OpenCover.Framework.ProfilerRegistration::GetProfilerPath(System.Boolean)</Name>
+                            <FileRef uid="41" />
+                            <SequencePoints>
+                                <SequencePoint vc="0" uspid="1972" ordinal="0" offset="0" sl="79" sc="9" el="79" ec="10" />
+                                <SequencePoint vc="0" uspid="1973" ordinal="1" offset="1" sl="80" sc="13" el="80" ec="107" />
+                                <SequencePoint vc="0" uspid="1974" ordinal="2" offset="40" sl="81" sc="9" el="81" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="0" uspid="1975" ordinal="0" offset="7" path="0" />
+                                <BranchPoint vc="0" uspid="1976" ordinal="1" offset="7" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="0" uspid="1972" ordinal="0" offset="0" sl="79" sc="9" el="79" ec="10" />
+                        </Method>
+                        <Method visited="false" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663654</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.ProfilerRegistration::.ctor()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="0" uspid="1977" ordinal="0" offset="0" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="55" visitedSequencePoints="54" numBranchPoints="20" visitedBranchPoints="19" sequenceCoverage="98.18" branchCoverage="95" maxCyclomaticComplexity="6" minCyclomaticComplexity="1" />
+                    <FullName>OpenCover.Framework.Service.ProfilerCommunication</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="6" visitedSequencePoints="6" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663660</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Service.ProfilerCommunication::.ctor(OpenCover.Framework.IFilter,OpenCover.Framework.Persistance.IPersistance,OpenCover.Framework.Model.IInstrumentationModelBuilderFactory)</Name>
+                            <FileRef uid="42" />
+                            <SequencePoints>
+                                <SequencePoint vc="14" uspid="1978" ordinal="0" offset="0" sl="21" sc="9" el="23" ec="84" />
+                                <SequencePoint vc="14" uspid="1979" ordinal="1" offset="7" sl="24" sc="9" el="24" ec="10" />
+                                <SequencePoint vc="14" uspid="1980" ordinal="2" offset="8" sl="25" sc="13" el="25" ec="30" />
+                                <SequencePoint vc="14" uspid="1981" ordinal="3" offset="15" sl="26" sc="13" el="26" ec="40" />
+                                <SequencePoint vc="14" uspid="1982" ordinal="4" offset="22" sl="27" sc="13" el="27" ec="86" />
+                                <SequencePoint vc="14" uspid="1983" ordinal="5" offset="29" sl="28" sc="9" el="28" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="14" uspid="1978" ordinal="0" offset="0" sl="21" sc="9" el="23" ec="84" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="6" sequenceCoverage="95.65" branchCoverage="90.91" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="23" visitedSequencePoints="22" numBranchPoints="11" visitedBranchPoints="10" sequenceCoverage="95.65" branchCoverage="90.91" maxCyclomaticComplexity="6" minCyclomaticComplexity="6" />
+                            <MetadataToken>100663661</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Service.ProfilerCommunication::TrackAssembly(System.String,System.String)</Name>
+                            <FileRef uid="42" />
+                            <SequencePoints>
+                                <SequencePoint vc="4" uspid="1984" ordinal="0" offset="0" sl="31" sc="9" el="31" ec="10" />
+                                <SequencePoint vc="4" uspid="1985" ordinal="1" offset="1" sl="32" sc="13" el="32" ec="53" />
+                                <SequencePoint vc="0" uspid="1986" ordinal="2" offset="20" sl="32" sc="54" el="32" ec="66" />
+                                <SequencePoint vc="4" uspid="1987" ordinal="3" offset="27" sl="33" sc="13" el="33" ec="34" />
+                                <SequencePoint vc="4" uspid="1988" ordinal="4" offset="29" sl="34" sc="13" el="34" ec="108" />
+                                <SequencePoint vc="4" uspid="1989" ordinal="5" offset="43" sl="35" sc="13" el="35" ec="52" />
+                                <SequencePoint vc="2" uspid="1990" ordinal="6" offset="59" sl="36" sc="13" el="36" ec="14" />
+                                <SequencePoint vc="2" uspid="1991" ordinal="7" offset="60" sl="37" sc="17" el="37" ec="58" />
+                                <SequencePoint vc="2" uspid="1992" ordinal="8" offset="68" sl="38" sc="17" el="38" ec="60" />
+                                <SequencePoint vc="2" uspid="1993" ordinal="9" offset="76" sl="39" sc="13" el="39" ec="14" />
+                                <SequencePoint vc="2" uspid="1994" ordinal="10" offset="79" sl="40" sc="18" el="40" ec="45" />
+                                <SequencePoint vc="1" uspid="1995" ordinal="11" offset="89" sl="41" sc="13" el="41" ec="14" />
+                                <SequencePoint vc="1" uspid="1996" ordinal="12" offset="90" sl="42" sc="17" el="42" ec="58" />
+                                <SequencePoint vc="1" uspid="1997" ordinal="13" offset="98" sl="43" sc="17" el="43" ec="64" />
+                                <SequencePoint vc="1" uspid="1998" ordinal="14" offset="106" sl="44" sc="13" el="44" ec="14" />
+                                <SequencePoint vc="4" uspid="1999" ordinal="15" offset="107" sl="46" sc="13" el="46" ec="63" />
+                                <SequencePoint vc="4" uspid="2000" ordinal="16" offset="120" sl="48" sc="13" el="48" ec="53" />
+                                <SequencePoint vc="1" uspid="2001" ordinal="17" offset="139" sl="49" sc="13" el="49" ec="14" />
+                                <SequencePoint vc="1" uspid="2002" ordinal="18" offset="140" sl="50" sc="17" el="50" ec="70" />
+                                <SequencePoint vc="1" uspid="2003" ordinal="19" offset="149" sl="51" sc="13" el="51" ec="14" />
+                                <SequencePoint vc="4" uspid="2004" ordinal="20" offset="150" sl="52" sc="13" el="52" ec="48" />
+                                <SequencePoint vc="4" uspid="2005" ordinal="21" offset="163" sl="53" sc="13" el="53" ec="58" />
+                                <SequencePoint vc="4" uspid="2006" ordinal="22" offset="175" sl="54" sc="9" el="54" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="0" uspid="2007" ordinal="0" offset="18" path="0" />
+                                <BranchPoint vc="4" uspid="2008" ordinal="1" offset="18" path="1" />
+                                <BranchPoint vc="2" uspid="2009" ordinal="2" offset="57" path="0" />
+                                <BranchPoint vc="2" uspid="2010" ordinal="3" offset="57" path="1" />
+                                <BranchPoint vc="1" uspid="2011" ordinal="4" offset="87" path="0" />
+                                <BranchPoint vc="1" uspid="2012" ordinal="5" offset="87" path="1" />
+                                <BranchPoint vc="1" uspid="2013" ordinal="6" offset="109" path="0" />
+                                <BranchPoint vc="3" uspid="2014" ordinal="7" offset="109" path="1" />
+                                <BranchPoint vc="1" uspid="2015" ordinal="8" offset="137" path="0" />
+                                <BranchPoint vc="3" uspid="2016" ordinal="9" offset="137" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="4" uspid="1984" ordinal="0" offset="0" sl="31" sc="9" el="31" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="6" visitedSequencePoints="6" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663662</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Service.ProfilerCommunication::GetBranchPoints(System.String,System.String,System.Int32,OpenCover.Framework.Model.BranchPoint[]&amp;)</Name>
+                            <FileRef uid="42" />
+                            <SequencePoints>
+                                <SequencePoint vc="2" uspid="2017" ordinal="0" offset="27" sl="57" sc="9" el="57" ec="10" />
+                                <SequencePoint vc="2" uspid="2018" ordinal="1" offset="28" sl="58" sc="13" el="58" ec="41" />
+                                <SequencePoint vc="2" uspid="2019" ordinal="2" offset="35" sl="60" sc="13" el="61" ec="84" />
+                                <SequencePoint vc="2" uspid="2020" ordinal="3" offset="69" sl="63" sc="13" el="63" ec="39" />
+                                <SequencePoint vc="2" uspid="2021" ordinal="4" offset="78" sl="64" sc="13" el="64" ec="24" />
+                                <SequencePoint vc="2" uspid="2022" ordinal="5" offset="82" sl="65" sc="9" el="65" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint vc="2" uspid="2023" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="6" visitedSequencePoints="6" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663663</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Service.ProfilerCommunication::GetSequencePoints(System.String,System.String,System.Int32,OpenCover.Framework.Model.InstrumentationPoint[]&amp;)</Name>
+                            <FileRef uid="42" />
+                            <SequencePoints>
+                                <SequencePoint vc="4" uspid="2024" ordinal="0" offset="27" sl="68" sc="9" el="68" ec="10" />
+                                <SequencePoint vc="4" uspid="2025" ordinal="1" offset="28" sl="69" sc="13" el="69" ec="50" />
+                                <SequencePoint vc="4" uspid="2026" ordinal="2" offset="35" sl="71" sc="13" el="72" ec="96" />
+                                <SequencePoint vc="4" uspid="2027" ordinal="3" offset="69" sl="74" sc="13" el="74" ec="39" />
+                                <SequencePoint vc="4" uspid="2028" ordinal="4" offset="78" sl="75" sc="13" el="75" ec="24" />
+                                <SequencePoint vc="4" uspid="2029" ordinal="5" offset="82" sl="76" sc="9" el="76" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint vc="4" uspid="2030" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="2" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="4" visitedSequencePoints="4" numBranchPoints="3" visitedBranchPoints="3" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="2" minCyclomaticComplexity="2" />
+                            <MetadataToken>100663664</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Service.ProfilerCommunication::GetPoints(System.Func`1&lt;System.Boolean&gt;,System.String,System.String,System.Int32,T[]&amp;)</Name>
+                            <FileRef uid="42" />
+                            <SequencePoints>
+                                <SequencePoint vc="6" uspid="2031" ordinal="0" offset="0" sl="79" sc="9" el="79" ec="10" />
+                                <SequencePoint vc="6" uspid="2032" ordinal="1" offset="1" sl="80" sc="13" el="80" ec="31" />
+                                <SequencePoint vc="6" uspid="2033" ordinal="2" offset="10" sl="81" sc="13" el="81" ec="96" />
+                                <SequencePoint vc="6" uspid="2034" ordinal="3" offset="35" sl="82" sc="9" el="82" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="4" uspid="2035" ordinal="0" offset="20" path="0" />
+                                <BranchPoint vc="2" uspid="2036" ordinal="1" offset="20" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="6" uspid="2031" ordinal="0" offset="0" sl="79" sc="9" el="79" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="4" visitedSequencePoints="4" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663665</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Service.ProfilerCommunication::CanReturnPoints(System.String,System.String,System.Int32)</Name>
+                            <FileRef uid="42" />
+                            <SequencePoints>
+                                <SequencePoint vc="6" uspid="2037" ordinal="0" offset="0" sl="85" sc="9" el="85" ec="10" />
+                                <SequencePoint vc="6" uspid="2038" ordinal="1" offset="1" sl="86" sc="13" el="86" ec="86" />
+                                <SequencePoint vc="6" uspid="2039" ordinal="2" offset="15" sl="87" sc="13" el="87" ec="69" />
+                                <SequencePoint vc="6" uspid="2040" ordinal="3" offset="31" sl="88" sc="9" el="88" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="6" uspid="2037" ordinal="0" offset="0" sl="85" sc="9" el="85" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="3" visitedSequencePoints="3" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663666</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Service.ProfilerCommunication::Stopping()</Name>
+                            <FileRef uid="42" />
+                            <SequencePoints>
+                                <SequencePoint vc="1" uspid="2041" ordinal="0" offset="0" sl="91" sc="9" el="91" ec="10" />
+                                <SequencePoint vc="1" uspid="2042" ordinal="1" offset="1" sl="92" sc="13" el="92" ec="35" />
+                                <SequencePoint vc="1" uspid="2043" ordinal="2" offset="13" sl="93" sc="9" el="93" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="1" uspid="2041" ordinal="0" offset="0" sl="91" sc="9" el="91" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="3" visitedSequencePoints="3" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663667</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Service.ProfilerCommunication::TrackMethod(System.String,System.String,System.Int32,System.UInt32&amp;)</Name>
+                            <FileRef uid="42" />
+                            <SequencePoints>
+                                <SequencePoint vc="2" uspid="2044" ordinal="0" offset="0" sl="96" sc="9" el="96" ec="10" />
+                                <SequencePoint vc="2" uspid="2045" ordinal="1" offset="1" sl="97" sc="13" el="97" ec="105" />
+                                <SequencePoint vc="2" uspid="2046" ordinal="2" offset="20" sl="98" sc="9" el="98" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="2" uspid="2044" ordinal="0" offset="0" sl="96" sc="9" el="96" ec="10" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                    <FullName>OpenCover.Framework.Service.ProfilerCommunication/&lt;&gt;c__DisplayClass1</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663782</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Service.ProfilerCommunication/&lt;&gt;c__DisplayClass1::.ctor()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="2" uspid="2047" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663783</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Service.ProfilerCommunication/&lt;&gt;c__DisplayClass1::&lt;GetBranchPoints&gt;b__0()</Name>
+                            <FileRef uid="42" />
+                            <SequencePoints>
+                                <SequencePoint vc="2" uspid="2048" ordinal="0" offset="0" sl="60" sc="39" el="60" ec="117" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="2" uspid="2048" ordinal="0" offset="0" sl="60" sc="39" el="60" ec="117" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                    <FullName>OpenCover.Framework.Service.ProfilerCommunication/&lt;&gt;c__DisplayClass4</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663784</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Service.ProfilerCommunication/&lt;&gt;c__DisplayClass4::.ctor()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="4" uspid="2049" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663785</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Service.ProfilerCommunication/&lt;&gt;c__DisplayClass4::&lt;GetSequencePoints&gt;b__3()</Name>
+                            <FileRef uid="42" />
+                            <SequencePoints>
+                                <SequencePoint vc="2" uspid="2050" ordinal="0" offset="0" sl="71" sc="39" el="71" ec="119" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="2" uspid="2050" ordinal="0" offset="0" sl="71" sc="39" el="71" ec="119" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="9" visitedSequencePoints="9" numBranchPoints="19" visitedBranchPoints="13" sequenceCoverage="100" branchCoverage="68.42" maxCyclomaticComplexity="7" minCyclomaticComplexity="1" />
+                    <FullName>OpenCover.Framework.Strategy.TrackMSTestTestMethods</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="7" sequenceCoverage="100" branchCoverage="53.85" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="3" visitedSequencePoints="3" numBranchPoints="13" visitedBranchPoints="7" sequenceCoverage="100" branchCoverage="53.85" maxCyclomaticComplexity="7" minCyclomaticComplexity="7" />
+                            <MetadataToken>100663669</MetadataToken>
+                            <Name>System.Collections.Generic.IEnumerable`1&lt;OpenCover.Framework.Model.TrackedMethod&gt; OpenCover.Framework.Strategy.TrackMSTestTestMethods::GetTrackedMethods(System.Collections.Generic.IEnumerable`1&lt;Mono.Cecil.TypeDefinition&gt;)</Name>
+                            <FileRef uid="45" />
+                            <SequencePoints>
+                                <SequencePoint vc="1" uspid="2051" ordinal="0" offset="0" sl="14" sc="9" el="14" ec="10" />
+                                <SequencePoint vc="1" uspid="2052" ordinal="1" offset="1" sl="15" sc="13" el="24" ec="35" />
+                                <SequencePoint vc="1" uspid="2053" ordinal="2" offset="211" sl="25" sc="9" el="25" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="1" uspid="2054" ordinal="0" offset="7" path="0" />
+                                <BranchPoint vc="0" uspid="2055" ordinal="1" offset="7" path="1" />
+                                <BranchPoint vc="1" uspid="2056" ordinal="2" offset="38" path="0" />
+                                <BranchPoint vc="0" uspid="2057" ordinal="3" offset="38" path="1" />
+                                <BranchPoint vc="1" uspid="2058" ordinal="4" offset="74" path="0" />
+                                <BranchPoint vc="0" uspid="2059" ordinal="5" offset="74" path="1" />
+                                <BranchPoint vc="1" uspid="2060" ordinal="6" offset="105" path="0" />
+                                <BranchPoint vc="0" uspid="2061" ordinal="7" offset="105" path="1" />
+                                <BranchPoint vc="1" uspid="2062" ordinal="8" offset="141" path="0" />
+                                <BranchPoint vc="0" uspid="2063" ordinal="9" offset="141" path="1" />
+                                <BranchPoint vc="1" uspid="2064" ordinal="10" offset="177" path="0" />
+                                <BranchPoint vc="0" uspid="2065" ordinal="11" offset="177" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="1" uspid="2051" ordinal="0" offset="0" sl="14" sc="9" el="14" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663670</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Strategy.TrackMSTestTestMethods::.ctor()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="3" uspid="2066" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663671</MetadataToken>
+                            <Name>System.Collections.Generic.IEnumerable`1&lt;Mono.Cecil.MethodDefinition&gt; OpenCover.Framework.Strategy.TrackMSTestTestMethods::&lt;GetTrackedMethods&gt;b__3(Mono.Cecil.TypeDefinition)</Name>
+                            <FileRef uid="45" />
+                            <SequencePoints>
+                                <SequencePoint vc="42" uspid="2067" ordinal="0" offset="0" sl="16" sc="46" el="16" ec="68" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="42" uspid="2067" ordinal="0" offset="0" sl="16" sc="46" el="16" ec="68" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663672</MetadataToken>
+                            <Name>&lt;&gt;f__AnonymousType1`2&lt;Mono.Cecil.TypeDefinition,Mono.Cecil.MethodDefinition&gt; OpenCover.Framework.Strategy.TrackMSTestTestMethods::&lt;GetTrackedMethods&gt;b__4(Mono.Cecil.TypeDefinition,Mono.Cecil.MethodDefinition)</Name>
+                            <FileRef uid="45" />
+                            <SequencePoints>
+                                <SequencePoint vc="377" uspid="2068" ordinal="0" offset="0" sl="16" sc="46" el="16" ec="68" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="377" uspid="2068" ordinal="0" offset="0" sl="16" sc="46" el="16" ec="68" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663673</MetadataToken>
+                            <Name>System.Collections.Generic.IEnumerable`1&lt;Mono.Cecil.CustomAttribute&gt; OpenCover.Framework.Strategy.TrackMSTestTestMethods::&lt;GetTrackedMethods&gt;b__5(&lt;&gt;f__AnonymousType1`2&lt;Mono.Cecil.TypeDefinition,Mono.Cecil.MethodDefinition&gt;)</Name>
+                            <FileRef uid="45" />
+                            <SequencePoints>
+                                <SequencePoint vc="377" uspid="2069" ordinal="0" offset="0" sl="17" sc="45" el="17" ec="78" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="377" uspid="2069" ordinal="0" offset="0" sl="17" sc="45" el="17" ec="78" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663674</MetadataToken>
+                            <Name>&lt;&gt;f__AnonymousType2`2&lt;&lt;&gt;f__AnonymousType1`2&lt;Mono.Cecil.TypeDefinition,Mono.Cecil.MethodDefinition&gt;,Mono.Cecil.CustomAttribute&gt; OpenCover.Framework.Strategy.TrackMSTestTestMethods::&lt;GetTrackedMethods&gt;b__6(&lt;&gt;f__AnonymousType1`2&lt;Mono.Cecil.TypeDefinition,Mono.Cecil.MethodDefinition&gt;,Mono.Cecil.CustomAttribute)</Name>
+                            <FileRef uid="45" />
+                            <SequencePoints>
+                                <SequencePoint vc="304" uspid="2070" ordinal="0" offset="0" sl="17" sc="45" el="17" ec="78" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="304" uspid="2070" ordinal="0" offset="0" sl="17" sc="45" el="17" ec="78" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663675</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Strategy.TrackMSTestTestMethods::&lt;GetTrackedMethods&gt;b__7(&lt;&gt;f__AnonymousType2`2&lt;&lt;&gt;f__AnonymousType1`2&lt;Mono.Cecil.TypeDefinition,Mono.Cecil.MethodDefinition&gt;,Mono.Cecil.CustomAttribute&gt;)</Name>
+                            <FileRef uid="45" />
+                            <SequencePoints>
+                                <SequencePoint vc="304" uspid="2071" ordinal="0" offset="0" sl="18" sc="27" el="18" ec="135" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="304" uspid="2071" ordinal="0" offset="0" sl="18" sc="27" el="18" ec="135" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663676</MetadataToken>
+                            <Name>OpenCover.Framework.Model.TrackedMethod OpenCover.Framework.Strategy.TrackMSTestTestMethods::&lt;GetTrackedMethods&gt;b__8(&lt;&gt;f__AnonymousType2`2&lt;&lt;&gt;f__AnonymousType1`2&lt;Mono.Cecil.TypeDefinition,Mono.Cecil.MethodDefinition&gt;,Mono.Cecil.CustomAttribute&gt;)</Name>
+                            <FileRef uid="45" />
+                            <SequencePoints>
+                                <SequencePoint vc="1" uspid="2072" ordinal="0" offset="0" sl="19" sc="28" el="24" ec="33" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="1" uspid="2072" ordinal="0" offset="0" sl="19" sc="28" el="24" ec="33" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="9" visitedSequencePoints="9" numBranchPoints="19" visitedBranchPoints="13" sequenceCoverage="100" branchCoverage="68.42" maxCyclomaticComplexity="7" minCyclomaticComplexity="1" />
+                    <FullName>OpenCover.Framework.Strategy.TrackNUnitTestMethods</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="7" sequenceCoverage="100" branchCoverage="53.85" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="3" visitedSequencePoints="3" numBranchPoints="13" visitedBranchPoints="7" sequenceCoverage="100" branchCoverage="53.85" maxCyclomaticComplexity="7" minCyclomaticComplexity="7" />
+                            <MetadataToken>100663677</MetadataToken>
+                            <Name>System.Collections.Generic.IEnumerable`1&lt;OpenCover.Framework.Model.TrackedMethod&gt; OpenCover.Framework.Strategy.TrackNUnitTestMethods::GetTrackedMethods(System.Collections.Generic.IEnumerable`1&lt;Mono.Cecil.TypeDefinition&gt;)</Name>
+                            <FileRef uid="46" />
+                            <SequencePoints>
+                                <SequencePoint vc="1" uspid="2073" ordinal="0" offset="0" sl="17" sc="9" el="17" ec="10" />
+                                <SequencePoint vc="1" uspid="2074" ordinal="1" offset="1" sl="18" sc="13" el="27" ec="24" />
+                                <SequencePoint vc="1" uspid="2075" ordinal="2" offset="211" sl="28" sc="9" el="28" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="1" uspid="2076" ordinal="0" offset="7" path="0" />
+                                <BranchPoint vc="0" uspid="2077" ordinal="1" offset="7" path="1" />
+                                <BranchPoint vc="1" uspid="2078" ordinal="2" offset="38" path="0" />
+                                <BranchPoint vc="0" uspid="2079" ordinal="3" offset="38" path="1" />
+                                <BranchPoint vc="1" uspid="2080" ordinal="4" offset="74" path="0" />
+                                <BranchPoint vc="0" uspid="2081" ordinal="5" offset="74" path="1" />
+                                <BranchPoint vc="1" uspid="2082" ordinal="6" offset="105" path="0" />
+                                <BranchPoint vc="0" uspid="2083" ordinal="7" offset="105" path="1" />
+                                <BranchPoint vc="1" uspid="2084" ordinal="8" offset="141" path="0" />
+                                <BranchPoint vc="0" uspid="2085" ordinal="9" offset="141" path="1" />
+                                <BranchPoint vc="1" uspid="2086" ordinal="10" offset="177" path="0" />
+                                <BranchPoint vc="0" uspid="2087" ordinal="11" offset="177" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="1" uspid="2073" ordinal="0" offset="0" sl="17" sc="9" el="17" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663678</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Strategy.TrackNUnitTestMethods::.ctor()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="3" uspid="2088" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663679</MetadataToken>
+                            <Name>System.Collections.Generic.IEnumerable`1&lt;Mono.Cecil.MethodDefinition&gt; OpenCover.Framework.Strategy.TrackNUnitTestMethods::&lt;GetTrackedMethods&gt;b__3(Mono.Cecil.TypeDefinition)</Name>
+                            <FileRef uid="46" />
+                            <SequencePoints>
+                                <SequencePoint vc="23" uspid="2089" ordinal="0" offset="0" sl="19" sc="46" el="19" ec="68" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="23" uspid="2089" ordinal="0" offset="0" sl="19" sc="46" el="19" ec="68" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663680</MetadataToken>
+                            <Name>&lt;&gt;f__AnonymousType1`2&lt;Mono.Cecil.TypeDefinition,Mono.Cecil.MethodDefinition&gt; OpenCover.Framework.Strategy.TrackNUnitTestMethods::&lt;GetTrackedMethods&gt;b__4(Mono.Cecil.TypeDefinition,Mono.Cecil.MethodDefinition)</Name>
+                            <FileRef uid="46" />
+                            <SequencePoints>
+                                <SequencePoint vc="245" uspid="2090" ordinal="0" offset="0" sl="19" sc="46" el="19" ec="68" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="245" uspid="2090" ordinal="0" offset="0" sl="19" sc="46" el="19" ec="68" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663681</MetadataToken>
+                            <Name>System.Collections.Generic.IEnumerable`1&lt;Mono.Cecil.CustomAttribute&gt; OpenCover.Framework.Strategy.TrackNUnitTestMethods::&lt;GetTrackedMethods&gt;b__5(&lt;&gt;f__AnonymousType1`2&lt;Mono.Cecil.TypeDefinition,Mono.Cecil.MethodDefinition&gt;)</Name>
+                            <FileRef uid="46" />
+                            <SequencePoints>
+                                <SequencePoint vc="245" uspid="2091" ordinal="0" offset="0" sl="20" sc="45" el="20" ec="78" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="245" uspid="2091" ordinal="0" offset="0" sl="20" sc="45" el="20" ec="78" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663682</MetadataToken>
+                            <Name>&lt;&gt;f__AnonymousType2`2&lt;&lt;&gt;f__AnonymousType1`2&lt;Mono.Cecil.TypeDefinition,Mono.Cecil.MethodDefinition&gt;,Mono.Cecil.CustomAttribute&gt; OpenCover.Framework.Strategy.TrackNUnitTestMethods::&lt;GetTrackedMethods&gt;b__6(&lt;&gt;f__AnonymousType1`2&lt;Mono.Cecil.TypeDefinition,Mono.Cecil.MethodDefinition&gt;,Mono.Cecil.CustomAttribute)</Name>
+                            <FileRef uid="46" />
+                            <SequencePoints>
+                                <SequencePoint vc="207" uspid="2092" ordinal="0" offset="0" sl="20" sc="45" el="20" ec="78" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="207" uspid="2092" ordinal="0" offset="0" sl="20" sc="45" el="20" ec="78" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663683</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Strategy.TrackNUnitTestMethods::&lt;GetTrackedMethods&gt;b__7(&lt;&gt;f__AnonymousType2`2&lt;&lt;&gt;f__AnonymousType1`2&lt;Mono.Cecil.TypeDefinition,Mono.Cecil.MethodDefinition&gt;,Mono.Cecil.CustomAttribute&gt;)</Name>
+                            <FileRef uid="46" />
+                            <SequencePoints>
+                                <SequencePoint vc="207" uspid="2093" ordinal="0" offset="0" sl="21" sc="27" el="21" ec="100" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="207" uspid="2093" ordinal="0" offset="0" sl="21" sc="27" el="21" ec="100" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663684</MetadataToken>
+                            <Name>OpenCover.Framework.Model.TrackedMethod OpenCover.Framework.Strategy.TrackNUnitTestMethods::&lt;GetTrackedMethods&gt;b__8(&lt;&gt;f__AnonymousType2`2&lt;&lt;&gt;f__AnonymousType1`2&lt;Mono.Cecil.TypeDefinition,Mono.Cecil.MethodDefinition&gt;,Mono.Cecil.CustomAttribute&gt;)</Name>
+                            <FileRef uid="46" />
+                            <SequencePoints>
+                                <SequencePoint vc="157" uspid="2094" ordinal="0" offset="0" sl="22" sc="28" el="27" ec="22" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="157" uspid="2094" ordinal="0" offset="0" sl="22" sc="28" el="27" ec="22" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="328" visitedSequencePoints="316" numBranchPoints="182" visitedBranchPoints="156" sequenceCoverage="96.34" branchCoverage="85.71" maxCyclomaticComplexity="18" minCyclomaticComplexity="1" />
+                    <FullName>OpenCover.Framework.Symbols.CecilSymbolManager</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="3" visitedSequencePoints="3" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663696</MetadataToken>
+                            <Name>System.String OpenCover.Framework.Symbols.CecilSymbolManager::get_ModulePath()</Name>
+                            <FileRef uid="47" />
+                            <SequencePoints>
+                                <SequencePoint vc="1" uspid="2095" ordinal="0" offset="0" sl="47" sc="17" el="47" ec="18" />
+                                <SequencePoint vc="1" uspid="2096" ordinal="1" offset="1" sl="47" sc="19" el="47" ec="38" />
+                                <SequencePoint vc="1" uspid="2097" ordinal="2" offset="10" sl="47" sc="39" el="47" ec="40" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="1" uspid="2095" ordinal="0" offset="0" sl="47" sc="17" el="47" ec="18" />
+                        </Method>
+                        <Method visited="false" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="3" visitedSequencePoints="0" numBranchPoints="1" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663697</MetadataToken>
+                            <Name>System.String OpenCover.Framework.Symbols.CecilSymbolManager::get_ModuleName()</Name>
+                            <FileRef uid="47" />
+                            <SequencePoints>
+                                <SequencePoint vc="0" uspid="2098" ordinal="0" offset="0" sl="52" sc="17" el="52" ec="18" />
+                                <SequencePoint vc="0" uspid="2099" ordinal="1" offset="1" sl="52" sc="19" el="52" ec="38" />
+                                <SequencePoint vc="0" uspid="2100" ordinal="2" offset="10" sl="52" sc="39" el="52" ec="40" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="0" uspid="2098" ordinal="0" offset="0" sl="52" sc="17" el="52" ec="18" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="6" sequenceCoverage="100" branchCoverage="81.82" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="29" visitedSequencePoints="29" numBranchPoints="11" visitedBranchPoints="9" sequenceCoverage="100" branchCoverage="81.82" maxCyclomaticComplexity="6" minCyclomaticComplexity="6" />
+                            <MetadataToken>100663701</MetadataToken>
+                            <Name>Mono.Cecil.AssemblyDefinition OpenCover.Framework.Symbols.CecilSymbolManager::get_SourceAssembly()</Name>
+                            <FileRef uid="47" />
+                            <SequencePoints>
+                                <SequencePoint vc="71" uspid="2101" ordinal="0" offset="0" sl="84" sc="13" el="84" ec="14" />
+                                <SequencePoint vc="71" uspid="2102" ordinal="1" offset="1" sl="85" sc="17" el="85" ec="43" />
+                                <SequencePoint vc="29" uspid="2103" ordinal="2" offset="22" sl="86" sc="17" el="86" ec="18" />
+                                <SequencePoint vc="29" uspid="2104" ordinal="3" offset="23" sl="87" sc="21" el="87" ec="68" />
+                                <SequencePoint vc="29" uspid="2105" ordinal="4" offset="29" sl="89" sc="21" el="89" ec="22" />
+                                <SequencePoint vc="29" uspid="2106" ordinal="5" offset="30" sl="90" sc="25" el="90" ec="58" />
+                                <SequencePoint vc="26" uspid="2107" ordinal="6" offset="37" sl="91" sc="25" el="91" ec="73" />
+                                <SequencePoint vc="26" uspid="2108" ordinal="7" offset="48" sl="93" sc="25" el="98" ec="27" />
+                                <SequencePoint vc="26" uspid="2109" ordinal="8" offset="84" sl="99" sc="25" el="99" ec="140" />
+                                <SequencePoint vc="26" uspid="2110" ordinal="9" offset="113" sl="101" sc="25" el="101" ec="53" />
+                                <SequencePoint vc="26" uspid="2111" ordinal="10" offset="128" sl="102" sc="29" el="102" ec="70" />
+                                <SequencePoint vc="26" uspid="2112" ordinal="11" offset="145" sl="103" sc="21" el="103" ec="22" />
+                                <SequencePoint vc="3" uspid="2113" ordinal="12" offset="148" sl="104" sc="21" el="104" ec="41" />
+                                <SequencePoint vc="3" uspid="2114" ordinal="13" offset="150" sl="105" sc="21" el="105" ec="22" />
+                                <SequencePoint vc="3" uspid="2115" ordinal="14" offset="151" sl="107" sc="25" el="107" ec="48" />
+                                <SequencePoint vc="3" uspid="2116" ordinal="15" offset="158" sl="108" sc="21" el="108" ec="22" />
+                                <SequencePoint vc="29" uspid="2117" ordinal="16" offset="164" sl="110" sc="21" el="110" ec="22" />
+                                <SequencePoint vc="29" uspid="2118" ordinal="17" offset="165" sl="111" sc="25" el="111" ec="68" />
+                                <SequencePoint vc="29" uspid="2119" ordinal="18" offset="172" sl="112" sc="21" el="112" ec="22" />
+                                <SequencePoint vc="29" uspid="2120" ordinal="19" offset="175" sl="113" sc="21" el="113" ec="49" />
+                                <SequencePoint vc="3" uspid="2121" ordinal="20" offset="193" sl="114" sc="21" el="114" ec="22" />
+                                <SequencePoint vc="3" uspid="2122" ordinal="21" offset="194" sl="115" sc="25" el="115" ec="52" />
+                                <SequencePoint vc="1" uspid="2123" ordinal="22" offset="214" sl="116" sc="25" el="116" ec="26" />
+                                <SequencePoint vc="1" uspid="2124" ordinal="23" offset="215" sl="117" sc="29" el="117" ec="113" />
+                                <SequencePoint vc="1" uspid="2125" ordinal="24" offset="238" sl="118" sc="25" el="118" ec="26" />
+                                <SequencePoint vc="3" uspid="2126" ordinal="25" offset="239" sl="119" sc="21" el="119" ec="22" />
+                                <SequencePoint vc="29" uspid="2127" ordinal="26" offset="240" sl="120" sc="17" el="120" ec="18" />
+                                <SequencePoint vc="71" uspid="2128" ordinal="27" offset="241" sl="121" sc="17" el="121" ec="40" />
+                                <SequencePoint vc="71" uspid="2129" ordinal="28" offset="251" sl="122" sc="13" el="122" ec="14" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="29" uspid="2130" ordinal="0" offset="17" path="0" />
+                                <BranchPoint vc="42" uspid="2131" ordinal="1" offset="17" path="1" />
+                                <BranchPoint vc="0" uspid="2132" ordinal="2" offset="39" path="0" />
+                                <BranchPoint vc="26" uspid="2133" ordinal="3" offset="39" path="1" />
+                                <BranchPoint vc="26" uspid="2134" ordinal="4" offset="126" path="0" />
+                                <BranchPoint vc="0" uspid="2135" ordinal="5" offset="126" path="1" />
+                                <BranchPoint vc="3" uspid="2136" ordinal="6" offset="191" path="0" />
+                                <BranchPoint vc="26" uspid="2137" ordinal="7" offset="191" path="1" />
+                                <BranchPoint vc="1" uspid="2138" ordinal="8" offset="212" path="0" />
+                                <BranchPoint vc="2" uspid="2139" ordinal="9" offset="212" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="71" uspid="2101" ordinal="0" offset="0" sl="84" sc="13" el="84" ec="14" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="8" visitedSequencePoints="8" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663695</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Symbols.CecilSymbolManager::.ctor(OpenCover.Framework.ICommandLine,OpenCover.Framework.IFilter,log4net.ILog,OpenCover.Framework.Strategy.ITrackedMethodStrategy[])</Name>
+                            <FileRef uid="47" />
+                            <SequencePoints>
+                                <SequencePoint vc="35" uspid="2140" ordinal="0" offset="0" sl="35" sc="9" el="35" ec="104" />
+                                <SequencePoint vc="35" uspid="2141" ordinal="1" offset="11" sl="37" sc="9" el="37" ec="139" />
+                                <SequencePoint vc="35" uspid="2142" ordinal="2" offset="18" sl="38" sc="9" el="38" ec="10" />
+                                <SequencePoint vc="35" uspid="2143" ordinal="3" offset="19" sl="39" sc="13" el="39" ec="40" />
+                                <SequencePoint vc="35" uspid="2144" ordinal="4" offset="26" sl="40" sc="13" el="40" ec="30" />
+                                <SequencePoint vc="35" uspid="2145" ordinal="5" offset="33" sl="41" sc="13" el="41" ec="30" />
+                                <SequencePoint vc="35" uspid="2146" ordinal="6" offset="40" sl="42" sc="13" el="42" ec="64" />
+                                <SequencePoint vc="35" uspid="2147" ordinal="7" offset="48" sl="43" sc="9" el="43" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="35" uspid="2140" ordinal="0" offset="0" sl="35" sc="9" el="35" ec="104" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="4" visitedSequencePoints="4" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663698</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Symbols.CecilSymbolManager::Initialise(System.String,System.String)</Name>
+                            <FileRef uid="47" />
+                            <SequencePoints>
+                                <SequencePoint vc="36" uspid="2148" ordinal="0" offset="0" sl="56" sc="9" el="56" ec="10" />
+                                <SequencePoint vc="36" uspid="2149" ordinal="1" offset="1" sl="57" sc="13" el="57" ec="38" />
+                                <SequencePoint vc="36" uspid="2150" ordinal="2" offset="8" sl="58" sc="13" el="58" ec="38" />
+                                <SequencePoint vc="36" uspid="2151" ordinal="3" offset="15" sl="59" sc="9" el="59" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="36" uspid="2148" ordinal="0" offset="0" sl="56" sc="9" el="56" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="3" sequenceCoverage="100" branchCoverage="40" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="4" visitedSequencePoints="4" numBranchPoints="5" visitedBranchPoints="2" sequenceCoverage="100" branchCoverage="40" maxCyclomaticComplexity="3" minCyclomaticComplexity="3" />
+                            <MetadataToken>100663699</MetadataToken>
+                            <Name>System.String OpenCover.Framework.Symbols.CecilSymbolManager::FindSymbolsFolder()</Name>
+                            <FileRef uid="47" />
+                            <SequencePoints>
+                                <SequencePoint vc="29" uspid="2152" ordinal="0" offset="0" sl="62" sc="9" el="62" ec="10" />
+                                <SequencePoint vc="29" uspid="2153" ordinal="1" offset="1" sl="63" sc="13" el="63" ec="65" />
+                                <SequencePoint vc="26" uspid="2154" ordinal="2" offset="13" sl="65" sc="13" el="65" ec="185" />
+                                <SequencePoint vc="26" uspid="2155" ordinal="3" offset="74" sl="66" sc="9" el="66" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="0" uspid="2156" ordinal="0" offset="26" path="0" />
+                                <BranchPoint vc="26" uspid="2157" ordinal="1" offset="26" path="1" />
+                                <BranchPoint vc="0" uspid="2158" ordinal="2" offset="52" path="0" />
+                                <BranchPoint vc="0" uspid="2159" ordinal="3" offset="52" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="29" uspid="2152" ordinal="0" offset="0" sl="62" sc="9" el="62" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="5" sequenceCoverage="72.73" branchCoverage="55.56" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="11" visitedSequencePoints="8" numBranchPoints="9" visitedBranchPoints="5" sequenceCoverage="72.73" branchCoverage="55.56" maxCyclomaticComplexity="5" minCyclomaticComplexity="5" />
+                            <MetadataToken>100663700</MetadataToken>
+                            <Name>System.String OpenCover.Framework.Symbols.CecilSymbolManager::FindSymbolsFolder(System.String,System.String)</Name>
+                            <FileRef uid="47" />
+                            <SequencePoints>
+                                <SequencePoint vc="26" uspid="2160" ordinal="0" offset="0" sl="69" sc="9" el="69" ec="10" />
+                                <SequencePoint vc="26" uspid="2161" ordinal="1" offset="1" sl="70" sc="13" el="70" ec="87" />
+                                <SequencePoint vc="26" uspid="2162" ordinal="2" offset="26" sl="71" sc="13" el="71" ec="14" />
+                                <SequencePoint vc="26" uspid="2163" ordinal="3" offset="27" sl="72" sc="17" el="72" ec="124" />
+                                <SequencePoint vc="26" uspid="2164" ordinal="4" offset="61" sl="73" sc="17" el="73" ec="18" />
+                                <SequencePoint vc="26" uspid="2165" ordinal="5" offset="62" sl="74" sc="21" el="74" ec="103" />
+                                <SequencePoint vc="26" uspid="2166" ordinal="6" offset="86" sl="75" sc="25" el="75" ec="45" />
+                                <SequencePoint vc="0" uspid="2167" ordinal="7" offset="90" sl="76" sc="17" el="76" ec="18" />
+                                <SequencePoint vc="0" uspid="2168" ordinal="8" offset="91" sl="77" sc="13" el="77" ec="14" />
+                                <SequencePoint vc="0" uspid="2169" ordinal="9" offset="92" sl="78" sc="13" el="78" ec="25" />
+                                <SequencePoint vc="26" uspid="2170" ordinal="10" offset="96" sl="79" sc="9" el="79" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="26" uspid="2171" ordinal="0" offset="7" path="0" />
+                                <BranchPoint vc="0" uspid="2172" ordinal="1" offset="7" path="1" />
+                                <BranchPoint vc="26" uspid="2173" ordinal="2" offset="24" path="0" />
+                                <BranchPoint vc="0" uspid="2174" ordinal="3" offset="24" path="1" />
+                                <BranchPoint vc="26" uspid="2175" ordinal="4" offset="59" path="0" />
+                                <BranchPoint vc="0" uspid="2176" ordinal="5" offset="59" path="1" />
+                                <BranchPoint vc="26" uspid="2177" ordinal="6" offset="84" path="0" />
+                                <BranchPoint vc="0" uspid="2178" ordinal="7" offset="84" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="26" uspid="2160" ordinal="0" offset="0" sl="69" sc="9" el="69" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="3" sequenceCoverage="100" branchCoverage="80" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="11" visitedSequencePoints="11" numBranchPoints="5" visitedBranchPoints="4" sequenceCoverage="100" branchCoverage="80" maxCyclomaticComplexity="3" minCyclomaticComplexity="3" />
+                            <MetadataToken>100663702</MetadataToken>
+                            <Name>OpenCover.Framework.Model.File[] OpenCover.Framework.Symbols.CecilSymbolManager::GetFiles()</Name>
+                            <FileRef uid="47" />
+                            <SequencePoints>
+                                <SequencePoint vc="1" uspid="2179" ordinal="0" offset="0" sl="126" sc="9" el="126" ec="10" />
+                                <SequencePoint vc="1" uspid="2180" ordinal="1" offset="1" sl="127" sc="13" el="127" ec="41" />
+                                <SequencePoint vc="1" uspid="2181" ordinal="2" offset="7" sl="128" sc="13" el="128" ec="20" />
+                                <SequencePoint vc="1" uspid="2182" ordinal="3" offset="8" sl="128" sc="48" el="128" ec="72" />
+                                <SequencePoint vc="83" uspid="2183" ordinal="4" offset="20" sl="128" sc="22" el="128" ec="44" />
+                                <SequencePoint vc="83" uspid="2184" ordinal="5" offset="25" sl="129" sc="13" el="129" ec="14" />
+                                <SequencePoint vc="83" uspid="2185" ordinal="6" offset="26" sl="130" sc="17" el="130" ec="57" />
+                                <SequencePoint vc="83" uspid="2186" ordinal="7" offset="39" sl="131" sc="13" el="131" ec="14" />
+                                <SequencePoint vc="84" uspid="2187" ordinal="8" offset="46" sl="128" sc="45" el="128" ec="47" />
+                                <SequencePoint vc="1" uspid="2188" ordinal="9" offset="59" sl="132" sc="13" el="132" ec="93" />
+                                <SequencePoint vc="1" uspid="2189" ordinal="10" offset="114" sl="133" sc="9" el="133" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="1" uspid="2190" ordinal="0" offset="57" path="0" />
+                                <BranchPoint vc="83" uspid="2191" ordinal="1" offset="57" path="1" />
+                                <BranchPoint vc="1" uspid="2192" ordinal="2" offset="75" path="0" />
+                                <BranchPoint vc="0" uspid="2193" ordinal="3" offset="75" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="1" uspid="2179" ordinal="0" offset="0" sl="126" sc="9" el="126" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="2" sequenceCoverage="87.5" branchCoverage="66.67" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="8" visitedSequencePoints="7" numBranchPoints="3" visitedBranchPoints="2" sequenceCoverage="87.5" branchCoverage="66.67" maxCyclomaticComplexity="2" minCyclomaticComplexity="2" />
+                            <MetadataToken>100663703</MetadataToken>
+                            <Name>OpenCover.Framework.Model.Class[] OpenCover.Framework.Symbols.CecilSymbolManager::GetInstrumentableTypes()</Name>
+                            <FileRef uid="47" />
+                            <SequencePoints>
+                                <SequencePoint vc="20" uspid="2194" ordinal="0" offset="0" sl="136" sc="9" el="136" ec="10" />
+                                <SequencePoint vc="20" uspid="2195" ordinal="1" offset="1" sl="137" sc="13" el="137" ec="40" />
+                                <SequencePoint vc="0" uspid="2196" ordinal="2" offset="17" sl="137" sc="41" el="137" ec="61" />
+                                <SequencePoint vc="20" uspid="2197" ordinal="3" offset="26" sl="138" sc="13" el="138" ec="45" />
+                                <SequencePoint vc="20" uspid="2198" ordinal="4" offset="32" sl="139" sc="13" el="139" ec="91" />
+                                <SequencePoint vc="20" uspid="2199" ordinal="5" offset="49" sl="140" sc="13" el="140" ec="84" />
+                                <SequencePoint vc="20" uspid="2200" ordinal="6" offset="69" sl="141" sc="13" el="141" ec="38" />
+                                <SequencePoint vc="20" uspid="2201" ordinal="7" offset="78" sl="142" sc="9" el="142" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="0" uspid="2202" ordinal="0" offset="15" path="0" />
+                                <BranchPoint vc="20" uspid="2203" ordinal="1" offset="15" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="20" uspid="2194" ordinal="0" offset="0" sl="136" sc="9" el="136" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="18" sequenceCoverage="98.04" branchCoverage="94.29" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="51" visitedSequencePoints="50" numBranchPoints="35" visitedBranchPoints="33" sequenceCoverage="98.04" branchCoverage="94.29" maxCyclomaticComplexity="18" minCyclomaticComplexity="18" />
+                            <MetadataToken>100663704</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Symbols.CecilSymbolManager::GetInstrumentableTypes(System.Collections.Generic.IEnumerable`1&lt;Mono.Cecil.TypeDefinition&gt;,System.Collections.Generic.List`1&lt;OpenCover.Framework.Model.Class&gt;,OpenCover.Framework.IFilter,System.String)</Name>
+                            <FileRef uid="47" />
+                            <SequencePoints>
+                                <SequencePoint vc="260" uspid="2204" ordinal="0" offset="0" sl="145" sc="9" el="145" ec="10" />
+                                <SequencePoint vc="260" uspid="2205" ordinal="1" offset="1" sl="146" sc="13" el="146" ec="20" />
+                                <SequencePoint vc="260" uspid="2206" ordinal="2" offset="2" sl="146" sc="44" el="146" ec="59" />
+                                <SequencePoint vc="1800" uspid="2207" ordinal="3" offset="15" sl="146" sc="22" el="146" ec="40" />
+                                <SequencePoint vc="1800" uspid="2208" ordinal="4" offset="23" sl="147" sc="13" el="147" ec="14" />
+                                <SequencePoint vc="1800" uspid="2209" ordinal="5" offset="24" sl="148" sc="17" el="148" ec="43" />
+                                <SequencePoint vc="0" uspid="2210" ordinal="6" offset="39" sl="148" sc="44" el="148" ec="53" />
+                                <SequencePoint vc="1800" uspid="2211" ordinal="7" offset="44" sl="149" sc="17" el="149" ec="77" />
+                                <SequencePoint vc="100" uspid="2212" ordinal="8" offset="71" sl="149" sc="78" el="149" ec="87" />
+                                <SequencePoint vc="1700" uspid="2213" ordinal="9" offset="76" sl="150" sc="17" el="150" ec="81" />
+                                <SequencePoint vc="1700" uspid="2214" ordinal="10" offset="100" sl="151" sc="17" el="151" ec="74" />
+                                <SequencePoint vc="1" uspid="2215" ordinal="11" offset="119" sl="152" sc="17" el="152" ec="18" />
+                                <SequencePoint vc="1" uspid="2216" ordinal="12" offset="120" sl="153" sc="21" el="153" ec="64" />
+                                <SequencePoint vc="1" uspid="2217" ordinal="13" offset="128" sl="154" sc="17" el="154" ec="18" />
+                                <SequencePoint vc="1699" uspid="2218" ordinal="14" offset="131" sl="155" sc="22" el="155" ec="68" />
+                                <SequencePoint vc="1" uspid="2219" ordinal="15" offset="147" sl="156" sc="17" el="156" ec="18" />
+                                <SequencePoint vc="1" uspid="2220" ordinal="16" offset="148" sl="157" sc="21" el="157" ec="67" />
+                                <SequencePoint vc="1" uspid="2221" ordinal="17" offset="156" sl="158" sc="17" el="158" ec="18" />
+                                <SequencePoint vc="1700" uspid="2222" ordinal="18" offset="157" sl="160" sc="17" el="160" ec="47" />
+                                <SequencePoint vc="1700" uspid="2223" ordinal="19" offset="163" sl="161" sc="17" el="161" ec="59" />
+                                <SequencePoint vc="1698" uspid="2224" ordinal="20" offset="178" sl="162" sc="17" el="162" ec="18" />
+                                <SequencePoint vc="1698" uspid="2225" ordinal="21" offset="179" sl="163" sc="21" el="163" ec="28" />
+                                <SequencePoint vc="1698" uspid="2226" ordinal="22" offset="180" sl="163" sc="54" el="163" ec="76" />
+                                <SequencePoint vc="9872" uspid="2227" ordinal="23" offset="198" sl="163" sc="30" el="163" ec="50" />
+                                <SequencePoint vc="9872" uspid="2228" ordinal="24" offset="206" sl="164" sc="21" el="164" ec="22" />
+                                <SequencePoint vc="9872" uspid="2229" ordinal="25" offset="207" sl="165" sc="25" el="165" ec="105" />
+                                <SequencePoint vc="9792" uspid="2230" ordinal="26" offset="239" sl="166" sc="25" el="166" ec="26" />
+                                <SequencePoint vc="9792" uspid="2231" ordinal="27" offset="240" sl="167" sc="29" el="167" ec="36" />
+                                <SequencePoint vc="9792" uspid="2232" ordinal="28" offset="241" sl="167" sc="57" el="167" ec="91" />
+                                <SequencePoint vc="17832" uspid="2233" ordinal="29" offset="261" sl="167" sc="38" el="167" ec="53" />
+                                <SequencePoint vc="17832" uspid="2234" ordinal="30" offset="270" sl="168" sc="29" el="168" ec="30" />
+                                <SequencePoint vc="17832" uspid="2235" ordinal="31" offset="271" sl="169" sc="33" el="169" ec="71" />
+                                <SequencePoint vc="7552" uspid="2236" ordinal="32" offset="287" sl="170" sc="33" el="170" ec="34" />
+                                <SequencePoint vc="7552" uspid="2237" ordinal="33" offset="288" sl="171" sc="37" el="171" ec="86" />
+                                <SequencePoint vc="7552" uspid="2238" ordinal="34" offset="312" sl="172" sc="37" el="172" ec="43" />
+                                <SequencePoint vc="10280" uspid="2239" ordinal="35" offset="314" sl="174" sc="29" el="174" ec="30" />
+                                <SequencePoint vc="20072" uspid="2240" ordinal="36" offset="315" sl="167" sc="54" el="167" ec="56" />
+                                <SequencePoint vc="9792" uspid="2241" ordinal="37" offset="346" sl="175" sc="25" el="175" ec="26" />
+                                <SequencePoint vc="9872" uspid="2242" ordinal="38" offset="347" sl="176" sc="21" el="176" ec="22" />
+                                <SequencePoint vc="11570" uspid="2243" ordinal="39" offset="348" sl="163" sc="51" el="163" ec="53" />
+                                <SequencePoint vc="1698" uspid="2244" ordinal="40" offset="382" sl="177" sc="17" el="177" ec="18" />
+                                <SequencePoint vc="1700" uspid="2245" ordinal="41" offset="383" sl="180" sc="17" el="180" ec="67" />
+                                <SequencePoint vc="1660" uspid="2246" ordinal="42" offset="413" sl="181" sc="17" el="181" ec="18" />
+                                <SequencePoint vc="1660" uspid="2247" ordinal="43" offset="414" sl="182" sc="21" el="182" ec="107" />
+                                <SequencePoint vc="1660" uspid="2248" ordinal="44" offset="468" sl="183" sc="21" el="183" ec="41" />
+                                <SequencePoint vc="1660" uspid="2249" ordinal="45" offset="476" sl="184" sc="17" el="184" ec="18" />
+                                <SequencePoint vc="1700" uspid="2250" ordinal="46" offset="477" sl="185" sc="17" el="185" ec="51" />
+                                <SequencePoint vc="240" uspid="2251" ordinal="47" offset="492" sl="186" sc="21" el="186" ec="101" />
+                                <SequencePoint vc="1700" uspid="2252" ordinal="48" offset="507" sl="187" sc="13" el="187" ec="14" />
+                                <SequencePoint vc="2060" uspid="2253" ordinal="49" offset="508" sl="146" sc="41" el="146" ec="43" />
+                                <SequencePoint vc="260" uspid="2254" ordinal="50" offset="547" sl="188" sc="9" el="188" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="0" uspid="2255" ordinal="0" offset="37" path="0" />
+                                <BranchPoint vc="1800" uspid="2256" ordinal="1" offset="37" path="1" />
+                                <BranchPoint vc="100" uspid="2257" ordinal="2" offset="50" path="0" />
+                                <BranchPoint vc="1700" uspid="2258" ordinal="3" offset="50" path="1" />
+                                <BranchPoint vc="100" uspid="2259" ordinal="4" offset="69" path="0" />
+                                <BranchPoint vc="1700" uspid="2260" ordinal="5" offset="69" path="1" />
+                                <BranchPoint vc="1" uspid="2261" ordinal="6" offset="117" path="0" />
+                                <BranchPoint vc="1699" uspid="2262" ordinal="7" offset="117" path="1" />
+                                <BranchPoint vc="1" uspid="2263" ordinal="8" offset="145" path="0" />
+                                <BranchPoint vc="1698" uspid="2264" ordinal="9" offset="145" path="1" />
+                                <BranchPoint vc="1698" uspid="2265" ordinal="10" offset="173" path="0" />
+                                <BranchPoint vc="2" uspid="2266" ordinal="11" offset="173" path="1" />
+                                <BranchPoint vc="9792" uspid="2267" ordinal="12" offset="213" path="0" />
+                                <BranchPoint vc="80" uspid="2268" ordinal="13" offset="213" path="1" />
+                                <BranchPoint vc="9792" uspid="2269" ordinal="14" offset="237" path="0" />
+                                <BranchPoint vc="80" uspid="2270" ordinal="15" offset="237" path="1" />
+                                <BranchPoint vc="7552" uspid="2271" ordinal="16" offset="285" path="0" />
+                                <BranchPoint vc="10280" uspid="2272" ordinal="17" offset="285" path="1" />
+                                <BranchPoint vc="2240" uspid="2273" ordinal="18" offset="326" path="0" />
+                                <BranchPoint vc="17832" uspid="2274" ordinal="19" offset="326" path="1" />
+                                <BranchPoint vc="1698" uspid="2275" ordinal="20" offset="359" path="0" />
+                                <BranchPoint vc="9872" uspid="2276" ordinal="21" offset="359" path="1" />
+                                <BranchPoint vc="60" uspid="2277" ordinal="22" offset="389" path="0" />
+                                <BranchPoint vc="1640" uspid="2278" ordinal="23" offset="389" path="1" />
+                                <BranchPoint vc="1660" uspid="2279" ordinal="24" offset="411" path="0" />
+                                <BranchPoint vc="40" uspid="2280" ordinal="25" offset="411" path="1" />
+                                <BranchPoint vc="1" uspid="2281" ordinal="26" offset="426" path="0" />
+                                <BranchPoint vc="1659" uspid="2282" ordinal="27" offset="426" path="1" />
+                                <BranchPoint vc="240" uspid="2283" ordinal="28" offset="490" path="0" />
+                                <BranchPoint vc="1460" uspid="2284" ordinal="29" offset="490" path="1" />
+                                <BranchPoint vc="260" uspid="2285" ordinal="30" offset="519" path="0" />
+                                <BranchPoint vc="1800" uspid="2286" ordinal="31" offset="519" path="1" />
+                                <BranchPoint vc="260" uspid="2287" ordinal="32" offset="535" path="0" />
+                                <BranchPoint vc="0" uspid="2288" ordinal="33" offset="535" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="260" uspid="2204" ordinal="0" offset="0" sl="145" sc="9" el="145" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="6" visitedSequencePoints="6" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663705</MetadataToken>
+                            <Name>OpenCover.Framework.Model.Method[] OpenCover.Framework.Symbols.CecilSymbolManager::GetMethodsForType(OpenCover.Framework.Model.Class,OpenCover.Framework.Model.File[])</Name>
+                            <FileRef uid="47" />
+                            <SequencePoints>
+                                <SequencePoint vc="14" uspid="2289" ordinal="0" offset="0" sl="192" sc="9" el="192" ec="10" />
+                                <SequencePoint vc="14" uspid="2290" ordinal="1" offset="1" sl="193" sc="13" el="193" ec="46" />
+                                <SequencePoint vc="14" uspid="2291" ordinal="2" offset="7" sl="194" sc="13" el="194" ec="91" />
+                                <SequencePoint vc="14" uspid="2292" ordinal="3" offset="24" sl="195" sc="13" el="195" ec="88" />
+                                <SequencePoint vc="14" uspid="2293" ordinal="4" offset="45" sl="196" sc="13" el="196" ec="38" />
+                                <SequencePoint vc="14" uspid="2294" ordinal="5" offset="54" sl="197" sc="9" el="197" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="14" uspid="2289" ordinal="0" offset="0" sl="192" sc="9" el="192" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="5" sequenceCoverage="85.71" branchCoverage="77.78" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="7" visitedSequencePoints="6" numBranchPoints="9" visitedBranchPoints="7" sequenceCoverage="85.71" branchCoverage="77.78" maxCyclomaticComplexity="5" minCyclomaticComplexity="5" />
+                            <MetadataToken>100663706</MetadataToken>
+                            <Name>System.String OpenCover.Framework.Symbols.CecilSymbolManager::GetFirstFile(Mono.Cecil.MethodDefinition)</Name>
+                            <FileRef uid="47" />
+                            <SequencePoints>
+                                <SequencePoint vc="50" uspid="2295" ordinal="0" offset="0" sl="200" sc="9" el="200" ec="10" />
+                                <SequencePoint vc="50" uspid="2296" ordinal="1" offset="1" sl="201" sc="13" el="201" ec="74" />
+                                <SequencePoint vc="50" uspid="2297" ordinal="2" offset="31" sl="202" sc="13" el="202" ec="14" />
+                                <SequencePoint vc="50" uspid="2298" ordinal="3" offset="32" sl="203" sc="17" el="206" ec="39" />
+                                <SequencePoint vc="50" uspid="2299" ordinal="4" offset="121" sl="207" sc="17" el="207" ec="33" />
+                                <SequencePoint vc="0" uspid="2300" ordinal="5" offset="125" sl="209" sc="13" el="209" ec="25" />
+                                <SequencePoint vc="50" uspid="2301" ordinal="6" offset="129" sl="210" sc="9" el="210" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="50" uspid="2302" ordinal="0" offset="7" path="0" />
+                                <BranchPoint vc="0" uspid="2303" ordinal="1" offset="7" path="1" />
+                                <BranchPoint vc="50" uspid="2304" ordinal="2" offset="29" path="0" />
+                                <BranchPoint vc="0" uspid="2305" ordinal="3" offset="29" path="1" />
+                                <BranchPoint vc="1" uspid="2306" ordinal="4" offset="48" path="0" />
+                                <BranchPoint vc="49" uspid="2307" ordinal="5" offset="48" path="1" />
+                                <BranchPoint vc="1" uspid="2308" ordinal="6" offset="84" path="0" />
+                                <BranchPoint vc="49" uspid="2309" ordinal="7" offset="84" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="50" uspid="2295" ordinal="0" offset="0" sl="200" sc="9" el="200" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="5" sequenceCoverage="100" branchCoverage="88.89" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="15" visitedSequencePoints="15" numBranchPoints="9" visitedBranchPoints="8" sequenceCoverage="100" branchCoverage="88.89" maxCyclomaticComplexity="5" minCyclomaticComplexity="5" />
+                            <MetadataToken>100663707</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Symbols.CecilSymbolManager::GetMethodsForType(System.Collections.Generic.IEnumerable`1&lt;Mono.Cecil.TypeDefinition&gt;,System.String,System.Collections.Generic.List`1&lt;OpenCover.Framework.Model.Method&gt;,OpenCover.Framework.Model.File[],OpenCover.Framework.IFilter)</Name>
+                            <FileRef uid="47" />
+                            <SequencePoints>
+                                <SequencePoint vc="182" uspid="2310" ordinal="0" offset="0" sl="213" sc="9" el="213" ec="10" />
+                                <SequencePoint vc="182" uspid="2311" ordinal="1" offset="1" sl="214" sc="13" el="214" ec="20" />
+                                <SequencePoint vc="182" uspid="2312" ordinal="2" offset="2" sl="214" sc="44" el="214" ec="59" />
+                                <SequencePoint vc="1260" uspid="2313" ordinal="3" offset="11" sl="214" sc="22" el="214" ec="40" />
+                                <SequencePoint vc="1260" uspid="2314" ordinal="4" offset="18" sl="215" sc="13" el="215" ec="14" />
+                                <SequencePoint vc="1260" uspid="2315" ordinal="5" offset="19" sl="216" sc="17" el="216" ec="57" />
+                                <SequencePoint vc="14" uspid="2316" ordinal="6" offset="38" sl="217" sc="17" el="217" ec="18" />
+                                <SequencePoint vc="14" uspid="2317" ordinal="7" offset="39" sl="218" sc="21" el="218" ec="82" />
+                                <SequencePoint vc="14" uspid="2318" ordinal="8" offset="50" sl="219" sc="21" el="219" ec="74" />
+                                <SequencePoint vc="14" uspid="2319" ordinal="9" offset="61" sl="220" sc="17" el="220" ec="18" />
+                                <SequencePoint vc="1260" uspid="2320" ordinal="10" offset="62" sl="221" sc="17" el="221" ec="51" />
+                                <SequencePoint vc="168" uspid="2321" ordinal="11" offset="75" sl="222" sc="21" el="222" ec="101" />
+                                <SequencePoint vc="1260" uspid="2322" ordinal="12" offset="92" sl="223" sc="13" el="223" ec="14" />
+                                <SequencePoint vc="1442" uspid="2323" ordinal="13" offset="93" sl="214" sc="41" el="214" ec="43" />
+                                <SequencePoint vc="182" uspid="2324" ordinal="14" offset="122" sl="224" sc="9" el="224" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="14" uspid="2325" ordinal="0" offset="36" path="0" />
+                                <BranchPoint vc="1246" uspid="2326" ordinal="1" offset="36" path="1" />
+                                <BranchPoint vc="168" uspid="2327" ordinal="2" offset="73" path="0" />
+                                <BranchPoint vc="1092" uspid="2328" ordinal="3" offset="73" path="1" />
+                                <BranchPoint vc="182" uspid="2329" ordinal="4" offset="101" path="0" />
+                                <BranchPoint vc="1260" uspid="2330" ordinal="5" offset="101" path="1" />
+                                <BranchPoint vc="182" uspid="2331" ordinal="6" offset="111" path="0" />
+                                <BranchPoint vc="0" uspid="2332" ordinal="7" offset="111" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="182" uspid="2310" ordinal="0" offset="0" sl="213" sc="9" el="213" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="5" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="16" visitedSequencePoints="16" numBranchPoints="9" visitedBranchPoints="9" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="5" minCyclomaticComplexity="5" />
+                            <MetadataToken>100663708</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Symbols.CecilSymbolManager::BuildMethods(System.Collections.Generic.ICollection`1&lt;OpenCover.Framework.Model.Method&gt;,OpenCover.Framework.Model.File[],OpenCover.Framework.IFilter,Mono.Cecil.TypeDefinition)</Name>
+                            <FileRef uid="47" />
+                            <SequencePoints>
+                                <SequencePoint vc="14" uspid="2333" ordinal="0" offset="0" sl="227" sc="9" el="227" ec="10" />
+                                <SequencePoint vc="14" uspid="2334" ordinal="1" offset="1" sl="228" sc="13" el="228" ec="20" />
+                                <SequencePoint vc="14" uspid="2335" ordinal="2" offset="2" sl="228" sc="46" el="228" ec="68" />
+                                <SequencePoint vc="62" uspid="2336" ordinal="3" offset="16" sl="228" sc="22" el="228" ec="42" />
+                                <SequencePoint vc="62" uspid="2337" ordinal="4" offset="24" sl="229" sc="13" el="229" ec="14" />
+                                <SequencePoint vc="62" uspid="2338" ordinal="5" offset="25" sl="230" sc="17" el="230" ec="49" />
+                                <SequencePoint vc="9" uspid="2339" ordinal="6" offset="38" sl="230" sc="50" el="230" ec="59" />
+                                <SequencePoint vc="53" uspid="2340" ordinal="7" offset="40" sl="231" sc="17" el="231" ec="47" />
+                                <SequencePoint vc="7" uspid="2341" ordinal="8" offset="53" sl="231" sc="48" el="231" ec="57" />
+                                <SequencePoint vc="46" uspid="2342" ordinal="9" offset="55" sl="232" sc="17" el="232" ec="47" />
+                                <SequencePoint vc="7" uspid="2343" ordinal="10" offset="68" sl="232" sc="48" el="232" ec="57" />
+                                <SequencePoint vc="39" uspid="2344" ordinal="11" offset="70" sl="234" sc="17" el="234" ec="82" />
+                                <SequencePoint vc="39" uspid="2345" ordinal="12" offset="80" sl="235" sc="17" el="235" ec="37" />
+                                <SequencePoint vc="39" uspid="2346" ordinal="13" offset="88" sl="236" sc="13" el="236" ec="14" />
+                                <SequencePoint vc="76" uspid="2347" ordinal="14" offset="89" sl="228" sc="43" el="228" ec="45" />
+                                <SequencePoint vc="14" uspid="2348" ordinal="15" offset="118" sl="237" sc="9" el="237" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="9" uspid="2349" ordinal="0" offset="36" path="0" />
+                                <BranchPoint vc="53" uspid="2350" ordinal="1" offset="36" path="1" />
+                                <BranchPoint vc="7" uspid="2351" ordinal="2" offset="51" path="0" />
+                                <BranchPoint vc="46" uspid="2352" ordinal="3" offset="51" path="1" />
+                                <BranchPoint vc="7" uspid="2353" ordinal="4" offset="66" path="0" />
+                                <BranchPoint vc="39" uspid="2354" ordinal="5" offset="66" path="1" />
+                                <BranchPoint vc="14" uspid="2355" ordinal="6" offset="98" path="0" />
+                                <BranchPoint vc="62" uspid="2356" ordinal="7" offset="98" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="14" uspid="2333" ordinal="0" offset="0" sl="227" sc="9" el="227" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="6" sequenceCoverage="100" branchCoverage="81.82" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="19" visitedSequencePoints="19" numBranchPoints="11" visitedBranchPoints="9" sequenceCoverage="100" branchCoverage="81.82" maxCyclomaticComplexity="6" minCyclomaticComplexity="6" />
+                            <MetadataToken>100663709</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Symbols.CecilSymbolManager::BuildPropertyMethods(System.Collections.Generic.ICollection`1&lt;OpenCover.Framework.Model.Method&gt;,OpenCover.Framework.Model.File[],OpenCover.Framework.IFilter,Mono.Cecil.TypeDefinition)</Name>
+                            <FileRef uid="47" />
+                            <SequencePoints>
+                                <SequencePoint vc="14" uspid="2357" ordinal="0" offset="0" sl="240" sc="9" el="240" ec="10" />
+                                <SequencePoint vc="14" uspid="2358" ordinal="1" offset="1" sl="241" sc="13" el="241" ec="20" />
+                                <SequencePoint vc="14" uspid="2359" ordinal="2" offset="2" sl="241" sc="48" el="241" ec="73" />
+                                <SequencePoint vc="10" uspid="2360" ordinal="3" offset="16" sl="241" sc="22" el="241" ec="44" />
+                                <SequencePoint vc="10" uspid="2361" ordinal="4" offset="24" sl="242" sc="13" el="242" ec="14" />
+                                <SequencePoint vc="10" uspid="2362" ordinal="5" offset="25" sl="243" sc="17" el="243" ec="77" />
+                                <SequencePoint vc="10" uspid="2363" ordinal="6" offset="33" sl="245" sc="17" el="245" ec="102" />
+                                <SequencePoint vc="7" uspid="2364" ordinal="7" offset="62" sl="246" sc="17" el="246" ec="18" />
+                                <SequencePoint vc="7" uspid="2365" ordinal="8" offset="63" sl="247" sc="21" el="247" ec="100" />
+                                <SequencePoint vc="7" uspid="2366" ordinal="9" offset="78" sl="248" sc="21" el="248" ec="41" />
+                                <SequencePoint vc="7" uspid="2367" ordinal="10" offset="86" sl="249" sc="17" el="249" ec="18" />
+                                <SequencePoint vc="10" uspid="2368" ordinal="11" offset="87" sl="251" sc="17" el="251" ec="102" />
+                                <SequencePoint vc="7" uspid="2369" ordinal="12" offset="116" sl="252" sc="17" el="252" ec="18" />
+                                <SequencePoint vc="7" uspid="2370" ordinal="13" offset="117" sl="253" sc="21" el="253" ec="100" />
+                                <SequencePoint vc="7" uspid="2371" ordinal="14" offset="132" sl="254" sc="21" el="254" ec="41" />
+                                <SequencePoint vc="7" uspid="2372" ordinal="15" offset="140" sl="255" sc="17" el="255" ec="18" />
+                                <SequencePoint vc="10" uspid="2373" ordinal="16" offset="141" sl="256" sc="13" el="256" ec="14" />
+                                <SequencePoint vc="24" uspid="2374" ordinal="17" offset="142" sl="241" sc="45" el="241" ec="47" />
+                                <SequencePoint vc="14" uspid="2375" ordinal="18" offset="176" sl="257" sc="9" el="257" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="10" uspid="2376" ordinal="0" offset="39" path="0" />
+                                <BranchPoint vc="0" uspid="2377" ordinal="1" offset="39" path="1" />
+                                <BranchPoint vc="7" uspid="2378" ordinal="2" offset="60" path="0" />
+                                <BranchPoint vc="3" uspid="2379" ordinal="3" offset="60" path="1" />
+                                <BranchPoint vc="10" uspid="2380" ordinal="4" offset="93" path="0" />
+                                <BranchPoint vc="0" uspid="2381" ordinal="5" offset="93" path="1" />
+                                <BranchPoint vc="7" uspid="2382" ordinal="6" offset="114" path="0" />
+                                <BranchPoint vc="3" uspid="2383" ordinal="7" offset="114" path="1" />
+                                <BranchPoint vc="14" uspid="2384" ordinal="8" offset="153" path="0" />
+                                <BranchPoint vc="10" uspid="2385" ordinal="9" offset="153" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="14" uspid="2357" ordinal="0" offset="0" sl="240" sc="9" el="240" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="5" sequenceCoverage="100" branchCoverage="88.89" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="16" visitedSequencePoints="16" numBranchPoints="9" visitedBranchPoints="8" sequenceCoverage="100" branchCoverage="88.89" maxCyclomaticComplexity="5" minCyclomaticComplexity="5" />
+                            <MetadataToken>100663710</MetadataToken>
+                            <Name>OpenCover.Framework.Model.Method OpenCover.Framework.Symbols.CecilSymbolManager::BuildMethod(System.Collections.Generic.IEnumerable`1&lt;OpenCover.Framework.Model.File&gt;,OpenCover.Framework.IFilter,Mono.Cecil.MethodDefinition,System.Boolean)</Name>
+                            <FileRef uid="47" />
+                            <SequencePoints>
+                                <SequencePoint vc="53" uspid="2386" ordinal="0" offset="6" sl="260" sc="9" el="260" ec="10" />
+                                <SequencePoint vc="53" uspid="2387" ordinal="1" offset="7" sl="261" sc="13" el="261" ec="39" />
+                                <SequencePoint vc="53" uspid="2388" ordinal="2" offset="13" sl="262" sc="13" el="262" ec="53" />
+                                <SequencePoint vc="53" uspid="2389" ordinal="3" offset="26" sl="263" sc="13" el="263" ec="67" />
+                                <SequencePoint vc="53" uspid="2390" ordinal="4" offset="39" sl="264" sc="13" el="264" ec="57" />
+                                <SequencePoint vc="53" uspid="2391" ordinal="5" offset="52" sl="265" sc="13" el="265" ec="57" />
+                                <SequencePoint vc="53" uspid="2392" ordinal="6" offset="65" sl="266" sc="13" el="266" ec="57" />
+                                <SequencePoint vc="53" uspid="2393" ordinal="7" offset="78" sl="267" sc="13" el="267" ec="77" />
+                                <SequencePoint vc="53" uspid="2394" ordinal="8" offset="99" sl="269" sc="13" el="269" ec="88" />
+                                <SequencePoint vc="3" uspid="2395" ordinal="9" offset="122" sl="270" sc="17" el="270" ec="63" />
+                                <SequencePoint vc="50" uspid="2396" ordinal="10" offset="132" sl="271" sc="18" el="271" ec="75" />
+                                <SequencePoint vc="4" uspid="2397" ordinal="11" offset="153" sl="272" sc="17" el="272" ec="58" />
+                                <SequencePoint vc="53" uspid="2398" ordinal="12" offset="161" sl="274" sc="13" el="274" ec="47" />
+                                <SequencePoint vc="53" uspid="2399" ordinal="13" offset="168" sl="275" sc="13" el="276" ec="86" />
+                                <SequencePoint vc="53" uspid="2400" ordinal="14" offset="234" sl="277" sc="13" el="277" ec="27" />
+                                <SequencePoint vc="53" uspid="2401" ordinal="15" offset="238" sl="278" sc="9" el="278" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="53" uspid="2403" ordinal="0" offset="100" path="0" />
+                                <BranchPoint vc="0" uspid="2404" ordinal="1" offset="100" path="1" />
+                                <BranchPoint vc="3" uspid="2405" ordinal="2" offset="120" path="0" />
+                                <BranchPoint vc="50" uspid="2406" ordinal="3" offset="120" path="1" />
+                                <BranchPoint vc="4" uspid="2407" ordinal="4" offset="151" path="0" />
+                                <BranchPoint vc="46" uspid="2408" ordinal="5" offset="151" path="1" />
+                                <BranchPoint vc="1" uspid="2409" ordinal="6" offset="192" path="0" />
+                                <BranchPoint vc="52" uspid="2410" ordinal="7" offset="192" path="1" />
+                            </BranchPoints>
+                            <MethodPoint vc="53" uspid="2402" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="6" visitedSequencePoints="6" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663711</MetadataToken>
+                            <Name>OpenCover.Framework.Model.SequencePoint[] OpenCover.Framework.Symbols.CecilSymbolManager::GetSequencePointsForToken(System.Int32)</Name>
+                            <FileRef uid="47" />
+                            <SequencePoints>
+                                <SequencePoint vc="3" uspid="2411" ordinal="0" offset="0" sl="281" sc="9" el="281" ec="10" />
+                                <SequencePoint vc="3" uspid="2412" ordinal="1" offset="1" sl="282" sc="13" el="282" ec="30" />
+                                <SequencePoint vc="3" uspid="2413" ordinal="2" offset="8" sl="283" sc="13" el="283" ec="50" />
+                                <SequencePoint vc="3" uspid="2414" ordinal="3" offset="14" sl="284" sc="13" el="284" ec="52" />
+                                <SequencePoint vc="3" uspid="2415" ordinal="4" offset="23" sl="285" sc="13" el="285" ec="35" />
+                                <SequencePoint vc="3" uspid="2416" ordinal="5" offset="32" sl="286" sc="9" el="286" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="3" uspid="2411" ordinal="0" offset="0" sl="281" sc="9" el="281" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="6" visitedSequencePoints="6" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663712</MetadataToken>
+                            <Name>OpenCover.Framework.Model.BranchPoint[] OpenCover.Framework.Symbols.CecilSymbolManager::GetBranchPointsForToken(System.Int32)</Name>
+                            <FileRef uid="47" />
+                            <SequencePoints>
+                                <SequencePoint vc="3" uspid="2417" ordinal="0" offset="0" sl="289" sc="9" el="289" ec="10" />
+                                <SequencePoint vc="3" uspid="2418" ordinal="1" offset="1" sl="290" sc="13" el="290" ec="30" />
+                                <SequencePoint vc="3" uspid="2419" ordinal="2" offset="8" sl="291" sc="13" el="291" ec="48" />
+                                <SequencePoint vc="3" uspid="2420" ordinal="3" offset="14" sl="292" sc="13" el="292" ec="50" />
+                                <SequencePoint vc="3" uspid="2421" ordinal="4" offset="23" sl="293" sc="13" el="293" ec="35" />
+                                <SequencePoint vc="3" uspid="2422" ordinal="5" offset="32" sl="294" sc="9" el="294" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="3" uspid="2417" ordinal="0" offset="0" sl="289" sc="9" el="289" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="6" visitedSequencePoints="6" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663713</MetadataToken>
+                            <Name>System.Int32 OpenCover.Framework.Symbols.CecilSymbolManager::GetCyclomaticComplexityForToken(System.Int32)</Name>
+                            <FileRef uid="47" />
+                            <SequencePoints>
+                                <SequencePoint vc="2" uspid="2423" ordinal="0" offset="0" sl="297" sc="9" el="297" ec="10" />
+                                <SequencePoint vc="2" uspid="2424" ordinal="1" offset="1" sl="298" sc="13" el="298" ec="30" />
+                                <SequencePoint vc="2" uspid="2425" ordinal="2" offset="8" sl="299" sc="13" el="299" ec="32" />
+                                <SequencePoint vc="2" uspid="2426" ordinal="3" offset="10" sl="300" sc="13" el="300" ec="68" />
+                                <SequencePoint vc="2" uspid="2427" ordinal="4" offset="20" sl="301" sc="13" el="301" ec="31" />
+                                <SequencePoint vc="2" uspid="2428" ordinal="5" offset="24" sl="302" sc="9" el="302" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="2" uspid="2423" ordinal="0" offset="0" sl="297" sc="9" el="297" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="2" sequenceCoverage="83.33" branchCoverage="66.67" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="6" visitedSequencePoints="5" numBranchPoints="3" visitedBranchPoints="2" sequenceCoverage="83.33" branchCoverage="66.67" maxCyclomaticComplexity="2" minCyclomaticComplexity="2" />
+                            <MetadataToken>100663714</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Symbols.CecilSymbolManager::BuildMethodMap()</Name>
+                            <FileRef uid="47" />
+                            <SequencePoints>
+                                <SequencePoint vc="8" uspid="2429" ordinal="0" offset="0" sl="306" sc="9" el="306" ec="10" />
+                                <SequencePoint vc="8" uspid="2430" ordinal="1" offset="1" sl="307" sc="13" el="307" ec="38" />
+                                <SequencePoint vc="0" uspid="2431" ordinal="2" offset="22" sl="307" sc="39" el="307" ec="46" />
+                                <SequencePoint vc="8" uspid="2432" ordinal="3" offset="24" sl="308" sc="13" el="308" ec="91" />
+                                <SequencePoint vc="8" uspid="2433" ordinal="4" offset="41" sl="309" sc="13" el="309" ec="45" />
+                                <SequencePoint vc="8" uspid="2434" ordinal="5" offset="49" sl="310" sc="9" el="310" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="0" uspid="2435" ordinal="0" offset="20" path="0" />
+                                <BranchPoint vc="8" uspid="2436" ordinal="1" offset="20" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="8" uspid="2429" ordinal="0" offset="0" sl="306" sc="9" el="306" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="7" sequenceCoverage="100" branchCoverage="84.62" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="19" visitedSequencePoints="19" numBranchPoints="13" visitedBranchPoints="11" sequenceCoverage="100" branchCoverage="84.62" maxCyclomaticComplexity="7" minCyclomaticComplexity="7" />
+                            <MetadataToken>100663715</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Symbols.CecilSymbolManager::BuildMethodMap(System.Collections.Generic.IEnumerable`1&lt;Mono.Cecil.TypeDefinition&gt;)</Name>
+                            <FileRef uid="47" />
+                            <SequencePoints>
+                                <SequencePoint vc="104" uspid="2437" ordinal="0" offset="0" sl="313" sc="9" el="313" ec="10" />
+                                <SequencePoint vc="104" uspid="2438" ordinal="1" offset="1" sl="314" sc="13" el="314" ec="20" />
+                                <SequencePoint vc="104" uspid="2439" ordinal="2" offset="2" sl="314" sc="44" el="314" ec="59" />
+                                <SequencePoint vc="720" uspid="2440" ordinal="3" offset="14" sl="314" sc="22" el="314" ec="40" />
+                                <SequencePoint vc="720" uspid="2441" ordinal="4" offset="21" sl="315" sc="13" el="315" ec="14" />
+                                <SequencePoint vc="720" uspid="2442" ordinal="5" offset="22" sl="316" sc="17" el="316" ec="24" />
+                                <SequencePoint vc="720" uspid="2443" ordinal="6" offset="23" sl="316" sc="50" el="317" ec="124" />
+                                <SequencePoint vc="3920" uspid="2444" ordinal="7" offset="73" sl="316" sc="26" el="316" ec="46" />
+                                <SequencePoint vc="3920" uspid="2445" ordinal="8" offset="80" sl="318" sc="17" el="318" ec="18" />
+                                <SequencePoint vc="3920" uspid="2446" ordinal="9" offset="81" sl="319" sc="21" el="319" ec="96" />
+                                <SequencePoint vc="3920" uspid="2447" ordinal="10" offset="109" sl="320" sc="17" el="320" ec="18" />
+                                <SequencePoint vc="4640" uspid="2448" ordinal="11" offset="110" sl="316" sc="47" el="316" ec="49" />
+                                <SequencePoint vc="720" uspid="2449" ordinal="12" offset="143" sl="321" sc="17" el="321" ec="51" />
+                                <SequencePoint vc="96" uspid="2450" ordinal="13" offset="158" sl="322" sc="17" el="322" ec="18" />
+                                <SequencePoint vc="96" uspid="2451" ordinal="14" offset="159" sl="323" sc="21" el="323" ec="64" />
+                                <SequencePoint vc="96" uspid="2452" ordinal="15" offset="172" sl="324" sc="17" el="324" ec="18" />
+                                <SequencePoint vc="720" uspid="2453" ordinal="16" offset="173" sl="325" sc="13" el="325" ec="14" />
+                                <SequencePoint vc="824" uspid="2454" ordinal="17" offset="174" sl="314" sc="41" el="314" ec="43" />
+                                <SequencePoint vc="104" uspid="2455" ordinal="18" offset="210" sl="326" sc="9" el="326" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="1" uspid="2456" ordinal="0" offset="34" path="0" />
+                                <BranchPoint vc="719" uspid="2457" ordinal="1" offset="34" path="1" />
+                                <BranchPoint vc="720" uspid="2458" ordinal="2" offset="120" path="0" />
+                                <BranchPoint vc="3920" uspid="2459" ordinal="3" offset="120" path="1" />
+                                <BranchPoint vc="720" uspid="2460" ordinal="4" offset="132" path="0" />
+                                <BranchPoint vc="0" uspid="2461" ordinal="5" offset="132" path="1" />
+                                <BranchPoint vc="96" uspid="2462" ordinal="6" offset="156" path="0" />
+                                <BranchPoint vc="624" uspid="2463" ordinal="7" offset="156" path="1" />
+                                <BranchPoint vc="104" uspid="2464" ordinal="8" offset="184" path="0" />
+                                <BranchPoint vc="720" uspid="2465" ordinal="9" offset="184" path="1" />
+                                <BranchPoint vc="104" uspid="2466" ordinal="10" offset="199" path="0" />
+                                <BranchPoint vc="0" uspid="2467" ordinal="11" offset="199" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="104" uspid="2437" ordinal="0" offset="0" sl="313" sc="9" el="313" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="5" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="18" visitedSequencePoints="18" numBranchPoints="9" visitedBranchPoints="9" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="5" minCyclomaticComplexity="5" />
+                            <MetadataToken>100663716</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Symbols.CecilSymbolManager::GetSequencePointsForToken(System.Int32,System.Collections.Generic.List`1&lt;OpenCover.Framework.Model.SequencePoint&gt;)</Name>
+                            <FileRef uid="47" />
+                            <SequencePoints>
+                                <SequencePoint vc="3" uspid="2468" ordinal="0" offset="0" sl="329" sc="9" el="329" ec="10" />
+                                <SequencePoint vc="3" uspid="2469" ordinal="1" offset="1" sl="330" sc="13" el="330" ec="63" />
+                                <SequencePoint vc="3" uspid="2470" ordinal="2" offset="9" sl="331" sc="13" el="331" ec="42" />
+                                <SequencePoint vc="1" uspid="2471" ordinal="3" offset="22" sl="331" sc="43" el="331" ec="50" />
+                                <SequencePoint vc="2" uspid="2472" ordinal="4" offset="27" sl="332" sc="13" el="332" ec="32" />
+                                <SequencePoint vc="2" uspid="2473" ordinal="5" offset="29" sl="333" sc="13" el="333" ec="20" />
+                                <SequencePoint vc="2" uspid="2474" ordinal="6" offset="30" sl="333" sc="41" el="333" ec="75" />
+                                <SequencePoint vc="12" uspid="2475" ordinal="7" offset="53" sl="333" sc="22" el="333" ec="37" />
+                                <SequencePoint vc="12" uspid="2476" ordinal="8" offset="61" sl="334" sc="13" el="334" ec="14" />
+                                <SequencePoint vc="12" uspid="2477" ordinal="9" offset="62" sl="335" sc="17" el="336" ec="77" />
+                                <SequencePoint vc="3" uspid="2478" ordinal="10" offset="98" sl="337" sc="17" el="337" ec="18" />
+                                <SequencePoint vc="3" uspid="2479" ordinal="11" offset="99" sl="338" sc="21" el="338" ec="56" />
+                                <SequencePoint vc="3" uspid="2480" ordinal="12" offset="106" sl="339" sc="21" el="347" ec="39" />
+                                <SequencePoint vc="3" uspid="2481" ordinal="13" offset="200" sl="348" sc="21" el="348" ec="37" />
+                                <SequencePoint vc="3" uspid="2482" ordinal="14" offset="209" sl="349" sc="17" el="349" ec="18" />
+                                <SequencePoint vc="12" uspid="2483" ordinal="15" offset="210" sl="350" sc="13" el="350" ec="14" />
+                                <SequencePoint vc="14" uspid="2484" ordinal="16" offset="211" sl="333" sc="38" el="333" ec="40" />
+                                <SequencePoint vc="3" uspid="2485" ordinal="17" offset="245" sl="351" sc="9" el="351" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="1" uspid="2486" ordinal="0" offset="20" path="0" />
+                                <BranchPoint vc="2" uspid="2487" ordinal="1" offset="20" path="1" />
+                                <BranchPoint vc="3" uspid="2488" ordinal="2" offset="68" path="0" />
+                                <BranchPoint vc="9" uspid="2489" ordinal="3" offset="68" path="1" />
+                                <BranchPoint vc="3" uspid="2490" ordinal="4" offset="96" path="0" />
+                                <BranchPoint vc="9" uspid="2491" ordinal="5" offset="96" path="1" />
+                                <BranchPoint vc="2" uspid="2492" ordinal="6" offset="222" path="0" />
+                                <BranchPoint vc="12" uspid="2493" ordinal="7" offset="222" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="3" uspid="2468" ordinal="0" offset="0" sl="329" sc="9" el="329" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="6" sequenceCoverage="96.30" branchCoverage="90.91" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="27" visitedSequencePoints="26" numBranchPoints="11" visitedBranchPoints="10" sequenceCoverage="96.30" branchCoverage="90.91" maxCyclomaticComplexity="6" minCyclomaticComplexity="6" />
+                            <MetadataToken>100663717</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Symbols.CecilSymbolManager::GetBranchPointsForToken(System.Int32,System.Collections.Generic.List`1&lt;OpenCover.Framework.Model.BranchPoint&gt;)</Name>
+                            <FileRef uid="47" />
+                            <SequencePoints>
+                                <SequencePoint vc="3" uspid="2494" ordinal="0" offset="0" sl="354" sc="9" el="354" ec="10" />
+                                <SequencePoint vc="3" uspid="2495" ordinal="1" offset="1" sl="355" sc="13" el="355" ec="63" />
+                                <SequencePoint vc="3" uspid="2496" ordinal="2" offset="9" sl="356" sc="13" el="356" ec="42" />
+                                <SequencePoint vc="0" uspid="2497" ordinal="3" offset="22" sl="356" sc="43" el="356" ec="50" />
+                                <SequencePoint vc="3" uspid="2498" ordinal="4" offset="27" sl="357" sc="13" el="357" ec="32" />
+                                <SequencePoint vc="3" uspid="2499" ordinal="5" offset="29" sl="358" sc="13" el="358" ec="20" />
+                                <SequencePoint vc="3" uspid="2500" ordinal="6" offset="30" sl="358" sc="41" el="358" ec="75" />
+                                <SequencePoint vc="65" uspid="2501" ordinal="7" offset="53" sl="358" sc="22" el="358" ec="37" />
+                                <SequencePoint vc="65" uspid="2502" ordinal="8" offset="61" sl="359" sc="13" el="359" ec="14" />
+                                <SequencePoint vc="65" uspid="2503" ordinal="9" offset="62" sl="360" sc="17" el="360" ec="79" />
+                                <SequencePoint vc="61" uspid="2504" ordinal="10" offset="86" sl="360" sc="80" el="360" ec="89" />
+                                <SequencePoint vc="4" uspid="2505" ordinal="11" offset="91" sl="361" sc="17" el="361" ec="60" />
+                                <SequencePoint vc="3" uspid="2506" ordinal="12" offset="116" sl="362" sc="17" el="362" ec="18" />
+                                <SequencePoint vc="3" uspid="2507" ordinal="13" offset="117" sl="363" sc="21" el="363" ec="112" />
+                                <SequencePoint vc="3" uspid="2508" ordinal="14" offset="164" sl="364" sc="21" el="364" ec="112" />
+                                <SequencePoint vc="3" uspid="2509" ordinal="15" offset="216" sl="365" sc="17" el="365" ec="18" />
+                                <SequencePoint vc="1" uspid="2510" ordinal="16" offset="219" sl="367" sc="17" el="367" ec="18" />
+                                <SequencePoint vc="1" uspid="2511" ordinal="17" offset="220" sl="368" sc="26" el="368" ec="36" />
+                                <SequencePoint vc="4" uspid="2512" ordinal="18" offset="225" sl="369" sc="21" el="369" ec="22" />
+                                <SequencePoint vc="4" uspid="2513" ordinal="19" offset="226" sl="370" sc="25" el="370" ec="116" />
+                                <SequencePoint vc="4" uspid="2514" ordinal="20" offset="279" sl="371" sc="21" el="371" ec="22" />
+                                <SequencePoint vc="4" uspid="2515" ordinal="21" offset="280" sl="368" sc="93" el="368" ec="96" />
+                                <SequencePoint vc="5" uspid="2516" ordinal="22" offset="286" sl="368" sc="37" el="368" ec="91" />
+                                <SequencePoint vc="1" uspid="2517" ordinal="23" offset="314" sl="372" sc="17" el="372" ec="18" />
+                                <SequencePoint vc="4" uspid="2518" ordinal="24" offset="315" sl="373" sc="13" el="373" ec="14" />
+                                <SequencePoint vc="68" uspid="2519" ordinal="25" offset="316" sl="358" sc="38" el="358" ec="40" />
+                                <SequencePoint vc="3" uspid="2520" ordinal="26" offset="350" sl="374" sc="9" el="374" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="0" uspid="2521" ordinal="0" offset="20" path="0" />
+                                <BranchPoint vc="3" uspid="2522" ordinal="1" offset="20" path="1" />
+                                <BranchPoint vc="61" uspid="2523" ordinal="2" offset="84" path="0" />
+                                <BranchPoint vc="4" uspid="2524" ordinal="3" offset="84" path="1" />
+                                <BranchPoint vc="3" uspid="2525" ordinal="4" offset="114" path="0" />
+                                <BranchPoint vc="1" uspid="2526" ordinal="5" offset="114" path="1" />
+                                <BranchPoint vc="1" uspid="2527" ordinal="6" offset="312" path="0" />
+                                <BranchPoint vc="4" uspid="2528" ordinal="7" offset="312" path="1" />
+                                <BranchPoint vc="3" uspid="2529" ordinal="8" offset="327" path="0" />
+                                <BranchPoint vc="65" uspid="2530" ordinal="9" offset="327" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="3" uspid="2494" ordinal="0" offset="0" sl="354" sc="9" el="354" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="2" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="3" visitedSequencePoints="3" numBranchPoints="3" visitedBranchPoints="3" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="2" minCyclomaticComplexity="2" />
+                            <MetadataToken>100663718</MetadataToken>
+                            <Name>Mono.Cecil.MethodDefinition OpenCover.Framework.Symbols.CecilSymbolManager::GetMethodDefinition(System.Int32)</Name>
+                            <FileRef uid="47" />
+                            <SequencePoints>
+                                <SequencePoint vc="8" uspid="2531" ordinal="0" offset="0" sl="377" sc="9" el="377" ec="10" />
+                                <SequencePoint vc="8" uspid="2532" ordinal="1" offset="1" sl="378" sc="13" el="378" ec="78" />
+                                <SequencePoint vc="8" uspid="2533" ordinal="2" offset="34" sl="379" sc="9" el="379" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="6" uspid="2534" ordinal="0" offset="13" path="0" />
+                                <BranchPoint vc="2" uspid="2535" ordinal="1" offset="13" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="8" uspid="2531" ordinal="0" offset="0" sl="377" sc="9" el="377" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="2" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="6" visitedSequencePoints="6" numBranchPoints="3" visitedBranchPoints="3" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="2" minCyclomaticComplexity="2" />
+                            <MetadataToken>100663719</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Symbols.CecilSymbolManager::GetCyclomaticComplexityForToken(System.Int32,System.Int32&amp;)</Name>
+                            <FileRef uid="47" />
+                            <SequencePoints>
+                                <SequencePoint vc="2" uspid="2536" ordinal="0" offset="0" sl="382" sc="9" el="382" ec="10" />
+                                <SequencePoint vc="2" uspid="2537" ordinal="1" offset="1" sl="383" sc="13" el="383" ec="63" />
+                                <SequencePoint vc="2" uspid="2538" ordinal="2" offset="9" sl="384" sc="13" el="384" ec="42" />
+                                <SequencePoint vc="1" uspid="2539" ordinal="3" offset="20" sl="384" sc="43" el="384" ec="50" />
+                                <SequencePoint vc="1" uspid="2540" ordinal="4" offset="22" sl="385" sc="13" el="385" ec="123" />
+                                <SequencePoint vc="2" uspid="2541" ordinal="5" offset="30" sl="386" sc="9" el="386" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="1" uspid="2542" ordinal="0" offset="18" path="0" />
+                                <BranchPoint vc="1" uspid="2543" ordinal="1" offset="18" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="2" uspid="2536" ordinal="0" offset="0" sl="382" sc="9" el="382" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="3" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="14" visitedSequencePoints="14" numBranchPoints="5" visitedBranchPoints="5" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="3" minCyclomaticComplexity="3" />
+                            <MetadataToken>100663720</MetadataToken>
+                            <Name>OpenCover.Framework.Model.TrackedMethod[] OpenCover.Framework.Symbols.CecilSymbolManager::GetTrackedMethods()</Name>
+                            <FileRef uid="47" />
+                            <SequencePoints>
+                                <SequencePoint vc="4" uspid="2544" ordinal="0" offset="0" sl="389" sc="9" el="389" ec="10" />
+                                <SequencePoint vc="4" uspid="2545" ordinal="1" offset="1" sl="390" sc="13" el="390" ec="38" />
+                                <SequencePoint vc="1" uspid="2546" ordinal="2" offset="19" sl="390" sc="39" el="390" ec="51" />
+                                <SequencePoint vc="3" uspid="2547" ordinal="3" offset="23" sl="391" sc="13" el="391" ec="60" />
+                                <SequencePoint vc="3" uspid="2548" ordinal="4" offset="29" sl="392" sc="13" el="392" ec="20" />
+                                <SequencePoint vc="3" uspid="2549" ordinal="5" offset="30" sl="392" sc="51" el="392" ec="75" />
+                                <SequencePoint vc="2" uspid="2550" ordinal="6" offset="43" sl="392" sc="22" el="392" ec="47" />
+                                <SequencePoint vc="2" uspid="2551" ordinal="7" offset="49" sl="393" sc="13" el="393" ec="14" />
+                                <SequencePoint vc="2" uspid="2552" ordinal="8" offset="50" sl="394" sc="17" el="394" ec="95" />
+                                <SequencePoint vc="2" uspid="2553" ordinal="9" offset="67" sl="395" sc="17" el="395" ec="99" />
+                                <SequencePoint vc="2" uspid="2554" ordinal="10" offset="81" sl="396" sc="13" el="396" ec="14" />
+                                <SequencePoint vc="5" uspid="2555" ordinal="11" offset="88" sl="392" sc="48" el="392" ec="50" />
+                                <SequencePoint vc="3" uspid="2556" ordinal="12" offset="102" sl="397" sc="13" el="397" ec="45" />
+                                <SequencePoint vc="4" uspid="2557" ordinal="13" offset="111" sl="398" sc="9" el="398" ec="10" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="1" uspid="2558" ordinal="0" offset="17" path="0" />
+                                <BranchPoint vc="3" uspid="2559" ordinal="1" offset="17" path="1" />
+                                <BranchPoint vc="3" uspid="2560" ordinal="2" offset="100" path="0" />
+                                <BranchPoint vc="2" uspid="2561" ordinal="3" offset="100" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="4" uspid="2544" ordinal="0" offset="0" sl="389" sc="9" el="389" ec="10" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663721</MetadataToken>
+                            <Name>OpenCover.Framework.Model.File OpenCover.Framework.Symbols.CecilSymbolManager::&lt;GetFiles&gt;b__1(OpenCover.Framework.Model.File)</Name>
+                            <FileRef uid="47" />
+                            <SequencePoints>
+                                <SequencePoint vc="25" uspid="2562" ordinal="0" offset="0" sl="132" sc="77" el="132" ec="81" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="25" uspid="2562" ordinal="0" offset="0" sl="132" sc="77" el="132" ec="81" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663722</MetadataToken>
+                            <Name>OpenCover.Framework.Model.File OpenCover.Framework.Symbols.CecilSymbolManager::&lt;GetInstrumentableTypes&gt;b__5(System.String)</Name>
+                            <FileRef uid="47" />
+                            <SequencePoints>
+                                <SequencePoint vc="1038" uspid="2563" ordinal="0" offset="0" sl="182" sc="67" el="182" ec="95" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="1038" uspid="2563" ordinal="0" offset="0" sl="182" sc="67" el="182" ec="95" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="3" sequenceCoverage="100" branchCoverage="80" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="5" visitedBranchPoints="4" sequenceCoverage="100" branchCoverage="80" maxCyclomaticComplexity="3" minCyclomaticComplexity="3" />
+                            <MetadataToken>100663723</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Symbols.CecilSymbolManager::&lt;GetFirstFile&gt;b__7(Mono.Cecil.Cil.Instruction)</Name>
+                            <FileRef uid="47" />
+                            <SequencePoints>
+                                <SequencePoint vc="76" uspid="2564" ordinal="0" offset="0" sl="204" sc="33" el="204" ec="141" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="41" uspid="2565" ordinal="0" offset="6" path="0" />
+                                <BranchPoint vc="35" uspid="2566" ordinal="1" offset="6" path="1" />
+                                <BranchPoint vc="41" uspid="2567" ordinal="2" offset="19" path="0" />
+                                <BranchPoint vc="0" uspid="2568" ordinal="3" offset="19" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="76" uspid="2564" ordinal="0" offset="0" sl="204" sc="33" el="204" ec="141" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663724</MetadataToken>
+                            <Name>System.String OpenCover.Framework.Symbols.CecilSymbolManager::&lt;GetFirstFile&gt;b__8(Mono.Cecil.Cil.Instruction)</Name>
+                            <FileRef uid="47" />
+                            <SequencePoints>
+                                <SequencePoint vc="41" uspid="2569" ordinal="0" offset="0" sl="205" sc="34" el="205" ec="62" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="41" uspid="2569" ordinal="0" offset="0" sl="205" sc="34" el="205" ec="62" />
+                        </Method>
+                        <Method visited="false" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="0" numBranchPoints="1" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663725</MetadataToken>
+                            <Name>OpenCover.Framework.Model.FileRef OpenCover.Framework.Symbols.CecilSymbolManager::&lt;BuildMethod&gt;b__d(OpenCover.Framework.Model.File)</Name>
+                            <FileRef uid="47" />
+                            <SequencePoints>
+                                <SequencePoint vc="0" uspid="2570" ordinal="0" offset="0" sl="276" sc="30" el="276" ec="67" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="0" uspid="2570" ordinal="0" offset="0" sl="276" sc="30" el="276" ec="67" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="2" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="3" visitedBranchPoints="3" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="2" minCyclomaticComplexity="2" />
+                            <MetadataToken>100663726</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Symbols.CecilSymbolManager::&lt;BuildMethodMap&gt;b__11(Mono.Cecil.MethodDefinition)</Name>
+                            <FileRef uid="47" />
+                            <SequencePoints>
+                                <SequencePoint vc="4032" uspid="2571" ordinal="0" offset="0" sl="317" sc="48" el="317" ec="123" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="3920" uspid="2572" ordinal="0" offset="6" path="0" />
+                                <BranchPoint vc="112" uspid="2573" ordinal="1" offset="6" path="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="4032" uspid="2571" ordinal="0" offset="0" sl="317" sc="48" el="317" ec="123" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="1" visitedSequencePoints="0" numBranchPoints="1" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                    <FullName>OpenCover.Framework.Symbols.CecilSymbolManager/&lt;&gt;c__DisplayClassf</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663798</MetadataToken>
+                            <Name>System.Void OpenCover.Framework.Symbols.CecilSymbolManager/&lt;&gt;c__DisplayClassf::.ctor()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="53" uspid="2574" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="false" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="0" numBranchPoints="1" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663799</MetadataToken>
+                            <Name>System.Boolean OpenCover.Framework.Symbols.CecilSymbolManager/&lt;&gt;c__DisplayClassf::&lt;BuildMethod&gt;b__c(OpenCover.Framework.Model.File)</Name>
+                            <FileRef uid="47" />
+                            <SequencePoints>
+                                <SequencePoint vc="0" uspid="2575" ordinal="0" offset="0" sl="275" sc="47" el="275" ec="85" />
+                            </SequencePoints>
+                            <BranchPoints />
+                            <MethodPoint xsi:type="SequencePoint" vc="0" uspid="2575" ordinal="0" offset="0" sl="275" sc="47" el="275" ec="85" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="0" minCyclomaticComplexity="0" />
+                    <FullName>&lt;PrivateImplementationDetails&gt;{4B830177-FE9D-42D5-8239-E2FB8A8A3F46}</FullName>
+                    <Methods />
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="4" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="3" minCyclomaticComplexity="1" />
+                    <FullName>&lt;&gt;f__AnonymousType0`2</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663748</MetadataToken>
+                            <Name>&lt;file&gt;j__TPar &lt;&gt;f__AnonymousType0`2::get_file()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="3" uspid="2576" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663749</MetadataToken>
+                            <Name>&lt;class&gt;j__TPar &lt;&gt;f__AnonymousType0`2::get_class()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="2" uspid="2577" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663747</MetadataToken>
+                            <Name>System.Void &lt;&gt;f__AnonymousType0`2::.ctor(&lt;file&gt;j__TPar,&lt;class&gt;j__TPar)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="2" uspid="2578" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="false" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663750</MetadataToken>
+                            <Name>System.String &lt;&gt;f__AnonymousType0`2::ToString()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="0" uspid="2579" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="false" cyclomaticComplexity="3" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="4" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="3" minCyclomaticComplexity="3" />
+                            <MetadataToken>100663751</MetadataToken>
+                            <Name>System.Boolean &lt;&gt;f__AnonymousType0`2::Equals(System.Object)</Name>
+                            <SequencePoints />
+                            <BranchPoints>
+                                <BranchPoint vc="0" uspid="2581" ordinal="0" offset="8" path="0" />
+                                <BranchPoint vc="0" uspid="2582" ordinal="1" offset="8" path="1" />
+                                <BranchPoint vc="0" uspid="2583" ordinal="2" offset="32" path="0" />
+                                <BranchPoint vc="0" uspid="2584" ordinal="3" offset="32" path="1" />
+                            </BranchPoints>
+                            <MethodPoint vc="0" uspid="2580" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="false" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663752</MetadataToken>
+                            <Name>System.Int32 &lt;&gt;f__AnonymousType0`2::GetHashCode()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="0" uspid="2585" ordinal="0" offset="0" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="4" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="3" minCyclomaticComplexity="1" />
+                    <FullName>&lt;&gt;f__AnonymousType1`2</FullName>
+                    <Methods>
+                        <Method visited="false" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663787</MetadataToken>
+                            <Name>&lt;typeDefinition&gt;j__TPar &lt;&gt;f__AnonymousType1`2::get_typeDefinition()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="0" uspid="2586" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663788</MetadataToken>
+                            <Name>&lt;methodDefinition&gt;j__TPar &lt;&gt;f__AnonymousType1`2::get_methodDefinition()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="938" uspid="2587" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663786</MetadataToken>
+                            <Name>System.Void &lt;&gt;f__AnonymousType1`2::.ctor(&lt;typeDefinition&gt;j__TPar,&lt;methodDefinition&gt;j__TPar)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="622" uspid="2588" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="false" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663789</MetadataToken>
+                            <Name>System.String &lt;&gt;f__AnonymousType1`2::ToString()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="0" uspid="2589" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="false" cyclomaticComplexity="3" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="4" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="3" minCyclomaticComplexity="3" />
+                            <MetadataToken>100663790</MetadataToken>
+                            <Name>System.Boolean &lt;&gt;f__AnonymousType1`2::Equals(System.Object)</Name>
+                            <SequencePoints />
+                            <BranchPoints>
+                                <BranchPoint vc="0" uspid="2591" ordinal="0" offset="8" path="0" />
+                                <BranchPoint vc="0" uspid="2592" ordinal="1" offset="8" path="1" />
+                                <BranchPoint vc="0" uspid="2593" ordinal="2" offset="32" path="0" />
+                                <BranchPoint vc="0" uspid="2594" ordinal="3" offset="32" path="1" />
+                            </BranchPoints>
+                            <MethodPoint vc="0" uspid="2590" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="false" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663791</MetadataToken>
+                            <Name>System.Int32 &lt;&gt;f__AnonymousType1`2::GetHashCode()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="0" uspid="2595" ordinal="0" offset="0" />
+                        </Method>
+                    </Methods>
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="4" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="3" minCyclomaticComplexity="1" />
+                    <FullName>&lt;&gt;f__AnonymousType2`2</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663793</MetadataToken>
+                            <Name>&lt;&lt;&gt;h__TransparentIdentifier0&gt;j__TPar &lt;&gt;f__AnonymousType2`2::get_&lt;&gt;h__TransparentIdentifier0()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="316" uspid="2596" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663794</MetadataToken>
+                            <Name>&lt;customAttribute&gt;j__TPar &lt;&gt;f__AnonymousType2`2::get_customAttribute()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="511" uspid="2597" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663792</MetadataToken>
+                            <Name>System.Void &lt;&gt;f__AnonymousType2`2::.ctor(&lt;&lt;&gt;h__TransparentIdentifier0&gt;j__TPar,&lt;customAttribute&gt;j__TPar)</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="511" uspid="2598" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="false" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663795</MetadataToken>
+                            <Name>System.String &lt;&gt;f__AnonymousType2`2::ToString()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="0" uspid="2599" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="false" cyclomaticComplexity="3" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="4" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="3" minCyclomaticComplexity="3" />
+                            <MetadataToken>100663796</MetadataToken>
+                            <Name>System.Boolean &lt;&gt;f__AnonymousType2`2::Equals(System.Object)</Name>
+                            <SequencePoints />
+                            <BranchPoints>
+                                <BranchPoint vc="0" uspid="2601" ordinal="0" offset="8" path="0" />
+                                <BranchPoint vc="0" uspid="2602" ordinal="1" offset="8" path="1" />
+                                <BranchPoint vc="0" uspid="2603" ordinal="2" offset="32" path="0" />
+                                <BranchPoint vc="0" uspid="2604" ordinal="3" offset="32" path="1" />
+                            </BranchPoints>
+                            <MethodPoint vc="0" uspid="2600" ordinal="0" offset="0" />
+                        </Method>
+                        <Method visited="false" cyclomaticComplexity="1" sequenceCoverage="0" branchCoverage="0" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+                            <MetadataToken>100663797</MetadataToken>
+                            <Name>System.Int32 &lt;&gt;f__AnonymousType2`2::GetHashCode()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="0" uspid="2605" ordinal="0" offset="0" />
+                        </Method>
+                    </Methods>
+                </Class>
+            </Classes>
+        </Module>
+        <Module skippedDueTo="Filter" hash="13-4C-94-D1-A1-A5-D9-8F-F1-E4-CE-A7-87-EF-CC-42-FC-6B-CA-BC">
+            <FullName>C:\Projects\opencover.git\working\main\bin\Debug\nunit.framework.dll</FullName>
+            <ModuleName>nunit.framework</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="1A-8E-7F-63-79-81-73-62-C8-B6-77-39-F8-97-1B-CB-6B-2B-67-76">
+            <FullName>C:\WINDOWS\Microsoft.Net\assembly\GAC_MSIL\Microsoft.VisualStudio.QualityTools.UnitTestFramework\v4.0_10.0.0.0__b03f5f7f11d50a3a\Microsoft.VisualStudio.QualityTools.UnitTestFramework.dll</FullName>
+            <ModuleName>Microsoft.VisualStudio.QualityTools.UnitTestFramework</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="3F-30-D4-1E-29-17-B3-6B-DB-A7-82-2B-2A-6D-0E-07-65-EE-77-A0">
+            <FullName>C:\Projects\opencover.git\working\main\bin\Debug\Moq.dll</FullName>
+            <ModuleName>Moq</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A3-24-11-39-F8-79-95-4F-05-15-1C-84-CE-09-0C-65-42-CD-C2-C7">
+            <FullName>C:\Projects\opencover.git\working\main\bin\Debug\Microsoft.Practices.Unity.dll</FullName>
+            <ModuleName>Microsoft.Practices.Unity</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="C9-9E-CD-25-91-A0-3C-D4-9D-F6-64-42-5E-C8-14-E7-98-5A-8D-03">
+            <FullName>C:\Projects\opencover.git\working\main\bin\Debug\xunit.dll</FullName>
+            <ModuleName>xunit</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="79-F8-9A-22-4E-29-52-37-00-CF-81-FF-1F-EA-05-EC-74-2A-2E-C8">
+            <FullName>C:\Projects\opencover.git\working\main\packages\NUnit.Runners.2.6.2\tools\lib\nunit-console-runner.dll</FullName>
+            <ModuleName>nunit-console-runner</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="84-64-E1-D2-0A-E2-91-23-AD-BD-B9-7A-3C-89-7B-66-65-58-46-1C">
+            <FullName>C:\WINDOWS\Microsoft.Net\assembly\GAC_MSIL\System.Runtime.Remoting\v4.0_4.0.0.0__b77a5c561934e089\System.Runtime.Remoting.dll</FullName>
+            <ModuleName>System.Runtime.Remoting</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="80-32-3B-47-08-F0-74-C4-64-F6-98-9B-54-B3-69-B5-B9-29-D3-E9">
+            <FullName>C:\WINDOWS\Microsoft.Net\assembly\GAC_MSIL\System.Configuration\v4.0_4.0.0.0__b03f5f7f11d50a3a\System.Configuration.dll</FullName>
+            <ModuleName>System.Configuration</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4B-C6-12-DA-61-6B-39-09-CD-DF-A1-00-79-12-63-F9-8E-72-76-27">
+            <FullName>C:\WINDOWS\Microsoft.Net\assembly\GAC_MSIL\System.Xml\v4.0_4.0.0.0__b77a5c561934e089\System.Xml.dll</FullName>
+            <ModuleName>System.Xml</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="8D-DF-74-1B-95-9B-7B-35-66-7B-AF-28-7B-35-EB-3D-F2-1B-0D-6A">
+            <FullName>C:\Projects\opencover.git\working\main\bin\Debug\log4net.dll</FullName>
+            <ModuleName>log4net</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="58-95-C1-AF-C4-E5-C6-BB-F3-54-7A-B0-3C-B7-C6-29-C9-42-CA-D4">
+            <FullName>C:\WINDOWS\Microsoft.Net\assembly\GAC_MSIL\System.Core\v4.0_4.0.0.0__b77a5c561934e089\System.Core.dll</FullName>
+            <ModuleName>System.Core</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="">
+            <FullName>RefEmit_InMemoryManifestModule</FullName>
+            <ModuleName>DynamicProxyGenAssembly2</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="64-3D-85-31-AE-4E-92-4B-57-06-67-78-88-3C-AE-C4-ED-7F-8F-4B">
+            <FullName>C:\Projects\opencover.git\working\main\bin\Debug\Mono.Cecil.dll</FullName>
+            <ModuleName>Mono.Cecil</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="">
+            <FullName>RefEmit_InMemoryManifestModule</FullName>
+            <ModuleName>Anonymously Hosted DynamicMethods Assembly</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="97-EA-AE-E5-3E-58-7C-BA-61-59-66-7A-3C-4D-49-76-69-B9-89-BF">
+            <FullName>C:\Projects\opencover.git\working\main\bin\Debug\Mono.Cecil.Pdb.dll</FullName>
+            <ModuleName>Mono.Cecil.Pdb</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="">
+            <FullName>RefEmit_InMemoryManifestModule</FullName>
+            <ModuleName>Microsoft.GeneratedCode</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B4-27-2F-54-23-AA-55-C2-EC-07-04-80-9D-C8-C3-B1-C2-75-F0-87">
+            <FullName>C:\Projects\opencover.git\working\main\bin\Debug\Gendarme.Rules.Maintainability.dll</FullName>
+            <ModuleName>Gendarme.Rules.Maintainability</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="70-2E-5B-8B-05-0C-3D-E1-31-05-34-A1-87-7E-B0-D3-D3-A6-4D-F9">
+            <FullName>C:\Projects\opencover.git\working\main\bin\Debug\Gendarme.Framework.dll</FullName>
+            <ModuleName>Gendarme.Framework</ModuleName>
+            <Classes />
+        </Module>
+    </Modules>
+</CoverageSession>

--- a/src/test/resources/edu/hm/hafner/coverage/parser/opencover/opencover.xml
+++ b/src/test/resources/edu/hm/hafner/coverage/parser/opencover/opencover.xml
@@ -1,0 +1,440 @@
+<?xml version="1.0" encoding="utf-8"?>
+<CoverageSession>
+  <Summary numSequencePoints="138" visitedSequencePoints="122" numBranchPoints="48" visitedBranchPoints="35" sequenceCoverage="88.4" branchCoverage="72.9" maxCyclomaticComplexity="67" minCyclomaticComplexity="67" visitedClasses="3" numClasses="4" visitedMethods="19" numMethods="21" />
+  <Modules>
+    <Module hash="D581F35C-22FE-42E6-B430-ADF48F3E7D6D">
+      <ModulePath>MyLogging.dll</ModulePath>
+      <ModuleTime>2019-10-11T04:15:26</ModuleTime>
+      <ModuleName>MyLogging</ModuleName>
+      <Files>
+        <File uid="1" fullPath="C:\temp\opencovertests\MyLogging.FancyClass.cs" />
+        <File uid="2" fullPath="C:\temp\opencovertests\MyLogging.FancyClassSettings.cs" />
+        <File uid="3" fullPath="C:\temp\opencovertests\MyLogging\FancyHelper.cs" />
+      </Files>
+      <Classes>
+        <Class>
+          <Summary numSequencePoints="121" visitedSequencePoints="106" numBranchPoints="46" visitedBranchPoints="33" sequenceCoverage="87.6" branchCoverage="71.73" maxCyclomaticComplexity="16" minCyclomaticComplexity="1" visitedClasses="1" numClasses="1" visitedMethods="13" numMethods="14" />
+          <FullName>MyLogging.FancyClass</FullName>
+          <Methods>
+            <Method cyclomaticComplexity="2" nPathComplexity="0" sequenceCoverage="100" branchCoverage="50" isConstructor="False" isGetter="True" isSetter="False" isStatic="True">
+              <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="2" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="50" maxCyclomaticComplexity="2" minCyclomaticComplexity="2" visitedClasses="0" numClasses="0" visitedMethods="1" numMethods="1" />
+              <MetadataToken />
+              <Name>System.Boolean MyLogging.FancyClass::get_IsMyCodeWrittenWell()</Name>
+              <FileRef uid="1" />
+              <SequencePoints>
+                <SequencePoint vc="62" uspid="30" ordinal="0" sl="30" sc="1" el="30" ec="2" bec="0" bev="0" fileid="1" />
+              </SequencePoints>
+              <BranchPoints>
+                <BranchPoint vc="0" uspid="30" ordinal="0" path="0" offset="7" offsetend="9" sl="30" fileid="1" />
+                <BranchPoint vc="62" uspid="30" ordinal="1" path="1" offset="7" offsetend="12" sl="30" fileid="1" />
+              </BranchPoints>
+              <MethodPoint vc="1" uspid="0" p8:type="SequencePoint" ordinal="0" offset="0" sc="0" sl="30" ec="1" el="30" bec="0" bev="0" fileid="1" xmlns:p8="xsi" />
+            </Method>
+            <Method cyclomaticComplexity="2" nPathComplexity="0" sequenceCoverage="0" branchCoverage="0" isConstructor="False" isGetter="True" isSetter="False" isStatic="True">
+              <Summary numSequencePoints="1" visitedSequencePoints="0" numBranchPoints="2" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="2" minCyclomaticComplexity="2" visitedClasses="0" numClasses="0" visitedMethods="0" numMethods="1" />
+              <MetadataToken />
+              <Name>System.Boolean MyLogging.FancyClass::get_IsEnabled()</Name>
+              <FileRef uid="1" />
+              <SequencePoints>
+                <SequencePoint vc="0" uspid="32" ordinal="0" sl="32" sc="1" el="32" ec="2" bec="0" bev="0" fileid="1" />
+              </SequencePoints>
+              <BranchPoints>
+                <BranchPoint vc="0" uspid="32" ordinal="0" path="0" offset="7" offsetend="9" sl="32" fileid="1" />
+                <BranchPoint vc="0" uspid="32" ordinal="1" path="1" offset="7" offsetend="12" sl="32" fileid="1" />
+              </BranchPoints>
+              <MethodPoint vc="0" uspid="0" p8:type="SequencePoint" ordinal="1" offset="1" sc="0" sl="32" ec="1" el="32" bec="0" bev="0" fileid="1" xmlns:p8="xsi" />
+            </Method>
+            <Method cyclomaticComplexity="1" nPathComplexity="0" sequenceCoverage="100" branchCoverage="100" isConstructor="False" isGetter="True" isSetter="False" isStatic="True">
+              <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" visitedClasses="0" numClasses="0" visitedMethods="1" numMethods="1" />
+              <MetadataToken />
+              <Name>System.Boolean MyLogging.FancyClass::get_IsReadyToLog()</Name>
+              <FileRef uid="1" />
+              <SequencePoints>
+                <SequencePoint vc="289" uspid="34" ordinal="0" sl="34" sc="1" el="34" ec="2" bec="0" bev="0" fileid="1" />
+              </SequencePoints>
+              <BranchPoints />
+              <MethodPoint vc="1" uspid="0" p8:type="SequencePoint" ordinal="2" offset="2" sc="0" sl="34" ec="1" el="34" bec="0" bev="0" fileid="1" xmlns:p8="xsi" />
+            </Method>
+            <Method cyclomaticComplexity="1" nPathComplexity="0" sequenceCoverage="100" branchCoverage="100" isConstructor="False" isGetter="True" isSetter="False" isStatic="True">
+              <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" visitedClasses="0" numClasses="0" visitedMethods="1" numMethods="1" />
+              <MetadataToken />
+              <Name>System.Int32 MyLogging.FancyClass::get_StartSoapTicks()</Name>
+              <FileRef uid="1" />
+              <SequencePoints>
+                <SequencePoint vc="5" uspid="36" ordinal="0" sl="36" sc="1" el="36" ec="2" bec="0" bev="0" fileid="1" />
+              </SequencePoints>
+              <BranchPoints />
+              <MethodPoint vc="1" uspid="0" p8:type="SequencePoint" ordinal="3" offset="3" sc="0" sl="36" ec="1" el="36" bec="0" bev="0" fileid="1" xmlns:p8="xsi" />
+            </Method>
+            <Method cyclomaticComplexity="1" nPathComplexity="0" sequenceCoverage="100" branchCoverage="100" isConstructor="False" isGetter="True" isSetter="False" isStatic="True">
+              <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" visitedClasses="0" numClasses="0" visitedMethods="1" numMethods="1" />
+              <MetadataToken />
+              <Name>System.Double MyLogging.FancyClass::get_StartSoapCpu()</Name>
+              <FileRef uid="1" />
+              <SequencePoints>
+                <SequencePoint vc="5" uspid="38" ordinal="0" sl="38" sc="1" el="38" ec="2" bec="0" bev="0" fileid="1" />
+              </SequencePoints>
+              <BranchPoints />
+              <MethodPoint vc="1" uspid="0" p8:type="SequencePoint" ordinal="4" offset="4" sc="0" sl="38" ec="1" el="38" bec="0" bev="0" fileid="1" xmlns:p8="xsi" />
+            </Method>
+            <Method cyclomaticComplexity="16" nPathComplexity="0" sequenceCoverage="79.59" branchCoverage="62.5" isConstructor="False" isGetter="False" isSetter="False" isStatic="True">
+              <Summary numSequencePoints="49" visitedSequencePoints="39" numBranchPoints="16" visitedBranchPoints="10" sequenceCoverage="79.59" branchCoverage="62.5" maxCyclomaticComplexity="16" minCyclomaticComplexity="16" visitedClasses="0" numClasses="0" visitedMethods="1" numMethods="1" />
+              <MetadataToken />
+              <Name>System.Void MyLogging.FancyClass::debuglog(System.String,T)</Name>
+              <FileRef uid="1" />
+              <SequencePoints>
+                <SequencePoint vc="62" uspid="51" ordinal="0" sl="51" sc="1" el="51" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="0" uspid="53" ordinal="1" sl="53" sc="1" el="53" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="62" uspid="56" ordinal="2" sl="56" sc="1" el="56" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="62" uspid="57" ordinal="3" sl="57" sc="1" el="57" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="62" uspid="59" ordinal="4" sl="59" sc="1" el="59" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="62" uspid="60" ordinal="5" sl="60" sc="1" el="60" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="62" uspid="62" ordinal="6" sl="62" sc="1" el="62" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="62" uspid="65" ordinal="7" sl="65" sc="1" el="65" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="62" uspid="66" ordinal="8" sl="66" sc="1" el="66" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="62" uspid="67" ordinal="9" sl="67" sc="1" el="67" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="62" uspid="69" ordinal="10" sl="69" sc="1" el="69" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="62" uspid="70" ordinal="11" sl="70" sc="1" el="70" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="62" uspid="71" ordinal="12" sl="71" sc="1" el="71" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="62" uspid="72" ordinal="13" sl="72" sc="1" el="72" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="62" uspid="73" ordinal="14" sl="73" sc="1" el="73" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="62" uspid="74" ordinal="15" sl="74" sc="1" el="74" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="62" uspid="76" ordinal="16" sl="76" sc="1" el="76" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="62" uspid="77" ordinal="17" sl="77" sc="1" el="77" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="62" uspid="78" ordinal="18" sl="78" sc="1" el="78" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="62" uspid="79" ordinal="19" sl="79" sc="1" el="79" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="62" uspid="80" ordinal="20" sl="80" sc="1" el="80" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="62" uspid="81" ordinal="21" sl="81" sc="1" el="81" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="62" uspid="82" ordinal="22" sl="82" sc="1" el="82" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="62" uspid="83" ordinal="23" sl="83" sc="1" el="83" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="62" uspid="84" ordinal="24" sl="84" sc="1" el="84" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="62" uspid="85" ordinal="25" sl="85" sc="1" el="85" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="62" uspid="87" ordinal="26" sl="87" sc="1" el="87" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="62" uspid="90" ordinal="27" sl="90" sc="1" el="90" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="62" uspid="91" ordinal="28" sl="91" sc="1" el="91" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="62" uspid="93" ordinal="29" sl="93" sc="1" el="93" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="62" uspid="94" ordinal="30" sl="94" sc="1" el="94" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="62" uspid="97" ordinal="31" sl="97" sc="1" el="97" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="62" uspid="99" ordinal="32" sl="99" sc="1" el="99" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="62" uspid="100" ordinal="33" sl="100" sc="1" el="100" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="62" uspid="102" ordinal="34" sl="102" sc="1" el="102" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="62" uspid="103" ordinal="35" sl="103" sc="1" el="103" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="62" uspid="104" ordinal="36" sl="104" sc="1" el="104" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="0" uspid="106" ordinal="37" sl="106" sc="1" el="106" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="0" uspid="108" ordinal="38" sl="108" sc="1" el="108" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="0" uspid="109" ordinal="39" sl="109" sc="1" el="109" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="0" uspid="110" ordinal="40" sl="110" sc="1" el="110" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="0" uspid="111" ordinal="41" sl="111" sc="1" el="111" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="0" uspid="112" ordinal="42" sl="112" sc="1" el="112" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="0" uspid="113" ordinal="43" sl="113" sc="1" el="113" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="0" uspid="116" ordinal="44" sl="116" sc="1" el="116" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="0" uspid="117" ordinal="45" sl="117" sc="1" el="117" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="62" uspid="120" ordinal="46" sl="120" sc="1" el="120" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="62" uspid="121" ordinal="47" sl="121" sc="1" el="121" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="62" uspid="123" ordinal="48" sl="123" sc="1" el="123" ec="2" bec="0" bev="0" fileid="1" />
+              </SequencePoints>
+              <BranchPoints>
+                <BranchPoint vc="0" uspid="51" ordinal="0" path="0" offset="6" offsetend="8" sl="51" fileid="1" />
+                <BranchPoint vc="62" uspid="51" ordinal="1" path="1" offset="6" offsetend="9" sl="51" fileid="1" />
+                <BranchPoint vc="62" uspid="60" ordinal="2" path="0" offset="38" offsetend="40" sl="60" fileid="1" />
+                <BranchPoint vc="62" uspid="60" ordinal="3" path="1" offset="38" offsetend="60" sl="60" fileid="1" />
+                <BranchPoint vc="62" uspid="85" ordinal="4" path="0" offset="278" offsetend="280" sl="85" fileid="1" />
+                <BranchPoint vc="62" uspid="85" ordinal="5" path="1" offset="278" offsetend="309" sl="85" fileid="1" />
+                <BranchPoint vc="62" uspid="91" ordinal="6" path="0" offset="324" offsetend="326" sl="91" fileid="1" />
+                <BranchPoint vc="0" uspid="93" ordinal="8" path="0" offset="332" offsetend="334" sl="93" fileid="1" />
+                <BranchPoint vc="62" uspid="93" ordinal="9" path="1" offset="332" offsetend="337" sl="93" fileid="1" />
+                <BranchPoint vc="0" uspid="93" ordinal="10" path="0" offset="351" offsetend="353" sl="93" fileid="1" />
+                <BranchPoint vc="62" uspid="93" ordinal="11" path="1" offset="351" offsetend="359" sl="93" fileid="1" />
+                <BranchPoint vc="62" uspid="91" ordinal="7" path="1" offset="324" offsetend="375" sl="91" fileid="1" />
+                <BranchPoint vc="0" uspid="104" ordinal="12" path="0" offset="448" offsetend="450" sl="104" fileid="1" />
+                <BranchPoint vc="0" uspid="106" ordinal="14" path="0" offset="461" offsetend="463" sl="106" fileid="1" />
+                <BranchPoint vc="0" uspid="106" ordinal="15" path="1" offset="461" offsetend="511" sl="106" fileid="1" />
+                <BranchPoint vc="62" uspid="104" ordinal="13" path="1" offset="448" offsetend="537" sl="104" fileid="1" />
+              </BranchPoints>
+              <MethodPoint vc="39" uspid="0" p8:type="SequencePoint" ordinal="5" offset="5" sc="0" sl="51" ec="1" el="123" bec="0" bev="0" fileid="1" xmlns:p8="xsi" />
+            </Method>
+            <Method cyclomaticComplexity="10" nPathComplexity="0" sequenceCoverage="90" branchCoverage="80" isConstructor="False" isGetter="False" isSetter="False" isStatic="True">
+              <Summary numSequencePoints="20" visitedSequencePoints="18" numBranchPoints="10" visitedBranchPoints="8" sequenceCoverage="90" branchCoverage="80" maxCyclomaticComplexity="10" minCyclomaticComplexity="10" visitedClasses="0" numClasses="0" visitedMethods="1" numMethods="1" />
+              <MetadataToken />
+              <Name>System.Void MyLogging.FancyClass::DebugLogSetup(System.String,MyLogging.FancyClassSettings)</Name>
+              <FileRef uid="1" />
+              <SequencePoints>
+                <SequencePoint vc="33" uspid="127" ordinal="0" sl="127" sc="1" el="127" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="0" uspid="129" ordinal="1" sl="129" sc="1" el="129" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="33" uspid="131" ordinal="2" sl="131" sc="1" el="131" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="0" uspid="133" ordinal="3" sl="133" sc="1" el="133" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="33" uspid="135" ordinal="4" sl="135" sc="1" el="135" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="33" uspid="136" ordinal="5" sl="136" sc="1" el="136" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="33" uspid="137" ordinal="6" sl="137" sc="1" el="137" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="33" uspid="139" ordinal="7" sl="139" sc="1" el="139" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="33" uspid="140" ordinal="8" sl="140" sc="1" el="140" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="4" uspid="142" ordinal="9" sl="142" sc="1" el="142" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="33" uspid="145" ordinal="10" sl="145" sc="1" el="145" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="4" uspid="147" ordinal="11" sl="147" sc="1" el="147" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="4" uspid="149" ordinal="12" sl="149" sc="1" el="149" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="4" uspid="150" ordinal="13" sl="150" sc="1" el="150" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="4" uspid="151" ordinal="14" sl="151" sc="1" el="151" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="4" uspid="152" ordinal="15" sl="152" sc="1" el="152" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="33" uspid="154" ordinal="16" sl="154" sc="1" el="154" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="33" uspid="155" ordinal="17" sl="155" sc="1" el="155" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="33" uspid="156" ordinal="18" sl="156" sc="1" el="156" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="33" uspid="157" ordinal="19" sl="157" sc="1" el="157" ec="2" bec="0" bev="0" fileid="1" />
+              </SequencePoints>
+              <BranchPoints>
+                <BranchPoint vc="0" uspid="127" ordinal="0" path="0" offset="6" offsetend="8" sl="127" fileid="1" />
+                <BranchPoint vc="33" uspid="127" ordinal="1" path="1" offset="6" offsetend="9" sl="127" fileid="1" />
+                <BranchPoint vc="0" uspid="131" ordinal="2" path="0" offset="20" offsetend="22" sl="131" fileid="1" />
+                <BranchPoint vc="33" uspid="131" ordinal="3" path="1" offset="20" offsetend="23" sl="131" fileid="1" />
+                <BranchPoint vc="29" uspid="140" ordinal="4" path="0" offset="61" offsetend="63" sl="140" fileid="1" />
+                <BranchPoint vc="4" uspid="140" ordinal="5" path="1" offset="61" offsetend="72" sl="140" fileid="1" />
+                <BranchPoint vc="4" uspid="140" ordinal="6" path="0" offset="70" offsetend="72" sl="140" fileid="1" />
+                <BranchPoint vc="33" uspid="140" ordinal="7" path="1" offset="70" offsetend="79" sl="140" fileid="1" />
+                <BranchPoint vc="4" uspid="145" ordinal="8" path="0" offset="85" offsetend="87" sl="145" fileid="1" />
+                <BranchPoint vc="33" uspid="145" ordinal="9" path="1" offset="85" offsetend="140" sl="145" fileid="1" />
+              </BranchPoints>
+              <MethodPoint vc="18" uspid="0" p8:type="SequencePoint" ordinal="6" offset="6" sc="0" sl="127" ec="1" el="157" bec="0" bev="0" fileid="1" xmlns:p8="xsi" />
+            </Method>
+            <Method cyclomaticComplexity="10" nPathComplexity="0" sequenceCoverage="100" branchCoverage="100" isConstructor="False" isGetter="False" isSetter="False" isStatic="True">
+              <Summary numSequencePoints="15" visitedSequencePoints="15" numBranchPoints="10" visitedBranchPoints="10" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="10" minCyclomaticComplexity="10" visitedClasses="0" numClasses="0" visitedMethods="1" numMethods="1" />
+              <MetadataToken />
+              <Name>System.Void MyLogging.FancyClass::DebugLogEndUp()</Name>
+              <FileRef uid="1" />
+              <SequencePoints>
+                <SequencePoint vc="34" uspid="161" ordinal="0" sl="161" sc="1" el="161" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="2" uspid="163" ordinal="1" sl="163" sc="1" el="163" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="32" uspid="166" ordinal="2" sl="166" sc="1" el="166" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="32" uspid="167" ordinal="3" sl="167" sc="1" el="167" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="1" uspid="169" ordinal="4" sl="169" sc="1" el="169" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="31" uspid="171" ordinal="5" sl="171" sc="1" el="171" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="31" uspid="173" ordinal="6" sl="173" sc="1" el="173" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="31" uspid="174" ordinal="7" sl="174" sc="1" el="174" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="2" uspid="176" ordinal="8" sl="176" sc="1" el="176" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="2" uspid="178" ordinal="9" sl="178" sc="1" el="178" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="2" uspid="179" ordinal="10" sl="179" sc="1" el="179" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="2" uspid="180" ordinal="11" sl="180" sc="1" el="180" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="31" uspid="182" ordinal="12" sl="182" sc="1" el="182" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="31" uspid="183" ordinal="13" sl="183" sc="1" el="183" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="31" uspid="184" ordinal="14" sl="184" sc="1" el="184" ec="2" bec="0" bev="0" fileid="1" />
+              </SequencePoints>
+              <BranchPoints>
+                <BranchPoint vc="2" uspid="161" ordinal="0" path="0" offset="6" offsetend="8" sl="161" fileid="1" />
+                <BranchPoint vc="32" uspid="161" ordinal="1" path="1" offset="6" offsetend="9" sl="161" fileid="1" />
+                <BranchPoint vc="31" uspid="167" ordinal="2" path="0" offset="30" offsetend="32" sl="167" fileid="1" />
+                <BranchPoint vc="1" uspid="167" ordinal="4" path="0" offset="33" offsetend="35" sl="167" fileid="1" />
+                <BranchPoint vc="31" uspid="167" ordinal="3" path="1" offset="30" offsetend="36" sl="167" fileid="1" />
+                <BranchPoint vc="31" uspid="167" ordinal="5" path="1" offset="33" offsetend="36" sl="167" fileid="1" />
+                <BranchPoint vc="30" uspid="173" ordinal="6" path="0" offset="53" offsetend="55" sl="173" fileid="1" />
+                <BranchPoint vc="1" uspid="173" ordinal="7" path="1" offset="53" offsetend="69" sl="173" fileid="1" />
+                <BranchPoint vc="2" uspid="174" ordinal="8" path="0" offset="79" offsetend="81" sl="174" fileid="1" />
+                <BranchPoint vc="31" uspid="174" ordinal="9" path="1" offset="79" offsetend="138" sl="174" fileid="1" />
+              </BranchPoints>
+              <MethodPoint vc="15" uspid="0" p8:type="SequencePoint" ordinal="7" offset="7" sc="0" sl="161" ec="1" el="184" bec="0" bev="0" fileid="1" xmlns:p8="xsi" />
+            </Method>
+            <Method cyclomaticComplexity="2" nPathComplexity="0" sequenceCoverage="75" branchCoverage="50" isConstructor="False" isGetter="False" isSetter="False" isStatic="True">
+              <Summary numSequencePoints="4" visitedSequencePoints="3" numBranchPoints="2" visitedBranchPoints="1" sequenceCoverage="75" branchCoverage="50" maxCyclomaticComplexity="2" minCyclomaticComplexity="2" visitedClasses="0" numClasses="0" visitedMethods="1" numMethods="1" />
+              <MetadataToken />
+              <Name>System.Void MyLogging.FancyClass::session_abandon()</Name>
+              <FileRef uid="1" />
+              <SequencePoints>
+                <SequencePoint vc="1" uspid="188" ordinal="0" sl="188" sc="1" el="188" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="0" uspid="190" ordinal="1" sl="190" sc="1" el="190" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="1" uspid="192" ordinal="2" sl="192" sc="1" el="192" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="1" uspid="193" ordinal="3" sl="193" sc="1" el="193" ec="2" bec="0" bev="0" fileid="1" />
+              </SequencePoints>
+              <BranchPoints>
+                <BranchPoint vc="0" uspid="188" ordinal="0" path="0" offset="6" offsetend="8" sl="188" fileid="1" />
+                <BranchPoint vc="1" uspid="188" ordinal="1" path="1" offset="6" offsetend="9" sl="188" fileid="1" />
+              </BranchPoints>
+              <MethodPoint vc="3" uspid="0" p8:type="SequencePoint" ordinal="8" offset="8" sc="0" sl="188" ec="1" el="193" bec="0" bev="0" fileid="1" xmlns:p8="xsi" />
+            </Method>
+            <Method cyclomaticComplexity="4" nPathComplexity="0" sequenceCoverage="91.66" branchCoverage="75" isConstructor="False" isGetter="False" isSetter="False" isStatic="True">
+              <Summary numSequencePoints="12" visitedSequencePoints="11" numBranchPoints="4" visitedBranchPoints="3" sequenceCoverage="91.66" branchCoverage="75" maxCyclomaticComplexity="4" minCyclomaticComplexity="4" visitedClasses="0" numClasses="0" visitedMethods="1" numMethods="1" />
+              <MetadataToken />
+              <Name>System.IO.FileInfo MyLogging.FancyClass::GetLatestsLogFile()</Name>
+              <FileRef uid="1" />
+              <SequencePoints>
+                <SequencePoint vc="33" uspid="197" ordinal="0" sl="197" sc="1" el="197" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="33" uspid="198" ordinal="1" sl="198" sc="1" el="198" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="33" uspid="199" ordinal="2" sl="199" sc="1" el="199" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="0" uspid="201" ordinal="3" sl="201" sc="1" el="201" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="33" uspid="204" ordinal="4" sl="204" sc="1" el="204" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="33" uspid="205" ordinal="5" sl="205" sc="1" el="205" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="33" uspid="206" ordinal="6" sl="206" sc="1" el="206" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="33" uspid="207" ordinal="7" sl="207" sc="1" el="207" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="62" uspid="208" ordinal="8" sl="208" sc="1" el="208" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="62" uspid="209" ordinal="9" sl="209" sc="1" el="209" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="62" uspid="210" ordinal="10" sl="210" sc="1" el="210" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="33" uspid="212" ordinal="11" sl="212" sc="1" el="212" ec="2" bec="0" bev="0" fileid="1" />
+              </SequencePoints>
+              <BranchPoints>
+                <BranchPoint vc="0" uspid="199" ordinal="0" path="0" offset="45" offsetend="47" sl="199" fileid="1" />
+                <BranchPoint vc="33" uspid="199" ordinal="1" path="1" offset="45" offsetend="49" sl="199" fileid="1" />
+                <BranchPoint vc="1" uspid="204" ordinal="2" path="0" offset="64" offsetend="66" sl="204" fileid="1" />
+                <BranchPoint vc="33" uspid="204" ordinal="3" path="1" offset="64" offsetend="89" sl="204" fileid="1" />
+              </BranchPoints>
+              <MethodPoint vc="11" uspid="0" p8:type="SequencePoint" ordinal="9" offset="9" sc="0" sl="197" ec="1" el="212" bec="0" bev="0" fileid="1" xmlns:p8="xsi" />
+            </Method>
+            <Method cyclomaticComplexity="1" nPathComplexity="0" sequenceCoverage="100" branchCoverage="100" isConstructor="False" isGetter="False" isSetter="False" isStatic="True">
+              <Summary numSequencePoints="3" visitedSequencePoints="3" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" visitedClasses="0" numClasses="0" visitedMethods="1" numMethods="1" />
+              <MetadataToken />
+              <Name>System.Boolean MyLogging.FancyClass::IsLogFileReachLimit(System.IO.FileInfo)</Name>
+              <FileRef uid="1" />
+              <SequencePoints>
+                <SequencePoint vc="59" uspid="218" ordinal="0" sl="218" sc="1" el="218" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="59" uspid="219" ordinal="1" sl="219" sc="1" el="219" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="59" uspid="221" ordinal="2" sl="221" sc="1" el="221" ec="2" bec="0" bev="0" fileid="1" />
+              </SequencePoints>
+              <BranchPoints />
+              <MethodPoint vc="3" uspid="0" p8:type="SequencePoint" ordinal="10" offset="10" sc="0" sl="218" ec="1" el="221" bec="0" bev="0" fileid="1" xmlns:p8="xsi" />
+            </Method>
+            <Method cyclomaticComplexity="1" nPathComplexity="0" sequenceCoverage="100" branchCoverage="100" isConstructor="False" isGetter="False" isSetter="False" isStatic="True">
+              <Summary numSequencePoints="5" visitedSequencePoints="5" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" visitedClasses="0" numClasses="0" visitedMethods="1" numMethods="1" />
+              <MetadataToken />
+              <Name>System.IO.FileInfo MyLogging.FancyClass::CreateLogFile()</Name>
+              <FileRef uid="1" />
+              <SequencePoints>
+                <SequencePoint vc="4" uspid="226" ordinal="0" sl="226" sc="1" el="226" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="4" uspid="227" ordinal="1" sl="227" sc="1" el="227" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="4" uspid="228" ordinal="2" sl="228" sc="1" el="228" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="4" uspid="229" ordinal="3" sl="229" sc="1" el="229" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="4" uspid="231" ordinal="4" sl="231" sc="1" el="231" ec="2" bec="0" bev="0" fileid="1" />
+              </SequencePoints>
+              <BranchPoints />
+              <MethodPoint vc="5" uspid="0" p8:type="SequencePoint" ordinal="11" offset="11" sc="0" sl="226" ec="1" el="231" bec="0" bev="0" fileid="1" xmlns:p8="xsi" />
+            </Method>
+            <Method cyclomaticComplexity="1" nPathComplexity="0" sequenceCoverage="100" branchCoverage="100" isConstructor="True" isGetter="False" isSetter="False" isStatic="True">
+              <Summary numSequencePoints="7" visitedSequencePoints="7" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" visitedClasses="0" numClasses="0" visitedMethods="1" numMethods="1" />
+              <MetadataToken />
+              <Name>System.Void MyLogging.FancyClass::.ctor()</Name>
+              <FileRef uid="1" />
+              <SequencePoints>
+                <SequencePoint vc="5" uspid="40" ordinal="0" sl="40" sc="1" el="40" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="5" uspid="42" ordinal="1" sl="42" sc="1" el="42" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="5" uspid="43" ordinal="2" sl="43" sc="1" el="43" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="5" uspid="44" ordinal="3" sl="44" sc="1" el="44" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="5" uspid="45" ordinal="4" sl="45" sc="1" el="45" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="5" uspid="46" ordinal="5" sl="46" sc="1" el="46" ec="2" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="5" uspid="47" ordinal="6" sl="47" sc="1" el="47" ec="2" bec="0" bev="0" fileid="1" />
+              </SequencePoints>
+              <BranchPoints />
+              <MethodPoint vc="7" uspid="0" p8:type="SequencePoint" ordinal="12" offset="12" sc="0" sl="40" ec="1" el="47" bec="0" bev="0" fileid="1" xmlns:p8="xsi" />
+            </Method>
+            <Method cyclomaticComplexity="1" nPathComplexity="0" sequenceCoverage="100" branchCoverage="100" isConstructor="True" isGetter="False" isSetter="False" isStatic="True">
+              <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" visitedClasses="0" numClasses="0" visitedMethods="1" numMethods="1" />
+              <MetadataToken />
+              <Name>System.Void MyLogging.FancyClass::.cctor()</Name>
+              <FileRef uid="1" />
+              <SequencePoints>
+                <SequencePoint vc="1" uspid="16" ordinal="0" sl="16" sc="1" el="16" ec="2" bec="0" bev="0" fileid="1" />
+              </SequencePoints>
+              <BranchPoints />
+              <MethodPoint vc="1" uspid="0" p8:type="SequencePoint" ordinal="13" offset="13" sc="0" sl="16" ec="1" el="16" bec="0" bev="0" fileid="1" xmlns:p8="xsi" />
+            </Method>
+          </Methods>
+        </Class>
+        <Class>
+          <Summary numSequencePoints="12" visitedSequencePoints="11" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="91.66" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" visitedClasses="1" numClasses="1" visitedMethods="5" numMethods="6" />
+          <FullName>MyLogging.FancyClassSettings</FullName>
+          <Methods>
+            <Method cyclomaticComplexity="1" nPathComplexity="0" sequenceCoverage="100" branchCoverage="100" isConstructor="False" isGetter="True" isSetter="False" isStatic="True">
+              <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" visitedClasses="0" numClasses="0" visitedMethods="1" numMethods="1" />
+              <MetadataToken />
+              <Name>System.Boolean MyLogging.FancyClassSettings::get_IsEnabled()</Name>
+              <FileRef uid="2" />
+              <SequencePoints>
+                <SequencePoint vc="33" uspid="5" ordinal="0" sl="5" sc="1" el="5" ec="2" bec="0" bev="0" fileid="2" />
+              </SequencePoints>
+              <BranchPoints />
+              <MethodPoint vc="1" uspid="0" p8:type="SequencePoint" ordinal="0" offset="0" sc="0" sl="5" ec="1" el="5" bec="0" bev="0" fileid="2" xmlns:p8="xsi" />
+            </Method>
+            <Method cyclomaticComplexity="1" nPathComplexity="0" sequenceCoverage="100" branchCoverage="100" isConstructor="False" isGetter="True" isSetter="False" isStatic="True">
+              <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" visitedClasses="0" numClasses="0" visitedMethods="1" numMethods="1" />
+              <MetadataToken />
+              <Name>System.String MyLogging.FancyClassSettings::get_Location()</Name>
+              <FileRef uid="2" />
+              <SequencePoints>
+                <SequencePoint vc="70" uspid="7" ordinal="0" sl="7" sc="1" el="7" ec="2" bec="0" bev="0" fileid="2" />
+              </SequencePoints>
+              <BranchPoints />
+              <MethodPoint vc="1" uspid="0" p8:type="SequencePoint" ordinal="1" offset="1" sc="0" sl="7" ec="1" el="7" bec="0" bev="0" fileid="2" xmlns:p8="xsi" />
+            </Method>
+            <Method cyclomaticComplexity="1" nPathComplexity="0" sequenceCoverage="0" branchCoverage="100" isConstructor="False" isGetter="True" isSetter="False" isStatic="True">
+              <Summary numSequencePoints="1" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" visitedClasses="0" numClasses="0" visitedMethods="0" numMethods="1" />
+              <MetadataToken />
+              <Name>System.Boolean MyLogging.FancyClassSettings::get_IsPretty()</Name>
+              <FileRef uid="2" />
+              <SequencePoints>
+                <SequencePoint vc="0" uspid="9" ordinal="0" sl="9" sc="1" el="9" ec="2" bec="0" bev="0" fileid="2" />
+              </SequencePoints>
+              <BranchPoints />
+              <MethodPoint vc="0" uspid="0" p8:type="SequencePoint" ordinal="2" offset="2" sc="0" sl="9" ec="1" el="9" bec="0" bev="0" fileid="2" xmlns:p8="xsi" />
+            </Method>
+            <Method cyclomaticComplexity="1" nPathComplexity="0" sequenceCoverage="100" branchCoverage="100" isConstructor="False" isGetter="True" isSetter="False" isStatic="True">
+              <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" visitedClasses="0" numClasses="0" visitedMethods="1" numMethods="1" />
+              <MetadataToken />
+              <Name>System.Int32 MyLogging.FancyClassSettings::get_Limit()</Name>
+              <FileRef uid="2" />
+              <SequencePoints>
+                <SequencePoint vc="91" uspid="11" ordinal="0" sl="11" sc="1" el="11" ec="2" bec="0" bev="0" fileid="2" />
+              </SequencePoints>
+              <BranchPoints />
+              <MethodPoint vc="1" uspid="0" p8:type="SequencePoint" ordinal="3" offset="3" sc="0" sl="11" ec="1" el="11" bec="0" bev="0" fileid="2" xmlns:p8="xsi" />
+            </Method>
+            <Method cyclomaticComplexity="1" nPathComplexity="0" sequenceCoverage="100" branchCoverage="100" isConstructor="False" isGetter="True" isSetter="False" isStatic="True">
+              <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" visitedClasses="0" numClasses="0" visitedMethods="1" numMethods="1" />
+              <MetadataToken />
+              <Name>System.Boolean MyLogging.FancyClassSettings::get_IsMyCodeWrittenWell()</Name>
+              <FileRef uid="2" />
+              <SequencePoints>
+                <SequencePoint vc="62" uspid="13" ordinal="0" sl="13" sc="1" el="13" ec="2" bec="0" bev="0" fileid="2" />
+              </SequencePoints>
+              <BranchPoints />
+              <MethodPoint vc="1" uspid="0" p8:type="SequencePoint" ordinal="4" offset="4" sc="0" sl="13" ec="1" el="13" bec="0" bev="0" fileid="2" xmlns:p8="xsi" />
+            </Method>
+            <Method cyclomaticComplexity="1" nPathComplexity="0" sequenceCoverage="100" branchCoverage="100" isConstructor="True" isGetter="False" isSetter="False" isStatic="True">
+              <Summary numSequencePoints="7" visitedSequencePoints="7" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" visitedClasses="0" numClasses="0" visitedMethods="1" numMethods="1" />
+              <MetadataToken />
+              <Name>System.Void MyLogging.FancyClassSettings::.ctor(System.Boolean,System.String,System.Boolean,System.Int32,System.Boolean)</Name>
+              <FileRef uid="2" />
+              <SequencePoints>
+                <SequencePoint vc="33" uspid="15" ordinal="0" sl="15" sc="1" el="15" ec="2" bec="0" bev="0" fileid="2" />
+                <SequencePoint vc="33" uspid="17" ordinal="1" sl="17" sc="1" el="17" ec="2" bec="0" bev="0" fileid="2" />
+                <SequencePoint vc="33" uspid="18" ordinal="2" sl="18" sc="1" el="18" ec="2" bec="0" bev="0" fileid="2" />
+                <SequencePoint vc="33" uspid="19" ordinal="3" sl="19" sc="1" el="19" ec="2" bec="0" bev="0" fileid="2" />
+                <SequencePoint vc="33" uspid="20" ordinal="4" sl="20" sc="1" el="20" ec="2" bec="0" bev="0" fileid="2" />
+                <SequencePoint vc="33" uspid="21" ordinal="5" sl="21" sc="1" el="21" ec="2" bec="0" bev="0" fileid="2" />
+                <SequencePoint vc="33" uspid="22" ordinal="6" sl="22" sc="1" el="22" ec="2" bec="0" bev="0" fileid="2" />
+              </SequencePoints>
+              <BranchPoints />
+              <MethodPoint vc="7" uspid="0" p8:type="SequencePoint" ordinal="5" offset="5" sc="0" sl="15" ec="1" el="22" bec="0" bev="0" fileid="2" xmlns:p8="xsi" />
+            </Method>
+          </Methods>
+        </Class>
+        <Class>
+          <Summary numSequencePoints="5" visitedSequencePoints="5" numBranchPoints="2" visitedBranchPoints="2" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="2" minCyclomaticComplexity="2" visitedClasses="1" numClasses="1" visitedMethods="1" numMethods="1" />
+          <FullName>MyLogging.FancyHelper</FullName>
+          <Methods>
+            <Method cyclomaticComplexity="2" nPathComplexity="0" sequenceCoverage="100" branchCoverage="100" isConstructor="False" isGetter="False" isSetter="False" isStatic="True">
+              <Summary numSequencePoints="5" visitedSequencePoints="5" numBranchPoints="2" visitedBranchPoints="2" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="2" minCyclomaticComplexity="2" visitedClasses="0" numClasses="0" visitedMethods="1" numMethods="1" />
+              <MetadataToken />
+              <Name>System.Int32 MyLogging.FancyHelper::Diff(System.Int32,System.Int32)</Name>
+              <FileRef uid="3" />
+              <SequencePoints>
+                <SequencePoint vc="64" uspid="8" ordinal="0" sl="8" sc="1" el="8" ec="2" bec="0" bev="0" fileid="3" />
+                <SequencePoint vc="64" uspid="9" ordinal="1" sl="9" sc="1" el="9" ec="2" bec="0" bev="0" fileid="3" />
+                <SequencePoint vc="64" uspid="10" ordinal="2" sl="10" sc="1" el="10" ec="2" bec="0" bev="0" fileid="3" />
+                <SequencePoint vc="1" uspid="12" ordinal="3" sl="12" sc="1" el="12" ec="2" bec="0" bev="0" fileid="3" />
+                <SequencePoint vc="64" uspid="14" ordinal="4" sl="14" sc="1" el="14" ec="2" bec="0" bev="0" fileid="3" />
+              </SequencePoints>
+              <BranchPoints>
+                <BranchPoint vc="1" uspid="10" ordinal="0" path="0" offset="8" offsetend="10" sl="10" fileid="3" />
+                <BranchPoint vc="64" uspid="10" ordinal="1" path="1" offset="8" offsetend="18" sl="10" fileid="3" />
+              </BranchPoints>
+              <MethodPoint vc="5" uspid="0" p8:type="SequencePoint" ordinal="0" offset="0" sc="0" sl="8" ec="1" el="14" bec="0" bev="0" fileid="3" xmlns:p8="xsi" />
+            </Method>
+          </Methods>
+        </Class>
+      </Classes>
+    </Module>
+  </Modules>
+</CoverageSession>


### PR DESCRIPTION
Add parser for the OpenCover format that was supported by the `coverage-api` plugin through `opencover` plugin (https://plugins.jenkins.io/opencover/)

OpenCover is not actively maintained but still the reference for .NET SDK legacy project (https://github.com/OpenCover/opencover)

I tried to get inspired from the Jacoco and Cobertura Parser to implement it. I'm getting similar coverage percentage from the `opencover`

### Testing done

Automated only.

But when integrated to coverage plugin I will do more test with real data when migrating from `publishCoverage` to `recordCoverage` step.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
