### PR TITLE
[JENKINS-72449] Add a toggle to ignore empty results

### DIFF
--- a/src/main/java/edu/hm/hafner/coverage/CoverageParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/CoverageParser.java
@@ -78,6 +78,36 @@ public abstract class CoverageParser implements Serializable {
     }
 
     /**
+     * Handles processing of empty results.
+     *
+     * @param log
+     *         the log
+     * @param isEmpty
+     *         determines whether the results are empty
+     * @throws NoSuchElementException if the results are empty and errors should not be ignored
+     */
+    protected void handleEmptyResults(final FilteredLog log, final boolean isEmpty) {
+        if (isEmpty) {
+            if (ignoreErrors()) {
+                log.logError("No coverage information found in the specified file.");
+            }
+            else {
+                throw new NoSuchElementException("No data found in the specified file.");
+            }
+        }
+    }
+
+    /**
+     * Handles processing of empty results.
+     *
+     * @param log
+     *         the log
+     */
+    protected void handleEmptyResults(final FilteredLog log) {
+        handleEmptyResults(log, true);
+    }
+
+    /**
      * Called after de-serialization to restore transient fields.
      *
      * @return this

--- a/src/main/java/edu/hm/hafner/coverage/CoverageParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/CoverageParser.java
@@ -18,6 +18,9 @@ import edu.hm.hafner.util.TreeStringBuilder;
  * @author Ullrich Hafner
  */
 public abstract class CoverageParser implements Serializable {
+    /** Error message when there are no results. */
+    public static final String EMPTY_MESSAGE = "No data found in the specified file.";
+
     /**
      * Defines how to handle fatal errors during parsing.
      */
@@ -89,10 +92,10 @@ public abstract class CoverageParser implements Serializable {
     protected void handleEmptyResults(final FilteredLog log, final boolean isEmpty) {
         if (isEmpty) {
             if (ignoreErrors()) {
-                log.logError("No coverage information found in the specified file.");
+                log.logError(EMPTY_MESSAGE);
             }
             else {
-                throw new NoSuchElementException("No data found in the specified file.");
+                throw new NoSuchElementException(EMPTY_MESSAGE);
             }
         }
     }

--- a/src/main/java/edu/hm/hafner/coverage/parser/CoberturaParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/parser/CoberturaParser.java
@@ -2,7 +2,6 @@ package edu.hm.hafner.coverage.parser;
 
 import java.io.Reader;
 import java.nio.file.Paths;
-import java.util.NoSuchElementException;
 import java.util.UUID;
 import java.util.regex.Pattern;
 import javax.xml.namespace.QName;
@@ -88,15 +87,7 @@ public class CoberturaParser extends CoverageParser {
             var eventReader = new SecureXmlParserFactory().createXmlEventReader(reader);
 
             var root = new ModuleNode("-"); // Cobertura has no support for module names
-            var isEmpty = readModule(log, eventReader, root);
-            if (isEmpty) {
-                if (ignoreErrors()) {
-                    log.logError("No coverage information found in the specified file.");
-                }
-                else {
-                    throw new NoSuchElementException("No coverage information found in the specified file.");
-                }
-            }
+            handleEmptyResults(log, readModule(log, eventReader, root));
             return root;
         }
         catch (XMLStreamException exception) {

--- a/src/main/java/edu/hm/hafner/coverage/parser/JacocoParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/parser/JacocoParser.java
@@ -101,7 +101,7 @@ public class JacocoParser extends CoverageParser {
                     }
                 }
             }
-            handleEmptyResults(log, true);
+            handleEmptyResults(log);
 
             return new ModuleNode("empty");
         }

--- a/src/main/java/edu/hm/hafner/coverage/parser/JacocoParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/parser/JacocoParser.java
@@ -2,7 +2,6 @@ package edu.hm.hafner.coverage.parser;
 
 import java.io.Reader;
 import java.nio.file.Paths;
-import java.util.NoSuchElementException;
 import java.util.Optional;
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLEventReader;
@@ -66,6 +65,23 @@ public class JacocoParser extends CoverageParser {
     private static final QName COVERED_BRANCHED = new QName("cb");
     private static final PathUtil PATH_UTIL = new PathUtil();
 
+    /**
+     * Creates a new instance of {@link JacocoParser}.
+     */
+    public JacocoParser() {
+        this(ProcessingMode.FAIL_FAST);
+    }
+
+    /**
+     * Creates a new instance of {@link JacocoParser}.
+     *
+     * @param processingMode
+     *         determines whether to ignore errors
+     */
+    public JacocoParser(final ProcessingMode processingMode) {
+        super(processingMode);
+    }
+
     @Override
     protected ModuleNode parseReport(final Reader reader, final FilteredLog log) {
         try {
@@ -85,7 +101,9 @@ public class JacocoParser extends CoverageParser {
                     }
                 }
             }
-            throw new NoSuchElementException("No coverage information found in the specified file.");
+            handleEmptyResults(log, true);
+
+            return new ModuleNode("empty");
         }
         catch (XMLStreamException exception) {
             throw new ParsingException(exception);

--- a/src/main/java/edu/hm/hafner/coverage/parser/JunitParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/parser/JunitParser.java
@@ -3,7 +3,6 @@ package edu.hm.hafner.coverage.parser;
 import java.io.Reader;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.UUID;
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLEventReader;
@@ -39,6 +38,23 @@ public class JunitParser extends CoverageParser {
     private static final QName SKIPPED = new QName("skipped");
     private static final String EMPTY = "-";
 
+    /**
+     * Creates a new instance of {@link JunitParser}.
+     */
+    public JunitParser() {
+        this(ProcessingMode.FAIL_FAST);
+    }
+
+    /**
+     * Creates a new instance of {@link JunitParser}.
+     *
+     * @param processingMode
+     *         determines whether to ignore errors
+     */
+    public JunitParser(final ProcessingMode processingMode) {
+        super(processingMode);
+    }
+
     @Override
     protected ModuleNode parseReport(final Reader reader, final FilteredLog log) {
         try {
@@ -47,9 +63,7 @@ public class JunitParser extends CoverageParser {
 
             var root = new ModuleNode(EMPTY);
             var tests = readTestCases(eventReader, root);
-            if (tests.isEmpty()) {
-                throw new NoSuchElementException("No test cases found");
-            }
+            handleEmptyResults(log, tests.isEmpty());
             return root;
         }
         catch (XMLStreamException exception) {

--- a/src/main/java/edu/hm/hafner/coverage/parser/PitestParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/parser/PitestParser.java
@@ -1,7 +1,6 @@
 package edu.hm.hafner.coverage.parser;
 
 import java.io.Reader;
-import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -47,6 +46,23 @@ public class PitestParser extends CoverageParser {
     private static final QName DETECTED = new QName("detected");
     private static final QName STATUS = new QName("status");
 
+    /**
+     * Creates a new instance of {@link PitestParser}.
+     */
+    public PitestParser() {
+        this(ProcessingMode.FAIL_FAST);
+    }
+
+    /**
+     * Creates a new instance of {@link PitestParser}.
+     *
+     * @param processingMode
+     *         determines whether to ignore errors
+     */
+    public PitestParser(final ProcessingMode processingMode) {
+        super(processingMode);
+    }
+
     @Override
     protected ModuleNode parseReport(final Reader reader, final FilteredLog log) {
         try {
@@ -63,9 +79,7 @@ public class PitestParser extends CoverageParser {
                     isEmpty = false;
                 }
             }
-            if (isEmpty) {
-                throw new NoSuchElementException("No mutations found in the specified file.");
-            }
+            handleEmptyResults(log, isEmpty);
             root.getAllFileNodes().forEach(this::collectLineCoverage);
             return root;
         }

--- a/src/test/java/edu/hm/hafner/coverage/parser/AbstractParserTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/parser/AbstractParserTest.java
@@ -66,10 +66,6 @@ abstract class AbstractParserTest {
 
     abstract CoverageParser createParser(ProcessingMode processingMode);
 
-    CoverageParser createParser() {
-        return createParser(ProcessingMode.FAIL_FAST);
-    }
-
     protected FilteredLog getLog() {
         return log;
     }
@@ -87,5 +83,6 @@ abstract class AbstractParserTest {
         var report = readReport("empty.xml", ProcessingMode.IGNORE_ERRORS);
 
         assertThat(report).hasNoChildren().hasNoValues();
+        assertThat(getLog().getErrorMessages()).contains(CoverageParser.EMPTY_MESSAGE);
     }
 }

--- a/src/test/java/edu/hm/hafner/coverage/parser/CoberturaParserTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/parser/CoberturaParserTest.java
@@ -31,8 +31,8 @@ class CoberturaParserTest extends AbstractParserTest {
     private static final int MISSED_LINES = 8 + 1 + 1 + 10;
 
     @Override
-    CoberturaParser createParser() {
-        return new CoberturaParser();
+    CoberturaParser createParser(final ProcessingMode processingMode) {
+        return new CoberturaParser(processingMode);
     }
 
     @Override

--- a/src/test/java/edu/hm/hafner/coverage/parser/JacocoParserTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/parser/JacocoParserTest.java
@@ -14,6 +14,7 @@ import org.junitpioneer.jupiter.DefaultLocale;
 import edu.hm.hafner.coverage.Coverage;
 import edu.hm.hafner.coverage.Coverage.CoverageBuilder;
 import edu.hm.hafner.coverage.CoverageParser;
+import edu.hm.hafner.coverage.CoverageParser.ProcessingMode;
 import edu.hm.hafner.coverage.CyclomaticComplexity;
 import edu.hm.hafner.coverage.FileNode;
 import edu.hm.hafner.coverage.FractionValue;
@@ -34,8 +35,8 @@ class JacocoParserTest extends AbstractParserTest {
     private static final String PROJECT_NAME = "Java coding style";
 
     @Override
-    CoverageParser createParser() {
-        return new JacocoParser();
+    CoverageParser createParser(final ProcessingMode processingMode) {
+        return new JacocoParser(processingMode);
     }
 
     @Override

--- a/src/test/java/edu/hm/hafner/coverage/parser/JunitParserTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/parser/JunitParserTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 
 import edu.hm.hafner.coverage.ClassNode;
 import edu.hm.hafner.coverage.CoverageParser;
+import edu.hm.hafner.coverage.CoverageParser.ProcessingMode;
 import edu.hm.hafner.coverage.Metric;
 import edu.hm.hafner.coverage.ModuleNode;
 import edu.hm.hafner.coverage.Node;
@@ -21,8 +22,8 @@ class JunitParserTest extends AbstractParserTest {
     private static final String EMPTY = "-";
 
     @Override
-    CoverageParser createParser() {
-        return new JunitParser();
+    CoverageParser createParser(final ProcessingMode processingMode) {
+        return new JunitParser(processingMode);
     }
 
     @Override

--- a/src/test/java/edu/hm/hafner/coverage/parser/PitestParserTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/parser/PitestParserTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 
 import edu.hm.hafner.coverage.Coverage;
 import edu.hm.hafner.coverage.CoverageParser;
+import edu.hm.hafner.coverage.CoverageParser.ProcessingMode;
 import edu.hm.hafner.coverage.FileNode;
 import edu.hm.hafner.coverage.ModuleNode;
 import edu.hm.hafner.coverage.Mutation;
@@ -21,8 +22,8 @@ class PitestParserTest extends AbstractParserTest {
     private static final String ENSURE = "Ensure.java";
 
     @Override
-    CoverageParser createParser() {
-        return new PitestParser();
+    CoverageParser createParser(final ProcessingMode processingMode) {
+        return new PitestParser(processingMode);
     }
 
     @Override

--- a/src/test/resources/edu/hm/hafner/coverage/parser/cobertura/empty.xml
+++ b/src/test/resources/edu/hm/hafner/coverage/parser/cobertura/empty.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">
+<coverage line-rate="0.76829268292683" branch-rate="0" lines-covered="63" lines-valid="82" branches-covered="0" branches-valid="0" complexity="22" version="0.4" timestamp="1653406063">
+</coverage>

--- a/src/test/resources/edu/hm/hafner/coverage/parser/jacoco/empty.xml
+++ b/src/test/resources/edu/hm/hafner/coverage/parser/jacoco/empty.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<other name="Java coding style">
+</other>

--- a/src/test/resources/edu/hm/hafner/coverage/parser/junit/empty.xml
+++ b/src/test/resources/edu/hm/hafner/coverage/parser/junit/empty.xml
@@ -1,0 +1,3 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<testsuite name="my.company.MainActivityTest" tests="1" failures="1" errors="0" skipped="0" time="66.551" timestamp="2020-09-04T08:53:58" hostname="localhost">
+</testsuite>

--- a/src/test/resources/edu/hm/hafner/coverage/parser/pit/empty.xml
+++ b/src/test/resources/edu/hm/hafner/coverage/parser/pit/empty.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mutations>
+</mutations>


### PR DESCRIPTION
Otherwise, the parsers will throw an exception.

Will fix jenkinsci/code-coverage-api-plugin#723.

See also https://issues.jenkins.io/browse/JENKINS-72449.
