### PR TITLE
Add support for NUnit format

### DIFF
--- a/src/main/java/edu/hm/hafner/coverage/parser/NunitParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/parser/NunitParser.java
@@ -20,7 +20,7 @@ import edu.hm.hafner.util.SecureXmlParserFactory;
 import edu.hm.hafner.util.SecureXmlParserFactory.ParsingException;
 
 /**
- * Parses reports in the NUnit format (https://docs.nunit.org/articles/nunit/technical-notes/usage/Test-Result-XML-Format.html) into a Java object model.
+ * Parses reports in the <a href="https://docs.nunit.org/articles/nunit/technical-notes/usage/Test-Result-XML-Format.html">NUnit format</a> into a Java object model.
  *
  * @author Valentin Delaye
  */
@@ -89,7 +89,6 @@ public class NunitParser extends CoverageParser {
         return tests;
     }
 
-    @SuppressWarnings("PMD.CyclomaticComplexity")
     private TestCase readTestCase(final XMLEventReader reader, final StartElement testCaseElement,
             final String suiteName, final ModuleNode root)
             throws XMLStreamException {
@@ -98,17 +97,17 @@ public class NunitParser extends CoverageParser {
         builder.withTestName(getOptionalValueOf(testCaseElement, NAME).orElse(createId()));
         
         var status = getValueOf(testCaseElement, RESULT);
-        if (status.equals(PASSED)) {
-            builder.withStatus(TestCase.TestResult.PASSED);
-        }
-        else if (status.equals(FAILED)) {
-            builder.withStatus(TestCase.TestResult.FAILED);
-        }
-        else if (status.equals(SKIPPED)) {
-            builder.withStatus(TestCase.TestResult.SKIPPED);
-        }
-        else {
-            builder.withStatus(TestCase.TestResult.SKIPPED);
+        switch (status) {
+            case PASSED:
+                builder.withStatus(TestCase.TestResult.PASSED);
+                break;
+            case FAILED:
+                builder.withStatus(TestCase.TestResult.FAILED);
+                break;
+            case SKIPPED:
+            default:
+                builder.withStatus(TestCase.TestResult.SKIPPED);
+                break;
         }
 
         while (reader.hasNext()) {

--- a/src/main/java/edu/hm/hafner/coverage/parser/NunitParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/parser/NunitParser.java
@@ -1,0 +1,166 @@
+package edu.hm.hafner.coverage.parser;
+
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLEventReader;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.events.StartElement;
+import javax.xml.stream.events.XMLEvent;
+
+import edu.hm.hafner.coverage.CoverageParser;
+import edu.hm.hafner.coverage.ModuleNode;
+import edu.hm.hafner.coverage.TestCase;
+import edu.hm.hafner.coverage.TestCase.TestCaseBuilder;
+import edu.hm.hafner.util.FilteredLog;
+import edu.hm.hafner.util.SecureXmlParserFactory;
+import edu.hm.hafner.util.SecureXmlParserFactory.ParsingException;
+
+/**
+ * Parses reports in the NUnit format (https://docs.nunit.org/articles/nunit/technical-notes/usage/Test-Result-XML-Format.html) into a Java object model.
+ *
+ * @author Valentin Delaye
+ */
+@SuppressWarnings("checkstyle:ClassDataAbstractionCoupling")
+public class NunitParser extends CoverageParser {
+    private static final long serialVersionUID = -5468593789018138107L;
+
+    private static final QName TEST_SUITE = new QName("test-suite");
+    private static final QName TEST_CASE = new QName("test-case");
+    private static final QName NAME = new QName("name");
+    private static final QName CLASS_NAME = new QName("classname");
+    private static final QName FAILURE = new QName("failure");
+    private static final QName MESSAGE = new QName("message");
+    private static final QName RESULT = new QName("result");
+    private static final String PASSED = "Passed";
+    private static final String FAILED = "Failed";
+    private static final String SKIPPED = "Skipped";
+
+    /**
+     * Creates a new instance of {@link NunitParser}.
+     */
+    public NunitParser() {
+        this(ProcessingMode.FAIL_FAST);
+    }
+
+    /**
+     * Creates a new instance of {@link NunitParser}.
+     *
+     * @param processingMode
+     *         determines whether to ignore errors
+     */
+    public NunitParser(final ProcessingMode processingMode) {
+        super(processingMode);
+    }
+
+    @Override
+    protected ModuleNode parseReport(final Reader reader, final FilteredLog log) {
+        try {
+            var factory = new SecureXmlParserFactory();
+            var eventReader = factory.createXmlEventReader(reader);
+
+            var root = new ModuleNode(EMPTY);
+            var tests = readTestCases(eventReader, root);
+            handleEmptyResults(log, tests.isEmpty());
+            return root;
+        }
+        catch (XMLStreamException exception) {
+            throw new ParsingException(exception);
+        }
+    }
+
+    private List<Object> readTestCases(final XMLEventReader eventReader,
+            final ModuleNode root) throws XMLStreamException {
+        String suiteName = EMPTY;
+        var tests = new ArrayList<>();
+        while (eventReader.hasNext()) {
+            XMLEvent event = eventReader.nextEvent();
+
+            if (event.isStartElement() && TEST_SUITE.equals(event.asStartElement().getName())) {
+                suiteName = getOptionalValueOf(event.asStartElement(), NAME).orElse(EMPTY);
+            }
+            else if (event.isStartElement() && TEST_CASE.equals(event.asStartElement().getName())) {
+                tests.add(readTestCase(eventReader, event.asStartElement(), suiteName, root));
+            }
+        }
+        return tests;
+    }
+
+    @SuppressWarnings("PMD.CyclomaticComplexity")
+    private TestCase readTestCase(final XMLEventReader reader, final StartElement testCaseElement,
+            final String suiteName, final ModuleNode root)
+            throws XMLStreamException {
+        var builder = new TestCaseBuilder();
+
+        builder.withTestName(getOptionalValueOf(testCaseElement, NAME).orElse(createId()));
+        
+        var status = getValueOf(testCaseElement, RESULT);
+        if (status.equals(PASSED)) {
+            builder.withStatus(TestCase.TestResult.PASSED);
+        }
+        else if (status.equals(FAILED)) {
+            builder.withStatus(TestCase.TestResult.FAILED);
+        }
+        else if (status.equals(SKIPPED)) {
+            builder.withStatus(TestCase.TestResult.SKIPPED);
+        }
+        else {
+            builder.withStatus(TestCase.TestResult.SKIPPED);
+        }
+
+        while (reader.hasNext()) {
+            XMLEvent event = reader.nextEvent();
+
+            if (event.isStartElement() && isFailure(event)) {
+                readFailure(reader, builder);
+            }
+            else if (event.isEndElement() && TEST_CASE.equals(event.asEndElement().getName())) {
+                var className = getOptionalValueOf(testCaseElement, CLASS_NAME).orElse(suiteName);
+                builder.withClassName(className);
+                var packageNode = root.findOrCreatePackageNode(EMPTY);
+                var classNode = packageNode.findOrCreateClassNode(className);
+                classNode.addTestCase(builder.build());
+                break;
+            }
+        }
+        return builder.build();
+    }
+
+    private boolean isFailure(final XMLEvent event) {
+        QName name;
+        if (event.isStartElement()) {
+            name = event.asStartElement().getName();
+        }
+        else {
+            name = event.asEndElement().getName();
+        }
+
+        return FAILURE.equals(name);
+    }
+
+    private void readFailure(final XMLEventReader reader, final TestCaseBuilder builder)
+            throws XMLStreamException {
+        builder.withFailure();
+        var aggregatedContent = new StringBuilder();
+        while (true) {
+            XMLEvent event = reader.nextEvent();
+            if (event.isCharacters()) {
+                aggregatedContent.append(event.asCharacters().getData());
+            }
+            else if (event.isEndElement() && isFailure(event)) {
+                return;
+            }
+            else if (event.isEndElement() && event.asEndElement().getName().equals(MESSAGE)) {
+                builder.withDescription(aggregatedContent.toString());
+                return;
+            }
+        }
+    }
+
+    private String createId() {
+        return UUID.randomUUID().toString();
+    }
+}

--- a/src/main/java/edu/hm/hafner/coverage/registry/ParserRegistry.java
+++ b/src/main/java/edu/hm/hafner/coverage/registry/ParserRegistry.java
@@ -7,6 +7,7 @@ import edu.hm.hafner.coverage.CoverageParser.ProcessingMode;
 import edu.hm.hafner.coverage.parser.CoberturaParser;
 import edu.hm.hafner.coverage.parser.JacocoParser;
 import edu.hm.hafner.coverage.parser.JunitParser;
+import edu.hm.hafner.coverage.parser.NunitParser;
 import edu.hm.hafner.coverage.parser.OpenCoverParser;
 import edu.hm.hafner.coverage.parser.PitestParser;
 
@@ -19,6 +20,7 @@ public class ParserRegistry {
     /** Supported parsers. */
     public enum CoverageParserType {
         COBERTURA,
+        NUNIT,
         OPENCOVER,
         JACOCO,
         PIT,
@@ -60,6 +62,8 @@ public class ParserRegistry {
                 return new CoberturaParser(processingMode);
             case OPENCOVER:
                 return new OpenCoverParser();
+            case NUNIT:
+                return new NunitParser();
             case JACOCO:
                 return new JacocoParser();
             case PIT:

--- a/src/test/java/edu/hm/hafner/coverage/parser/NunitParserTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/parser/NunitParserTest.java
@@ -1,0 +1,115 @@
+package edu.hm.hafner.coverage.parser;
+
+import java.util.Collection;
+import java.util.NoSuchElementException;
+
+import org.junit.jupiter.api.Test;
+
+import edu.hm.hafner.coverage.ClassNode;
+import edu.hm.hafner.coverage.CoverageParser;
+import edu.hm.hafner.coverage.CoverageParser.ProcessingMode;
+import edu.hm.hafner.coverage.Metric;
+import edu.hm.hafner.coverage.ModuleNode;
+import edu.hm.hafner.coverage.Node;
+import edu.hm.hafner.coverage.PackageNode;
+import edu.hm.hafner.coverage.TestCase;
+import edu.hm.hafner.coverage.TestCase.TestResult;
+import edu.hm.hafner.coverage.TestCount;
+
+import static edu.hm.hafner.coverage.assertions.Assertions.*;
+
+class NunitParserTest extends AbstractParserTest {
+    private static final String EMPTY = "-";
+
+    @Override
+    CoverageParser createParser(final ProcessingMode processingMode) {
+        return new NunitParser(processingMode);
+    }
+
+    @Override
+    protected String getFolder() {
+        return "nunit";
+    }
+
+    @Test
+    void shouldReadReport() {
+        ModuleNode tree = readReport("nunit.xml");
+
+        assertThat(tree).hasName(EMPTY);
+        assertThat(getPackage(tree)).hasName("-");
+        assertThat(getFirstClass(tree)).hasName("Tests");
+        assertThat(getFirstTest(tree).getDescription()).contains("Expected string length 4 but was 5. Strings differ at index 4");
+
+        assertThat(tree.aggregateValues()).contains(new TestCount(4));
+    }
+
+    @Test
+    void shouldReadReportInV2Format() {
+        ModuleNode tree = readReport("nunit2-format.xml");
+
+        assertThat(tree).hasName(EMPTY);
+        assertThat(getPackage(tree)).hasName("-");
+        assertThat(getFirstClass(tree)).hasName("MockTestFixture");
+        assertThat(getFirstTest(tree).getDescription()).contains("Intentional failure");
+
+        assertThat(tree.aggregateValues()).contains(new TestCount(28));
+    }
+
+    @Test
+    void shouldReadReportWithoutErrorMessage() {
+        ModuleNode tree = readReport("nunit-no-message.xml");
+
+        assertThat(tree).hasName(EMPTY);
+        assertThat(getPackage(tree)).hasName("-");
+        assertThat(getFirstClass(tree)).hasName("Tests");
+        assertThat(getFirstTest(tree).getDescription()).contains("");
+        assertThat(tree.aggregateValues()).contains(new TestCount(4));
+    }
+
+    @Test
+    void shouldReadReportWithoutFailure() {
+        ModuleNode tree = readReport("nunit-no-failure-block.xml");
+
+        assertThat(tree).hasName(EMPTY);
+        assertThat(getPackage(tree)).hasName("-");
+        assertThat(getFirstClass(tree)).hasName("Tests");
+        assertThat(getFirstTest(tree).getDescription()).contains("");
+        assertThat(tree.aggregateValues()).contains(new TestCount(4));
+    }
+
+    @Test
+    void shouldReadReportWithInvalidStatus() {
+        ModuleNode tree = readReport("nunit-invalid-status.xml");
+
+        assertThat(tree).hasName(EMPTY);
+        assertThat(getPackage(tree)).hasName("-");
+        assertThat(getFirstClass(tree)).hasName("Tests");
+        assertThat(tree.aggregateValues()).contains(new TestCount(4));
+    }
+
+    private PackageNode getPackage(final Node node) {
+        var children = node.getChildren();
+        assertThat(children).hasSize(1).first().isInstanceOf(PackageNode.class);
+
+        return (PackageNode) children.get(0);
+    }
+
+    private ClassNode getFirstClass(final Node node) {
+        var packageNode = getPackage(node);
+
+        var children = packageNode.getChildren();
+        assertThat(children).isNotEmpty().first().isInstanceOf(ClassNode.class);
+
+        return (ClassNode) children.get(0);
+    }
+
+    private TestCase getFirstTest(final Node node) {
+        return node.getAll(Metric.CLASS).stream()
+                .map(ClassNode.class::cast)
+                .map(ClassNode::getTestCases)
+                .flatMap(Collection::stream)
+                .filter(test -> test.getResult() == TestResult.FAILED)
+                .findFirst()
+                .orElseThrow(() -> new NoSuchElementException("No failed test found"));
+    }
+}

--- a/src/test/java/edu/hm/hafner/coverage/registry/ParserRegistryTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/registry/ParserRegistryTest.java
@@ -6,6 +6,7 @@ import edu.hm.hafner.coverage.CoverageParser.ProcessingMode;
 import edu.hm.hafner.coverage.parser.CoberturaParser;
 import edu.hm.hafner.coverage.parser.JacocoParser;
 import edu.hm.hafner.coverage.parser.JunitParser;
+import edu.hm.hafner.coverage.parser.NunitParser;
 import edu.hm.hafner.coverage.parser.PitestParser;
 import edu.hm.hafner.coverage.parser.OpenCoverParser;
 import edu.hm.hafner.coverage.registry.ParserRegistry.CoverageParserType;
@@ -26,6 +27,7 @@ class ParserRegistryTest {
         assertThat(registry.get(CoverageParserType.JUNIT, ProcessingMode.IGNORE_ERRORS))
                 .isInstanceOf(JunitParser.class);
         assertThat(registry.get(CoverageParserType.OPENCOVER, ProcessingMode.IGNORE_ERRORS)).isInstanceOf(OpenCoverParser.class);
+        assertThat(registry.get(CoverageParserType.NUNIT, ProcessingMode.IGNORE_ERRORS)).isInstanceOf(NunitParser.class);
     }
 
     @Test

--- a/src/test/resources/edu/hm/hafner/coverage/parser/nunit/empty.xml
+++ b/src/test/resources/edu/hm/hafner/coverage/parser/nunit/empty.xml
@@ -1,0 +1,2 @@
+<test-run id="1" duration="0.0" testcasecount="0" total="0" passed="0" failed="0" inconclusive="0" skipped="0" result="Passed" start-time="2024-01-23T 12:33:37Z" end-time="2024-01-23T 12:33:37Z">
+</test-run>

--- a/src/test/resources/edu/hm/hafner/coverage/parser/nunit/nunit-invalid-status.xml
+++ b/src/test/resources/edu/hm/hafner/coverage/parser/nunit/nunit-invalid-status.xml
@@ -1,0 +1,29 @@
+<test-run id="2" duration="0.46225700000000003" testcasecount="4" total="4" passed="2" failed="1" inconclusive="0" skipped="1" result="Failed" start-time="2024-01-23T 12:33:37Z" end-time="2024-01-23T 12:33:47Z">
+    <test-suite type="Assembly" name="test.dll" fullname="/home/jenkins/bin/Debug/net8.0/test.dll" total="4" passed="2" failed="1" inconclusive="0" skipped="1" result="Failed" start-time="2024-01-23T 12:33:46Z" end-time="2024-01-23T 12:33:47Z" duration="0.462257">
+      <test-suite type="TestSuite" name="test" fullname="test" total="4" passed="2" failed="1" inconclusive="0" skipped="1" result="Failed" start-time="2024-01-23T 12:33:46Z" end-time="2024-01-23T 12:33:47Z" duration="0.462257">
+        <test-suite type="TestFixture" name="Tests" fullname="test.Tests" classname="test.Tests" total="4" passed="2" failed="1" inconclusive="0" skipped="1" result="Failed" start-time="2024-01-23T 12:33:46Z" end-time="2024-01-23T 12:33:47Z" duration="0.462257">
+          <test-case name="FailedTEst" fullname="test.Tests.FailedTEst" methodname="FailedTEst" classname="Tests" result="Failed" start-time="2024-01-23T 12:33:46Z" end-time="2024-01-23T 12:33:46Z" duration="0.057283" asserts="0" seed="1556857297">
+            <failure>
+              <message>  Expected string length 4 but was 5. Strings differ at index 4.
+    Expected: "Test"
+    But was:  "Test1"
+    ---------------^
+  </message>
+              <stack-trace>   at test.Tests.FailedTEst() in /home/jenkins/Tests.cs:line 50
+  
+  1)    at test.Tests.FailedTEst() in /home/jenkins/Tests.cs:line 50
+  
+  </stack-trace>
+            </failure>
+          </test-case>
+          <test-case name="IgnoredTest" fullname="test.Tests.IgnoredTest" methodname="IgnoredTest" classname="Tests" result="Invalid" start-time="2024-01-23T 12:33:46Z" end-time="2024-01-23T 12:33:46Z" duration="0.000378" asserts="0" seed="1438305193">
+            <output><![CDATA[Skipping this test
+  ]]></output>
+          </test-case>
+          <test-case name="ShouldConnectToDatabase" fullname="test.Tests.ShouldConnectToDatabase" methodname="ShouldConnectToDatabase" classname="Tests" result="Invalid" start-time="2024-01-23T 12:33:46Z" end-time="2024-01-23T 12:33:47Z" duration="0.404245" asserts="0" seed="802014458" />
+          <test-case name="ShouldCreateItem" fullname="test.Tests.ShouldCreateItem" methodname="ShouldCreateItem" classname="Tests" result="Passed" start-time="2024-01-23T 12:33:47Z" end-time="2024-01-23T 12:33:47Z" duration="0.000351" asserts="0" seed="606875445" />
+        </test-suite>
+      </test-suite>
+      <errors />
+    </test-suite>
+  </test-run>

--- a/src/test/resources/edu/hm/hafner/coverage/parser/nunit/nunit-no-failure-block.xml
+++ b/src/test/resources/edu/hm/hafner/coverage/parser/nunit/nunit-no-failure-block.xml
@@ -1,0 +1,16 @@
+<test-run id="2" duration="0.46225700000000003" testcasecount="4" total="4" passed="2" failed="1" inconclusive="0" skipped="1" result="Failed" start-time="2024-01-23T 12:33:37Z" end-time="2024-01-23T 12:33:47Z">
+    <test-suite type="Assembly" name="test.dll" fullname="/home/jenkins/bin/Debug/net8.0/test.dll" total="4" passed="2" failed="1" inconclusive="0" skipped="1" result="Failed" start-time="2024-01-23T 12:33:46Z" end-time="2024-01-23T 12:33:47Z" duration="0.462257">
+      <test-suite type="TestSuite" name="test" fullname="test" total="4" passed="2" failed="1" inconclusive="0" skipped="1" result="Failed" start-time="2024-01-23T 12:33:46Z" end-time="2024-01-23T 12:33:47Z" duration="0.462257">
+        <test-suite type="TestFixture" name="Tests" fullname="test.Tests" classname="test.Tests" total="4" passed="2" failed="1" inconclusive="0" skipped="1" result="Failed" start-time="2024-01-23T 12:33:46Z" end-time="2024-01-23T 12:33:47Z" duration="0.462257">
+          <test-case name="FailedTEst" fullname="test.Tests.FailedTEst" methodname="FailedTEst" classname="Tests" result="Failed" start-time="2024-01-23T 12:33:46Z" end-time="2024-01-23T 12:33:46Z" duration="0.057283" asserts="0" seed="1556857297" />
+          <test-case name="IgnoredTest" fullname="test.Tests.IgnoredTest" methodname="IgnoredTest" classname="Tests" result="Skipped" start-time="2024-01-23T 12:33:46Z" end-time="2024-01-23T 12:33:46Z" duration="0.000378" asserts="0" seed="1438305193">
+            <output><![CDATA[Skipping this test
+  ]]></output>
+          </test-case>
+          <test-case name="ShouldConnectToDatabase" fullname="test.Tests.ShouldConnectToDatabase" methodname="ShouldConnectToDatabase" classname="Tests" result="Passed" start-time="2024-01-23T 12:33:46Z" end-time="2024-01-23T 12:33:47Z" duration="0.404245" asserts="0" seed="802014458" />
+          <test-case name="ShouldCreateItem" fullname="test.Tests.ShouldCreateItem" methodname="ShouldCreateItem" classname="Tests" result="Passed" start-time="2024-01-23T 12:33:47Z" end-time="2024-01-23T 12:33:47Z" duration="0.000351" asserts="0" seed="606875445" />
+        </test-suite>
+      </test-suite>
+      <errors />
+    </test-suite>
+  </test-run>

--- a/src/test/resources/edu/hm/hafner/coverage/parser/nunit/nunit-no-message.xml
+++ b/src/test/resources/edu/hm/hafner/coverage/parser/nunit/nunit-no-message.xml
@@ -1,0 +1,18 @@
+<test-run id="2" duration="0.46225700000000003" testcasecount="4" total="4" passed="2" failed="1" inconclusive="0" skipped="1" result="Failed" start-time="2024-01-23T 12:33:37Z" end-time="2024-01-23T 12:33:47Z">
+    <test-suite type="Assembly" name="test.dll" fullname="/home/jenkins/bin/Debug/net8.0/test.dll" total="4" passed="2" failed="1" inconclusive="0" skipped="1" result="Failed" start-time="2024-01-23T 12:33:46Z" end-time="2024-01-23T 12:33:47Z" duration="0.462257">
+      <test-suite type="TestSuite" name="test" fullname="test" total="4" passed="2" failed="1" inconclusive="0" skipped="1" result="Failed" start-time="2024-01-23T 12:33:46Z" end-time="2024-01-23T 12:33:47Z" duration="0.462257">
+        <test-suite type="TestFixture" name="Tests" fullname="test.Tests" classname="test.Tests" total="4" passed="2" failed="1" inconclusive="0" skipped="1" result="Failed" start-time="2024-01-23T 12:33:46Z" end-time="2024-01-23T 12:33:47Z" duration="0.462257">
+          <test-case name="FailedTEst" fullname="test.Tests.FailedTEst" methodname="FailedTEst" classname="Tests" result="Failed" start-time="2024-01-23T 12:33:46Z" end-time="2024-01-23T 12:33:46Z" duration="0.057283" asserts="0" seed="1556857297">
+            <failure />
+          </test-case>
+          <test-case name="IgnoredTest" fullname="test.Tests.IgnoredTest" methodname="IgnoredTest" classname="Tests" result="Skipped" start-time="2024-01-23T 12:33:46Z" end-time="2024-01-23T 12:33:46Z" duration="0.000378" asserts="0" seed="1438305193">
+            <output><![CDATA[Skipping this test
+  ]]></output>
+          </test-case>
+          <test-case name="ShouldConnectToDatabase" fullname="test.Tests.ShouldConnectToDatabase" methodname="ShouldConnectToDatabase" classname="Tests" result="Passed" start-time="2024-01-23T 12:33:46Z" end-time="2024-01-23T 12:33:47Z" duration="0.404245" asserts="0" seed="802014458" />
+          <test-case name="ShouldCreateItem" fullname="test.Tests.ShouldCreateItem" methodname="ShouldCreateItem" classname="Tests" result="Passed" start-time="2024-01-23T 12:33:47Z" end-time="2024-01-23T 12:33:47Z" duration="0.000351" asserts="0" seed="606875445" />
+        </test-suite>
+      </test-suite>
+      <errors />
+    </test-suite>
+  </test-run>

--- a/src/test/resources/edu/hm/hafner/coverage/parser/nunit/nunit.xml
+++ b/src/test/resources/edu/hm/hafner/coverage/parser/nunit/nunit.xml
@@ -1,0 +1,29 @@
+<test-run id="2" duration="0.46225700000000003" testcasecount="4" total="4" passed="2" failed="1" inconclusive="0" skipped="1" result="Failed" start-time="2024-01-23T 12:33:37Z" end-time="2024-01-23T 12:33:47Z">
+    <test-suite type="Assembly" name="test.dll" fullname="/home/jenkins/bin/Debug/net8.0/test.dll" total="4" passed="2" failed="1" inconclusive="0" skipped="1" result="Failed" start-time="2024-01-23T 12:33:46Z" end-time="2024-01-23T 12:33:47Z" duration="0.462257">
+      <test-suite type="TestSuite" name="test" fullname="test" total="4" passed="2" failed="1" inconclusive="0" skipped="1" result="Failed" start-time="2024-01-23T 12:33:46Z" end-time="2024-01-23T 12:33:47Z" duration="0.462257">
+        <test-suite type="TestFixture" name="Tests" fullname="test.Tests" classname="test.Tests" total="4" passed="2" failed="1" inconclusive="0" skipped="1" result="Failed" start-time="2024-01-23T 12:33:46Z" end-time="2024-01-23T 12:33:47Z" duration="0.462257">
+          <test-case name="FailedTEst" fullname="test.Tests.FailedTEst" methodname="FailedTEst" classname="Tests" result="Failed" start-time="2024-01-23T 12:33:46Z" end-time="2024-01-23T 12:33:46Z" duration="0.057283" asserts="0" seed="1556857297">
+            <failure>
+              <message>  Expected string length 4 but was 5. Strings differ at index 4.
+    Expected: "Test"
+    But was:  "Test1"
+    ---------------^
+  </message>
+              <stack-trace>   at test.Tests.FailedTEst() in /home/jenkins/Tests.cs:line 50
+  
+  1)    at test.Tests.FailedTEst() in /home/jenkins/Tests.cs:line 50
+  
+  </stack-trace>
+            </failure>
+          </test-case>
+          <test-case name="IgnoredTest" fullname="test.Tests.IgnoredTest" methodname="IgnoredTest" classname="Tests" result="Skipped" start-time="2024-01-23T 12:33:46Z" end-time="2024-01-23T 12:33:46Z" duration="0.000378" asserts="0" seed="1438305193">
+            <output><![CDATA[Skipping this test
+  ]]></output>
+          </test-case>
+          <test-case name="ShouldConnectToDatabase" fullname="test.Tests.ShouldConnectToDatabase" methodname="ShouldConnectToDatabase" classname="Tests" result="Passed" start-time="2024-01-23T 12:33:46Z" end-time="2024-01-23T 12:33:47Z" duration="0.404245" asserts="0" seed="802014458" />
+          <test-case name="ShouldCreateItem" fullname="test.Tests.ShouldCreateItem" methodname="ShouldCreateItem" classname="Tests" result="Passed" start-time="2024-01-23T 12:33:47Z" end-time="2024-01-23T 12:33:47Z" duration="0.000351" asserts="0" seed="606875445" />
+        </test-suite>
+      </test-suite>
+      <errors />
+    </test-suite>
+  </test-run>

--- a/src/test/resources/edu/hm/hafner/coverage/parser/nunit/nunit2-format.xml
+++ b/src/test/resources/edu/hm/hafner/coverage/parser/nunit/nunit2-format.xml
@@ -1,0 +1,190 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!--This file represents the results of running a test suite-->
+<test-results name="/home/charlie/Dev/NUnit/nunit-2.5/work/src/bin/Debug/tests/mock-assembly.dll" total="21" errors="1" failures="1" not-run="7" inconclusive="1" ignored="4" skipped="0" invalid="3" date="2010-10-18" time="13:23:35">
+  <environment nunit-version="2.5.8.0" clr-version="2.0.50727.1433" os-version="Unix 2.6.32.25" platform="Unix" cwd="/home/charlie/Dev/NUnit/nunit-2.5/work/src/bin/Debug" machine-name="cedar" user="charlie" user-domain="cedar" />
+  <culture-info current-culture="en-US" current-uiculture="en-US" />
+  <test-suite type="Assembly" name="/home/charlie/Dev/NUnit/nunit-2.5/work/src/bin/Debug/tests/mock-assembly.dll" executed="True" result="Failure" success="False" time="0.824" asserts="0">
+    <results>
+      <test-suite type="Namespace" name="NUnit" executed="True" result="Failure" success="False" time="0.807" asserts="0">
+        <results>
+          <test-suite type="Namespace" name="Tests" executed="True" result="Failure" success="False" time="0.803" asserts="0">
+            <results>
+              <test-suite type="Namespace" name="Assemblies" executed="True" result="Failure" success="False" time="0.606" asserts="0">
+                <results>
+                  <test-suite type="TestFixture" name="MockTestFixture" description="Fake Test Fixture" executed="True" result="Failure" success="False" time="0.582" asserts="0">
+                    <categories>
+                      <category name="FixtureCategory" />
+                    </categories>
+                    <results>
+                      <test-case name="NUnit.Tests.Assemblies.MockTestFixture.FailingTest" executed="True" result="Failure" success="False" time="0.013" asserts="0">
+                        <failure>
+                          <message><![CDATA[Intentional failure]]></message>
+                          <stack-trace><![CDATA[at NUnit.Tests.Assemblies.MockTestFixture.FailingTest () [0x00000] in /home/charlie/Dev/NUnit/nunit-2.5/work/src/tests/mock-assembly/MockAssembly.cs:121
+]]></stack-trace>
+                        </failure>
+                      </test-case>
+                      <test-case name="NUnit.Tests.Assemblies.MockTestFixture.InconclusiveTest" executed="True" result="Inconclusive" success="False" time="0.001" asserts="0">
+                        <reason>
+                          <message><![CDATA[No valid data]]></message>
+                        </reason>
+                      </test-case>
+                      <test-case name="NUnit.Tests.Assemblies.MockTestFixture.MockTest1" description="Mock Test #1" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                      <test-case name="NUnit.Tests.Assemblies.MockTestFixture.MockTest2" description="This is a really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really long description" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                        <categories>
+                          <category name="MockCategory" />
+                        </categories>
+                        <properties>
+                          <property name="Severity" value="Critical" />
+                        </properties>
+                      </test-case>
+                      <test-case name="NUnit.Tests.Assemblies.MockTestFixture.MockTest3" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <categories>
+                          <category name="AnotherCategory" />
+                          <category name="MockCategory" />
+                        </categories>
+                        <reason>
+                          <message><![CDATA[Succeeded!]]></message>
+                        </reason>
+                      </test-case>
+                      <test-case name="NUnit.Tests.Assemblies.MockTestFixture.MockTest4" executed="False" result="Ignored">
+                        <categories>
+                          <category name="Foo" />
+                        </categories>
+                        <reason>
+                          <message><![CDATA[ignoring this test method for now]]></message>
+                        </reason>
+                      </test-case>
+                      <test-case name="NUnit.Tests.Assemblies.MockTestFixture.MockTest5" executed="False" result="NotRunnable">
+                        <reason>
+                          <message><![CDATA[Method is not public]]></message>
+                        </reason>
+                      </test-case>
+                      <test-case name="NUnit.Tests.Assemblies.MockTestFixture.NotRunnableTest" executed="False" result="NotRunnable">
+                        <reason>
+                          <message><![CDATA[No arguments were provided]]></message>
+                        </reason>
+                      </test-case>
+                      <test-case name="NUnit.Tests.Assemblies.MockTestFixture.TestWithException" executed="True" result="Error" success="False" time="0.001" asserts="0">
+                        <failure>
+                          <message><![CDATA[System.ApplicationException : Intentional Exception]]></message>
+                          <stack-trace><![CDATA[at NUnit.Tests.Assemblies.MockTestFixture.TestWithException () [0x00000] in /home/charlie/Dev/NUnit/nunit-2.5/work/src/tests/mock-assembly/MockAssembly.cs:153
+]]></stack-trace>
+                        </failure>
+                      </test-case>
+                      <test-case name="NUnit.Tests.Assemblies.MockTestFixture.TestWithManyProperties" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                        <properties>
+                          <property name="Size" value="5" />
+                          <property name="TargetMethod" value="SomeClassName" />
+                        </properties>
+                      </test-case>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+              <test-suite type="TestFixture" name="BadFixture" executed="False" result="NotRunnable">
+                <reason>
+                  <message><![CDATA[No suitable constructor was found]]></message>
+                </reason>
+                <results>
+                  <test-case name="NUnit.Tests.BadFixture.SomeTest" executed="False" result="NotRunnable">
+                    <reason>
+                      <message><![CDATA[No suitable constructor was found]]></message>
+                    </reason>
+                  </test-case>
+                </results>
+              </test-suite>
+              <test-suite type="TestFixture" name="FixtureWithTestCases" executed="True" result="Success" success="True" time="0.043" asserts="0">
+                <results>
+                  <test-suite type="ParameterizedTest" name="GenericMethod" executed="True" result="Success" success="True" time="0.013" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Tests.FixtureWithTestCases.GenericMethod&lt;Double&gt;(9.2d,11.7d)" executed="True" result="Success" success="True" time="0.007" asserts="1" />
+                      <test-case name="NUnit.Tests.FixtureWithTestCases.GenericMethod&lt;Int32&gt;(2,4)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="ParameterizedTest" name="MethodWithParameters" executed="True" result="Success" success="True" time="0.011" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Tests.FixtureWithTestCases.MethodWithParameters(9,11)" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                      <test-case name="NUnit.Tests.FixtureWithTestCases.MethodWithParameters(2,2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+              <test-suite type="GenericFixture" name="GenericFixture&lt;T&gt;" executed="True" result="Success" success="True" time="0.012" asserts="0">
+                <results>
+                  <test-suite type="TestFixture" name="GenericFixture&lt;Double&gt;(11.5d)" executed="True" result="Success" success="True" time="0.011" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Tests.GenericFixture&lt;Double&gt;(11.5d).Test1" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                      <test-case name="NUnit.Tests.GenericFixture&lt;Double&gt;(11.5d).Test2" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="GenericFixture&lt;Int32&gt;(5)" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Tests.GenericFixture&lt;Int32&gt;(5).Test1" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                      <test-case name="NUnit.Tests.GenericFixture&lt;Int32&gt;(5).Test2" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+              <test-suite type="TestFixture" name="IgnoredFixture" executed="False" result="Ignored">
+                <reason>
+                  <message><![CDATA[]]></message>
+                </reason>
+                <results>
+                  <test-case name="NUnit.Tests.IgnoredFixture.Test1" executed="False" result="Ignored">
+                    <reason>
+                      <message><![CDATA[]]></message>
+                    </reason>
+                  </test-case>
+                  <test-case name="NUnit.Tests.IgnoredFixture.Test2" executed="False" result="Ignored">
+                    <reason>
+                      <message><![CDATA[]]></message>
+                    </reason>
+                  </test-case>
+                  <test-case name="NUnit.Tests.IgnoredFixture.Test3" executed="False" result="Ignored">
+                    <reason>
+                      <message><![CDATA[]]></message>
+                    </reason>
+                  </test-case>
+                </results>
+              </test-suite>
+              <test-suite type="ParameterizedFixture" name="ParameterizedFixture" executed="True" result="Success" success="True" time="0.069" asserts="0">
+                <results>
+                  <test-suite type="TestFixture" name="ParameterizedFixture(42)" executed="True" result="Success" success="True" time="0.048" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Tests.ParameterizedFixture(42).Test1" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                      <test-case name="NUnit.Tests.ParameterizedFixture(42).Test2" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="ParameterizedFixture(5)" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Tests.ParameterizedFixture(5).Test1" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                      <test-case name="NUnit.Tests.ParameterizedFixture(5).Test2" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+              <test-suite type="Namespace" name="Singletons" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                <results>
+                  <test-suite type="TestFixture" name="OneTestCase" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Tests.Singletons.OneTestCase.TestCase" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+              <test-suite type="Namespace" name="TestAssembly" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                <results>
+                  <test-suite type="TestFixture" name="MockTestFixture" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Tests.TestAssembly.MockTestFixture.MyTest" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+    </results>
+  </test-suite>
+</test-results>


### PR DESCRIPTION
Add test count metric for NUnit which is a famous test runner for .NET project (Similar to JUnit).

The XML format is somehow similar but different (different tag, attributes, or errors message stored deeper on the XML structure

It's possible there is duplicate between the JUnit and NUnit parser. We could perhaps move some utils to the parent class

### Testing done

- 100% test coverage

![coverage_nunit](https://github.com/jenkinsci/coverage-model/assets/825750/8e711751-4227-48eb-8413-4006bb880cce)


- Support of NUnit 2 and NUnit 3 format (https://docs.nunit.org/articles/nunit/technical-notes/usage/Test-Result-XML-Format.html)

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
