### PR TITLE
Add support for XUnit .NET format

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,5 +31,6 @@ This library consists basically of two separate parts:
     * [PIT](https://pitest.org/) Mutation coverage results
     * [JUnit](https://junit.org/junit5/) test results
     * [NUnit](https://nunit.org) test results
+    * [XUnit](https://xunit.net) test results
 
 All source code is licensed under the MIT license. Contributions to this library are welcome! 

--- a/src/main/java/edu/hm/hafner/coverage/parser/XunitParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/parser/XunitParser.java
@@ -1,0 +1,115 @@
+package edu.hm.hafner.coverage.parser;
+
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLEventReader;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.events.StartElement;
+import javax.xml.stream.events.XMLEvent;
+
+import edu.hm.hafner.coverage.ModuleNode;
+import edu.hm.hafner.coverage.TestCase;
+import edu.hm.hafner.coverage.TestCase.TestCaseBuilder;
+
+/**
+ * Parses reports in the
+ * <a href="https://xunit.net/docs/format-xml-v2">XUnit format</a>
+ * into a Java object model.
+ *
+ * @author Valentin Delaye
+ */
+@SuppressWarnings("checkstyle:ClassDataAbstractionCoupling")
+public class XunitParser extends AbstractTestParser {
+    private static final long serialVersionUID = -5468593789018138107L;
+
+    private static final QName COLLECTION = new QName("collection");
+    private static final QName TEST = new QName("test");
+    private static final QName RESULT = new QName("result");
+    private static final QName TYPE = new QName("type");
+    private static final String PASS = "Pass";
+    private static final String FAIL = "Fail";
+    private static final String SKIP = "Skip";
+
+    /**
+     * Creates a new instance of {@link XunitParser}.
+     */
+    public XunitParser() {
+        this(ProcessingMode.FAIL_FAST);
+    }
+
+    /**
+     * Creates a new instance of {@link XunitParser}.
+     *
+     * @param processingMode
+     *         determines whether to ignore errors
+     */
+    public XunitParser(final ProcessingMode processingMode) {
+        super(processingMode, COLLECTION, TEST);
+    }
+
+    @Override
+    TestCase readTestCase(final XMLEventReader reader, final StartElement testCaseElement,
+            final String suiteName, final ModuleNode root) throws XMLStreamException {
+        var builder = new TestCaseBuilder();
+
+        builder.withTestName(getOptionalValueOf(testCaseElement, NAME).orElse(createId()));
+
+        readStatus(testCaseElement, builder);
+
+        while (reader.hasNext()) {
+            XMLEvent event = reader.nextEvent();
+
+            if (event.isStartElement() && isFailure(event)) {
+                readFailure(reader, builder);
+            }
+            else if (event.isEndElement() && TEST.equals(event.asEndElement().getName())) {
+                var className = getOptionalValueOf(testCaseElement, TYPE).orElse(suiteName);
+                builder.withClassName(className);
+                var packageNode = root.findOrCreatePackageNode(EMPTY);
+                var classNode = packageNode.findOrCreateClassNode(className);
+                classNode.addTestCase(builder.build());
+                return builder.build();
+            }
+        }
+        throw createEofException();
+    }
+
+    private void readStatus(final StartElement testCaseElement, final TestCaseBuilder builder) {
+        var status = getValueOf(testCaseElement, RESULT);
+        switch (status) {
+            case PASS:
+                builder.withStatus(TestCase.TestResult.PASSED);
+                break;
+            case FAIL:
+                builder.withStatus(TestCase.TestResult.FAILED);
+                break;
+            case SKIP:
+            default:
+                builder.withStatus(TestCase.TestResult.SKIPPED);
+                break;
+        }
+    }
+
+    private boolean isFailure(final XMLEvent event) {
+        return FAILURE.equals(getElementName(event));
+    }
+
+    private void readFailure(final XMLEventReader reader, final TestCaseBuilder builder)
+            throws XMLStreamException {
+        builder.withFailure();
+
+        var aggregatedContent = new StringBuilder();
+        while (true) {
+            XMLEvent event = reader.nextEvent();
+            if (event.isCharacters()) {
+                aggregatedContent.append(event.asCharacters().getData());
+            }
+            else if (event.isEndElement() && isFailure(event)) {
+                return;
+            }
+            else if (event.isEndElement() && event.asEndElement().getName().equals(MESSAGE)) {
+                builder.withDescription(aggregatedContent.toString());
+                return;
+            }
+        }
+    }
+}

--- a/src/main/java/edu/hm/hafner/coverage/registry/ParserRegistry.java
+++ b/src/main/java/edu/hm/hafner/coverage/registry/ParserRegistry.java
@@ -10,6 +10,7 @@ import edu.hm.hafner.coverage.parser.JunitParser;
 import edu.hm.hafner.coverage.parser.NunitParser;
 import edu.hm.hafner.coverage.parser.OpenCoverParser;
 import edu.hm.hafner.coverage.parser.PitestParser;
+import edu.hm.hafner.coverage.parser.XunitParser;
 
 /**
  * Provides a registry for all available {@link CoverageParserType parsers}.
@@ -24,7 +25,8 @@ public class ParserRegistry {
         OPENCOVER,
         JACOCO,
         PIT,
-        JUNIT
+        JUNIT,
+        XUNIT
     }
 
     /**
@@ -70,6 +72,8 @@ public class ParserRegistry {
                 return new PitestParser(processingMode);
             case JUNIT:
                 return new JunitParser(processingMode);
+            case XUNIT:
+                return new XunitParser(processingMode);
         }
         throw new IllegalArgumentException("Unknown parser type: " + parser);
     }

--- a/src/test/java/edu/hm/hafner/coverage/parser/XunitParserTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/parser/XunitParserTest.java
@@ -1,0 +1,103 @@
+package edu.hm.hafner.coverage.parser;
+
+import java.util.Collection;
+import java.util.NoSuchElementException;
+
+import org.junit.jupiter.api.Test;
+
+import edu.hm.hafner.coverage.ClassNode;
+import edu.hm.hafner.coverage.CoverageParser;
+import edu.hm.hafner.coverage.CoverageParser.ProcessingMode;
+import edu.hm.hafner.coverage.Metric;
+import edu.hm.hafner.coverage.ModuleNode;
+import edu.hm.hafner.coverage.Node;
+import edu.hm.hafner.coverage.PackageNode;
+import edu.hm.hafner.coverage.TestCase;
+import edu.hm.hafner.coverage.TestCase.TestResult;
+import edu.hm.hafner.coverage.TestCount;
+
+import static edu.hm.hafner.coverage.assertions.Assertions.*;
+
+class XunitParserTest extends AbstractParserTest {
+    private static final String EMPTY = "-";
+
+    @Override
+    CoverageParser createParser(final ProcessingMode processingMode) {
+        return new XunitParser(processingMode);
+    }
+
+    @Override
+    protected String getFolder() {
+        return "xunit";
+    }
+
+    @Test
+    void shouldReadReport() {
+        ModuleNode tree = readReport("xunit.xml");
+
+        assertThat(tree).hasName(EMPTY);
+        assertThat(getPackage(tree)).hasName("-");
+        assertThat(getFirstClass(tree)).hasName("test.Tests2");
+        assertThat(getFirstTest(tree).getDescription()).contains("Assert.Equal() Failure");
+
+        assertThat(tree.aggregateValues()).contains(new TestCount(3));
+    }
+
+    @Test
+    void shouldReadReportWithoutFailure() {
+        ModuleNode tree = readReport("xunit-no-failure-block.xml");
+
+        assertThat(tree).hasName(EMPTY);
+        assertThat(getPackage(tree)).hasName("-");
+        assertThat(getFirstClass(tree)).hasName("test.Tests2");
+        assertThat(getFirstTest(tree).getDescription()).contains("");
+        assertThat(tree.aggregateValues()).contains(new TestCount(3));
+    }
+
+    @Test
+    void shouldReadReportWithInvalidStatus() {
+        ModuleNode tree = readReport("xunit-invalid-status.xml");
+
+        assertThat(tree).hasName(EMPTY);
+        assertThat(getPackage(tree)).hasName("-");
+        assertThat(getFirstClass(tree)).hasName("test.Tests2");
+        assertThat(tree.aggregateValues()).contains(new TestCount(3));
+    }
+
+    @Test
+    void shouldReadReportWithoutErrorMessage() {
+        ModuleNode tree = readReport("xunit-no-message.xml");
+
+        assertThat(tree).hasName(EMPTY);
+        assertThat(getPackage(tree)).hasName("-");
+        assertThat(getFirstClass(tree)).hasName("test.Tests2");
+        assertThat(getFirstTest(tree).getDescription()).contains("");
+        assertThat(tree.aggregateValues()).contains(new TestCount(3));
+    }
+
+    private PackageNode getPackage(final Node node) {
+        var children = node.getChildren();
+        assertThat(children).hasSize(1).first().isInstanceOf(PackageNode.class);
+
+        return (PackageNode) children.get(0);
+    }
+
+    private ClassNode getFirstClass(final Node node) {
+        var packageNode = getPackage(node);
+
+        var children = packageNode.getChildren();
+        assertThat(children).isNotEmpty().first().isInstanceOf(ClassNode.class);
+
+        return (ClassNode) children.get(0);
+    }
+
+    private TestCase getFirstTest(final Node node) {
+        return node.getAll(Metric.CLASS).stream()
+                .map(ClassNode.class::cast)
+                .map(ClassNode::getTestCases)
+                .flatMap(Collection::stream)
+                .filter(test -> test.getResult() == TestResult.FAILED)
+                .findFirst()
+                .orElseThrow(() -> new NoSuchElementException("No failed test found"));
+    }
+}

--- a/src/test/java/edu/hm/hafner/coverage/registry/ParserRegistryTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/registry/ParserRegistryTest.java
@@ -8,6 +8,7 @@ import edu.hm.hafner.coverage.parser.JacocoParser;
 import edu.hm.hafner.coverage.parser.JunitParser;
 import edu.hm.hafner.coverage.parser.NunitParser;
 import edu.hm.hafner.coverage.parser.PitestParser;
+import edu.hm.hafner.coverage.parser.XunitParser;
 import edu.hm.hafner.coverage.parser.OpenCoverParser;
 import edu.hm.hafner.coverage.registry.ParserRegistry.CoverageParserType;
 
@@ -28,6 +29,7 @@ class ParserRegistryTest {
                 .isInstanceOf(JunitParser.class);
         assertThat(registry.get(CoverageParserType.OPENCOVER, ProcessingMode.IGNORE_ERRORS)).isInstanceOf(OpenCoverParser.class);
         assertThat(registry.get(CoverageParserType.NUNIT, ProcessingMode.IGNORE_ERRORS)).isInstanceOf(NunitParser.class);
+        assertThat(registry.get(CoverageParserType.XUNIT, ProcessingMode.IGNORE_ERRORS)).isInstanceOf(XunitParser.class);
     }
 
     @Test

--- a/src/test/resources/edu/hm/hafner/coverage/parser/xunit/empty.xml
+++ b/src/test/resources/edu/hm/hafner/coverage/parser/xunit/empty.xml
@@ -1,0 +1,1 @@
+<assembly name="test.dll" run-date="2024-01-23" run-time="12:33:37" total="0" passed="0" failed="0" skipped="0" />

--- a/src/test/resources/edu/hm/hafner/coverage/parser/xunit/xunit-invalid-status.xml
+++ b/src/test/resources/edu/hm/hafner/coverage/parser/xunit/xunit-invalid-status.xml
@@ -1,0 +1,29 @@
+<assemblies timestamp="01/26/2024 13:49:51">
+    <assembly name="/home/jenkins/test2/bin/Debug/net8.0/test2.dll" run-date="2024-01-26" run-time="13:49:51" total="3" passed="1" failed="1" skipped="1" time="1.100" errors="0">
+      <errors />
+      <collection total="3" passed="1" failed="1" skipped="1" name="Test collection for test.Tests2" time="0.005">
+        <test name="test.Tests2.ShouldCreateItem" type="test.Tests2" method="ShouldCreateItem" time="0.0026206" result="invalid">
+          <traits />
+        </test>
+        <test name="test.Tests2.ShouldCreateItem3" type="test.Tests2" method="ShouldCreateItem3" time="0.0010000" result="invalid">
+          <reason><![CDATA[specific reason]]></reason>
+          <output>specific reason
+  </output>
+          <traits />
+        </test>
+        <test name="test.Tests2.ShouldCreateItem2" type="test.Tests2" method="ShouldCreateItem2" time="0.0010159" result="invalid">
+          <failure>
+            <message>Assert.Equal() Failure
+                ↓ (pos 4)
+  Expected: Test3
+  Actual:   Test
+                ↑ (pos 4)</message>
+            <stack-trace>   at test.Tests2.ShouldCreateItem2() in /home/jenkins/test2/Tests2.cs:line 36
+     at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
+     at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)</stack-trace>
+          </failure>
+          <traits />
+        </test>
+      </collection>
+    </assembly>
+  </assemblies>

--- a/src/test/resources/edu/hm/hafner/coverage/parser/xunit/xunit-no-failure-block.xml
+++ b/src/test/resources/edu/hm/hafner/coverage/parser/xunit/xunit-no-failure-block.xml
@@ -1,0 +1,19 @@
+<assemblies timestamp="01/26/2024 13:49:51">
+    <assembly name="/home/jenkins/test2/bin/Debug/net8.0/test2.dll" run-date="2024-01-26" run-time="13:49:51" total="3" passed="1" failed="1" skipped="1" time="1.100" errors="0">
+      <errors />
+      <collection total="3" passed="1" failed="1" skipped="1" name="Test collection for test.Tests2" time="0.005">
+        <test name="test.Tests2.ShouldCreateItem" type="test.Tests2" method="ShouldCreateItem" time="0.0026206" result="Pass">
+          <traits />
+        </test>
+        <test name="test.Tests2.ShouldCreateItem3" type="test.Tests2" method="ShouldCreateItem3" time="0.0010000" result="Skip">
+          <reason><![CDATA[specific reason]]></reason>
+          <output>specific reason
+  </output>
+          <traits />
+        </test>
+        <test name="test.Tests2.ShouldCreateItem2" type="test.Tests2" method="ShouldCreateItem2" time="0.0010159" result="Fail">
+          <traits />
+        </test>
+      </collection>
+    </assembly>
+  </assemblies>

--- a/src/test/resources/edu/hm/hafner/coverage/parser/xunit/xunit-no-message.xml
+++ b/src/test/resources/edu/hm/hafner/coverage/parser/xunit/xunit-no-message.xml
@@ -1,0 +1,20 @@
+<assemblies timestamp="01/26/2024 13:49:51">
+    <assembly name="/home/jenkins/test2/bin/Debug/net8.0/test2.dll" run-date="2024-01-26" run-time="13:49:51" total="3" passed="1" failed="1" skipped="1" time="1.100" errors="0">
+      <errors />
+      <collection total="3" passed="1" failed="1" skipped="1" name="Test collection for test.Tests2" time="0.005">
+        <test name="test.Tests2.ShouldCreateItem" type="test.Tests2" method="ShouldCreateItem" time="0.0026206" result="Pass">
+          <traits />
+        </test>
+        <test name="test.Tests2.ShouldCreateItem3" type="test.Tests2" method="ShouldCreateItem3" time="0.0010000" result="Skip">
+          <reason><![CDATA[specific reason]]></reason>
+          <output>specific reason
+  </output>
+          <traits />
+        </test>
+        <test name="test.Tests2.ShouldCreateItem2" type="test.Tests2" method="ShouldCreateItem2" time="0.0010159" result="Fail">
+          <failure />
+          <traits />
+        </test>
+      </collection>
+    </assembly>
+  </assemblies>

--- a/src/test/resources/edu/hm/hafner/coverage/parser/xunit/xunit.xml
+++ b/src/test/resources/edu/hm/hafner/coverage/parser/xunit/xunit.xml
@@ -1,0 +1,29 @@
+<assemblies timestamp="01/26/2024 13:49:51">
+    <assembly name="/home/jenkins/test2/bin/Debug/net8.0/test2.dll" run-date="2024-01-26" run-time="13:49:51" total="3" passed="1" failed="1" skipped="1" time="1.100" errors="0">
+      <errors />
+      <collection total="3" passed="1" failed="1" skipped="1" name="Test collection for test.Tests2" time="0.005">
+        <test name="test.Tests2.ShouldCreateItem" type="test.Tests2" method="ShouldCreateItem" time="0.0026206" result="Pass">
+          <traits />
+        </test>
+        <test name="test.Tests2.ShouldCreateItem3" type="test.Tests2" method="ShouldCreateItem3" time="0.0010000" result="Skip">
+          <reason><![CDATA[specific reason]]></reason>
+          <output>specific reason
+  </output>
+          <traits />
+        </test>
+        <test name="test.Tests2.ShouldCreateItem2" type="test.Tests2" method="ShouldCreateItem2" time="0.0010159" result="Fail">
+          <failure>
+            <message>Assert.Equal() Failure
+                ↓ (pos 4)
+  Expected: Test3
+  Actual:   Test
+                ↑ (pos 4)</message>
+            <stack-trace>   at test.Tests2.ShouldCreateItem2() in /home/jenkins/test2/Tests2.cs:line 36
+     at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
+     at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)</stack-trace>
+          </failure>
+          <traits />
+        </test>
+      </collection>
+    </assembly>
+  </assemblies>


### PR DESCRIPTION
Realized that I have some .NET project using XUnit .NET runner (https://xunit.net/) running instead of NUnit.

XML format is (again) a bit different (https://xunit.net/docs/format-xml-v2)

But very similar and can be integrated easily since https://github.com/jenkinsci/coverage-model/pull/70

### Testing done

Automated tests and tested with generated XML file on a sample .NET project

```
dotnet test --logger:"xunit;LogFilePath=xunit-result.xml" /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
```

Added 1 passed test, 1 skipped and 1 failure

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
