### PR TITLE
[JENKINS-72757] Merge coverage files with incompatible counters

### DIFF
--- a/src/main/java/edu/hm/hafner/coverage/FileNode.java
+++ b/src/main/java/edu/hm/hafner/coverage/FileNode.java
@@ -153,8 +153,16 @@ public final class FileNode extends Node {
             int rightTotal = rightCovered + rightMissed;
 
             if (leftTotal != rightTotal) {
-                throw new IllegalArgumentException(String.format("Cannot merge coverage information for line %d in %s",
-                        line, this));
+                if (leftTotal == leftCovered || rightTotal == rightCovered) {
+                    leftCovered = Math.max(leftTotal, rightTotal);
+                    leftMissed = 0;
+                    leftTotal = leftCovered;
+                }
+                else {
+                    throw new IllegalArgumentException(
+                            String.format("Cannot merge coverage information for line %d in %s",
+                                    line, this));
+                }
             }
             if (leftTotal > 1) {
                 if (leftCovered > rightCovered) { // exact branch coverage cannot be computed
@@ -574,8 +582,8 @@ public final class FileNode extends Node {
     }
 
     /**
-     * Returns the lines that have no line coverage grouped in LineRanges.
-     * E.g., the lines [1, 2, 3] will be grouped in one {@link LineRange} instance.
+     * Returns the lines that have no line coverage grouped in LineRanges. E.g., the lines [1, 2, 3] will be grouped in
+     * one {@link LineRange} instance.
      *
      * @return the aggregated LineRanges that have no line coverage
      */
@@ -630,8 +638,8 @@ public final class FileNode extends Node {
     }
 
     /**
-     * Returns the lines that contain mutations. The returned map contains the line number as the key and a
-     * list of mutations as value.
+     * Returns the lines that contain mutations. The returned map contains the line number as the key and a list of
+     * mutations as value.
      *
      * @return the lines that have no line coverage
      */

--- a/src/test/java/edu/hm/hafner/coverage/parser/CoberturaParserTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/parser/CoberturaParserTest.java
@@ -40,6 +40,34 @@ class CoberturaParserTest extends AbstractParserTest {
         return "cobertura";
     }
 
+    @Test @Issue("JENKINS-72757")
+    void shouldMergeIfCountersAreNotCompatible() {
+        Node left = readReport("merge-a.xml");
+        assertThat(left.getAllFileNodes()).hasSize(1)
+                .element(0).satisfies(fileNode -> {
+                    assertThat(fileNode.getCoveredOfLine(61)).isEqualTo(2);
+                    assertThat(fileNode.getMissedOfLine(61)).isEqualTo(0);
+                });
+
+        Node right = readReport("merge-b.xml");
+        assertThat(right.getAllFileNodes()).hasSize(1)
+                .element(0).satisfies(fileNode -> {
+                    assertThat(fileNode.getCoveredOfLine(61)).isEqualTo(0);
+                    assertThat(fileNode.getMissedOfLine(61)).isEqualTo(4);
+                });
+
+        assertThat(left.merge(right).getAllFileNodes()).hasSize(1)
+                .element(0).satisfies(fileNode -> {
+                    assertThat(fileNode.getCoveredOfLine(61)).isEqualTo(4);
+                    assertThat(fileNode.getMissedOfLine(61)).isEqualTo(0);
+                });
+        assertThat(right.merge(left).getAllFileNodes()).hasSize(1)
+                .element(0).satisfies(fileNode -> {
+                    assertThat(fileNode.getCoveredOfLine(61)).isEqualTo(4);
+                    assertThat(fileNode.getMissedOfLine(61)).isEqualTo(0);
+                });
+    }
+
     @Test
     void shouldIgnoreMissingConditionAttribute() {
         Node missingCondition = readReport("cobertura-missing-condition-coverage.xml");

--- a/src/test/resources/edu/hm/hafner/coverage/parser/cobertura/merge-a.xml
+++ b/src/test/resources/edu/hm/hafner/coverage/parser/cobertura/merge-a.xml
@@ -1,0 +1,257 @@
+<?xml version="1.0" ?>
+<!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">
+<coverage lines-valid="8" lines-covered="8" line-rate="1" branches-valid="4" branches-covered="4" branch-rate="1"
+          timestamp="1394890504210" complexity="0" version="0.1">
+  <packages>
+    <package name="3" line-rate="1" branch-rate="1">
+      <classes>
+        <class line-rate="0.6111111111111112" branch-rate="0.6666666666666666" complexity="7" name="Ns.B.Query.SomeClass" filename="src/Ns.B/Query/SomeClass.cs">
+          <methods>
+            <method line-rate="1" branch-rate="1" complexity="1" name=".ctor" signature="()">
+              <lines>
+                <line number="77" hits="1" branch="False" />
+              </lines>
+            </method>
+            <method line-rate="0.5882352941176471" branch-rate="0.6666666666666666" complexity="6" name="GetValue" signature="(Ns.B.ISomeInterface, string)">
+              <lines>
+                <line number="81" hits="1" branch="True" condition-coverage="100% (2/2)">
+                  <conditions>
+                    <condition number="0" type="jump" coverage="100%" />
+                  </conditions>
+                </line>
+                <line number="83" hits="1" branch="False" />
+                <line number="84" hits="1" branch="True" condition-coverage="100% (2/2)">
+                  <conditions>
+                    <condition number="0" type="jump" coverage="100%" />
+                  </conditions>
+                </line>
+                <line number="86" hits="1" branch="False" />
+                <line number="87" hits="1" branch="False" />
+                <line number="89" hits="1" branch="True" />
+                <line number="91" hits="1" branch="False" />
+                <line number="93" hits="1" branch="False" />
+                <line number="94" hits="1" branch="True" />
+                <line number="95" hits="1" branch="False" />
+                <line number="97" hits="0" branch="False" />
+                <line number="98" hits="0" branch="False" />
+                <line number="100" hits="0" branch="True" condition-coverage="0% (0/2)">
+                  <conditions>
+                    <condition number="0" type="jump" coverage="0%" />
+                  </conditions>
+                </line>
+                <line number="102" hits="0" branch="False" />
+                <line number="103" hits="0" branch="False" />
+                <line number="106" hits="0" branch="False" />
+                <line number="107" hits="0" branch="False" />
+              </lines>
+            </method>
+          </methods>
+          <lines>
+            <line number="77" hits="1" branch="False" />
+            <line number="81" hits="1" branch="True" condition-coverage="100% (2/2)">
+              <conditions>
+                <condition number="0" type="jump" coverage="100%" />
+              </conditions>
+            </line>
+            <line number="83" hits="1" branch="False" />
+            <line number="84" hits="1" branch="True" condition-coverage="100% (2/2)">
+              <conditions>
+                <condition number="0" type="jump" coverage="100%" />
+              </conditions>
+            </line>
+            <line number="86" hits="1" branch="False" />
+            <line number="87" hits="1" branch="False" />
+            <line number="89" hits="1" branch="True" />
+            <line number="91" hits="1" branch="False" />
+            <line number="93" hits="1" branch="False" />
+            <line number="94" hits="1" branch="True" />
+            <line number="95" hits="1" branch="False" />
+            <line number="97" hits="0" branch="False" />
+            <line number="98" hits="0" branch="False" />
+            <line number="100" hits="0" branch="True" condition-coverage="0% (0/2)">
+              <conditions>
+                <condition number="0" type="jump" coverage="0%" />
+              </conditions>
+            </line>
+            <line number="102" hits="0" branch="False" />
+            <line number="103" hits="0" branch="False" />
+            <line number="106" hits="0" branch="False" />
+            <line number="107" hits="0" branch="False" />
+          </lines>
+        </class>
+        <class line-rate="0.75" branch-rate="1" complexity="14" name="Ns.B.Query.SomeClass.SomeNestedClass" filename="src/Ns.B/Query/SomeClass.cs">
+          <methods>
+            <method line-rate="1" branch-rate="1" complexity="1" name="get_Count" signature="()">
+              <lines>
+                <line number="21" hits="1" branch="False" />
+              </lines>
+            </method>
+            <method line-rate="0" branch-rate="1" complexity="1" name="get_Length" signature="()">
+              <lines>
+                <line number="23" hits="0" branch="False" />
+              </lines>
+            </method>
+            <method line-rate="0" branch-rate="1" complexity="1" name="get_Item" signature="(int)">
+              <lines>
+                <line number="25" hits="0" branch="False" />
+              </lines>
+            </method>
+            <method line-rate="1" branch-rate="1" complexity="1" name="get_Item" signature="(string)">
+              <lines>
+                <line number="26" hits="1" branch="False" />
+              </lines>
+            </method>
+            <method line-rate="1" branch-rate="1" complexity="1" name=".ctor" signature="(Ns.B.ISomeInterface, System.Collections.Generic.IDictionary&lt;string, Ns.A.Query.ISomeOtherInterface&gt;, string)">
+              <lines>
+                <line number="28" hits="1" branch="False" />
+                <line number="30" hits="1" branch="False" />
+                <line number="31" hits="1" branch="False" />
+                <line number="32" hits="1" branch="False" />
+                <line number="33" hits="1" branch="False" />
+                <line number="34" hits="1" branch="False" />
+              </lines>
+            </method>
+            <method line-rate="0.6842105263157895" branch-rate="1" complexity="6" name="GetValue" signature="(string, bool)">
+              <lines>
+                <line number="38" hits="1" branch="True" />
+                <line number="40" hits="0" branch="False" />
+                <line number="41" hits="0" branch="False" />
+                <line number="44" hits="1" branch="False" />
+                <line number="45" hits="1" branch="True" condition-coverage="100% (4/4)">
+                  <conditions>
+                    <condition number="0" type="jump" coverage="100%" />
+                    <condition number="1" type="jump" coverage="100%" />
+                  </conditions>
+                </line>
+                <line number="47" hits="1" branch="False" />
+                <line number="48" hits="1" branch="False" />
+                <line number="50" hits="1" branch="True" condition-coverage="100% (2/2)">
+                  <conditions>
+                    <condition number="0" type="jump" coverage="100%" />
+                  </conditions>
+                </line>
+                <line number="52" hits="1" branch="False" />
+                <line number="54" hits="1" branch="False" />
+                <line number="55" hits="1" branch="True" />
+                <line number="56" hits="1" branch="False" />
+                <line number="58" hits="0" branch="False" />
+                <line number="59" hits="0" branch="False" />
+                <line number="61" hits="1" branch="True" />
+                <line number="63" hits="1" branch="False" />
+                <line number="64" hits="1" branch="False" />
+                <line number="67" hits="0" branch="False" />
+                <line number="68" hits="0" branch="False" />
+              </lines>
+            </method>
+            <method line-rate="1" branch-rate="1" complexity="1" name="GetEnumerator" signature="()">
+              <lines>
+                <line number="71" hits="1" branch="False" />
+              </lines>
+            </method>
+            <method line-rate="1" branch-rate="1" complexity="1" name="System.Collections.IEnumerable.GetEnumerator" signature="()">
+              <lines>
+                <line number="73" hits="1" branch="False" />
+              </lines>
+            </method>
+            <method line-rate="1" branch-rate="1" complexity="1" name=".cctor" signature="()">
+              <lines>
+                <line number="15" hits="1" branch="False" />
+              </lines>
+            </method>
+          </methods>
+          <lines>
+            <line number="15" hits="1" branch="False" />
+            <line number="21" hits="1" branch="False" />
+            <line number="23" hits="0" branch="False" />
+            <line number="25" hits="0" branch="False" />
+            <line number="26" hits="1" branch="False" />
+            <line number="28" hits="1" branch="False" />
+            <line number="30" hits="1" branch="False" />
+            <line number="31" hits="1" branch="False" />
+            <line number="32" hits="1" branch="False" />
+            <line number="33" hits="1" branch="False" />
+            <line number="34" hits="1" branch="False" />
+            <line number="38" hits="1" branch="True" />
+            <line number="40" hits="0" branch="False" />
+            <line number="41" hits="0" branch="False" />
+            <line number="44" hits="1" branch="False" />
+            <line number="45" hits="1" branch="True" condition-coverage="100% (4/4)">
+              <conditions>
+                <condition number="0" type="jump" coverage="100%" />
+                <condition number="1" type="jump" coverage="100%" />
+              </conditions>
+            </line>
+            <line number="47" hits="1" branch="False" />
+            <line number="48" hits="1" branch="False" />
+            <line number="50" hits="1" branch="True" condition-coverage="100% (2/2)">
+              <conditions>
+                <condition number="0" type="jump" coverage="100%" />
+              </conditions>
+            </line>
+            <line number="52" hits="1" branch="False" />
+            <line number="54" hits="1" branch="False" />
+            <line number="55" hits="1" branch="True" />
+            <line number="56" hits="1" branch="False" />
+            <line number="58" hits="0" branch="False" />
+            <line number="59" hits="0" branch="False" />
+            <line number="61" hits="1" branch="True" />
+            <line number="63" hits="1" branch="False" />
+            <line number="64" hits="1" branch="False" />
+            <line number="67" hits="0" branch="False" />
+            <line number="68" hits="0" branch="False" />
+            <line number="71" hits="1" branch="False" />
+            <line number="73" hits="1" branch="False" />
+          </lines>
+        </class>
+        <class line-rate="1" branch-rate="1" complexity="1" name="Ns.B.Query.SomeClass.&lt;&gt;c" filename="src/Ns.B/Query/SomeClass.cs">
+          <methods>
+            <method line-rate="1" branch-rate="1" complexity="1" name="&lt;GetValue&gt;b__2_0" signature="(Ns.A.Query.ISomeOtherInterface)">
+              <lines>
+                <line number="81" hits="1" branch="False" />
+              </lines>
+            </method>
+          </methods>
+          <lines>
+            <line number="81" hits="1" branch="False" />
+          </lines>
+        </class>
+        <class line-rate="1" branch-rate="1" complexity="1" name="Ns.B.Query.SomeClass.&lt;&gt;c__DisplayClass2_0" filename="src/Ns.B/Query/SomeClass.cs">
+          <methods>
+            <method line-rate="1" branch-rate="1" complexity="1" name="&lt;GetValue&gt;b__1" signature="(string)">
+              <lines>
+                <line number="83" hits="1" branch="False" />
+              </lines>
+            </method>
+          </methods>
+          <lines>
+            <line number="83" hits="1" branch="False" />
+          </lines>
+        </class>
+        <class line-rate="1" branch-rate="1" complexity="1" name="Ns.B.Query.SomeClass.SomeNestedClass.&lt;&gt;c__DisplayClass13_0" filename="src/Ns.B/Query/SomeClass.cs">
+          <methods>
+            <method line-rate="1" branch-rate="1" complexity="1" name="&lt;.ctor&gt;b__0" signature="()">
+              <lines>
+                <line number="33" hits="1" branch="False" />
+              </lines>
+            </method>
+          </methods>
+          <lines>
+            <line number="33" hits="1" branch="False" />
+          </lines>
+        </class>
+        <class line-rate="1" branch-rate="1" complexity="1" name="Ns.B.Query.SomeClass.SomeNestedClass.&lt;&gt;c__DisplayClass14_0" filename="src/Ns.B/Query/SomeClass.cs">
+          <methods>
+            <method line-rate="1" branch-rate="1" complexity="1" name="&lt;GetValue&gt;b__0" signature="(string)">
+              <lines>
+                <line number="44" hits="1" branch="False" />
+              </lines>
+            </method>
+          </methods>
+          <lines>
+            <line number="44" hits="1" branch="False" />
+          </lines>
+        </class>
+      </classes>
+    </package>
+  </packages>
+</coverage>

--- a/src/test/resources/edu/hm/hafner/coverage/parser/cobertura/merge-b.xml
+++ b/src/test/resources/edu/hm/hafner/coverage/parser/cobertura/merge-b.xml
@@ -1,0 +1,299 @@
+<?xml version="1.0" ?>
+<!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">
+<coverage lines-valid="8" lines-covered="8" line-rate="1" branches-valid="4" branches-covered="4" branch-rate="1"
+          timestamp="1394890504210" complexity="0" version="0.1">
+  <packages>
+    <package name="3" line-rate="1" branch-rate="1">
+      <classes>
+        <class line-rate="0.6111111111111112" branch-rate="0.6" complexity="11" name="Ns.B.Query.SomeClass" filename="src/Ns.B/Query/SomeClass.cs">
+          <methods>
+            <method line-rate="1" branch-rate="1" complexity="1" name=".ctor" signature="()">
+              <lines>
+                <line number="77" hits="1" branch="False" />
+              </lines>
+            </method>
+            <method line-rate="0.5882352941176471" branch-rate="0.6" complexity="10" name="GetValue" signature="(Ns.B.ISomeInterface, string)">
+              <lines>
+                <line number="81" hits="1" branch="True" condition-coverage="100% (2/2)">
+                  <conditions>
+                    <condition number="0" type="jump" coverage="100%" />
+                  </conditions>
+                </line>
+                <line number="83" hits="1" branch="False" />
+                <line number="84" hits="1" branch="True" condition-coverage="100% (2/2)">
+                  <conditions>
+                    <condition number="0" type="jump" coverage="100%" />
+                  </conditions>
+                </line>
+                <line number="86" hits="1" branch="False" />
+                <line number="87" hits="1" branch="False" />
+                <line number="89" hits="1" branch="True" condition-coverage="50% (1/2)">
+                  <conditions>
+                    <condition number="0" type="jump" coverage="50%" />
+                  </conditions>
+                </line>
+                <line number="91" hits="1" branch="False" />
+                <line number="93" hits="1" branch="False" />
+                <line number="94" hits="1" branch="True" condition-coverage="50% (1/2)">
+                  <conditions>
+                    <condition number="0" type="jump" coverage="50%" />
+                  </conditions>
+                </line>
+                <line number="95" hits="1" branch="False" />
+                <line number="97" hits="0" branch="False" />
+                <line number="98" hits="0" branch="False" />
+                <line number="100" hits="0" branch="True" condition-coverage="0% (0/2)">
+                  <conditions>
+                    <condition number="0" type="jump" coverage="0%" />
+                  </conditions>
+                </line>
+                <line number="102" hits="0" branch="False" />
+                <line number="103" hits="0" branch="False" />
+                <line number="106" hits="0" branch="False" />
+                <line number="107" hits="0" branch="False" />
+              </lines>
+            </method>
+          </methods>
+          <lines>
+            <line number="77" hits="1" branch="False" />
+            <line number="81" hits="1" branch="True" condition-coverage="100% (2/2)">
+              <conditions>
+                <condition number="0" type="jump" coverage="100%" />
+              </conditions>
+            </line>
+            <line number="83" hits="1" branch="False" />
+            <line number="84" hits="1" branch="True" condition-coverage="100% (2/2)">
+              <conditions>
+                <condition number="0" type="jump" coverage="100%" />
+              </conditions>
+            </line>
+            <line number="86" hits="1" branch="False" />
+            <line number="87" hits="1" branch="False" />
+            <line number="89" hits="1" branch="True" condition-coverage="50% (1/2)">
+              <conditions>
+                <condition number="0" type="jump" coverage="50%" />
+              </conditions>
+            </line>
+            <line number="91" hits="1" branch="False" />
+            <line number="93" hits="1" branch="False" />
+            <line number="94" hits="1" branch="True" condition-coverage="50% (1/2)">
+              <conditions>
+                <condition number="0" type="jump" coverage="50%" />
+              </conditions>
+            </line>
+            <line number="95" hits="1" branch="False" />
+            <line number="97" hits="0" branch="False" />
+            <line number="98" hits="0" branch="False" />
+            <line number="100" hits="0" branch="True" condition-coverage="0% (0/2)">
+              <conditions>
+                <condition number="0" type="jump" coverage="0%" />
+              </conditions>
+            </line>
+            <line number="102" hits="0" branch="False" />
+            <line number="103" hits="0" branch="False" />
+            <line number="106" hits="0" branch="False" />
+            <line number="107" hits="0" branch="False" />
+          </lines>
+        </class>
+        <class line-rate="0.5" branch-rate="0.2857142857142857" complexity="22" name="Ns.B.Query.SomeClass.SomeNestedClass" filename="src/Ns.B/Query/SomeClass.cs">
+          <methods>
+            <method line-rate="0" branch-rate="1" complexity="1" name="get_Count" signature="()">
+              <lines>
+                <line number="21" hits="0" branch="False" />
+              </lines>
+            </method>
+            <method line-rate="0" branch-rate="1" complexity="1" name="get_Length" signature="()">
+              <lines>
+                <line number="23" hits="0" branch="False" />
+              </lines>
+            </method>
+            <method line-rate="0" branch-rate="1" complexity="1" name="get_Item" signature="(int)">
+              <lines>
+                <line number="25" hits="0" branch="False" />
+              </lines>
+            </method>
+            <method line-rate="0" branch-rate="1" complexity="1" name="get_Item" signature="(string)">
+              <lines>
+                <line number="26" hits="0" branch="False" />
+              </lines>
+            </method>
+            <method line-rate="1" branch-rate="1" complexity="1" name=".ctor" signature="(Ns.B.ISomeInterface, System.Collections.Generic.IDictionary&lt;string, Ns.A.Query.ISomeOtherInterface&gt;, string)">
+              <lines>
+                <line number="28" hits="1" branch="False" />
+                <line number="30" hits="1" branch="False" />
+                <line number="31" hits="1" branch="False" />
+                <line number="32" hits="1" branch="False" />
+                <line number="33" hits="1" branch="False" />
+                <line number="34" hits="1" branch="False" />
+              </lines>
+            </method>
+            <method line-rate="0.42105263157894735" branch-rate="0.2857142857142857" complexity="14" name="GetValue" signature="(string, bool)">
+              <lines>
+                <line number="38" hits="1" branch="True" condition-coverage="50% (1/2)">
+                  <conditions>
+                    <condition number="0" type="jump" coverage="50%" />
+                  </conditions>
+                </line>
+                <line number="40" hits="0" branch="False" />
+                <line number="41" hits="0" branch="False" />
+                <line number="44" hits="1" branch="False" />
+                <line number="45" hits="1" branch="True" condition-coverage="25% (1/4)">
+                  <conditions>
+                    <condition number="0" type="jump" coverage="50%" />
+                    <condition number="1" type="jump" coverage="0%" />
+                  </conditions>
+                </line>
+                <line number="47" hits="0" branch="False" />
+                <line number="48" hits="0" branch="False" />
+                <line number="50" hits="1" branch="True" condition-coverage="50% (1/2)">
+                  <conditions>
+                    <condition number="0" type="jump" coverage="50%" />
+                  </conditions>
+                </line>
+                <line number="52" hits="1" branch="False" />
+                <line number="54" hits="1" branch="False" />
+                <line number="55" hits="1" branch="True" condition-coverage="50% (1/2)">
+                  <conditions>
+                    <condition number="0" type="jump" coverage="50%" />
+                  </conditions>
+                </line>
+                <line number="56" hits="1" branch="False" />
+                <line number="58" hits="0" branch="False" />
+                <line number="59" hits="0" branch="False" />
+                <line number="61" hits="0" branch="True" condition-coverage="0% (0/4)">
+                  <conditions>
+                    <condition number="0" type="jump" coverage="0%" />
+                    <condition number="1" type="jump" coverage="0%" />
+                  </conditions>
+                </line>
+                <line number="63" hits="0" branch="False" />
+                <line number="64" hits="0" branch="False" />
+                <line number="67" hits="0" branch="False" />
+                <line number="68" hits="0" branch="False" />
+              </lines>
+            </method>
+            <method line-rate="1" branch-rate="1" complexity="1" name="GetEnumerator" signature="()">
+              <lines>
+                <line number="71" hits="1" branch="False" />
+              </lines>
+            </method>
+            <method line-rate="0" branch-rate="1" complexity="1" name="System.Collections.IEnumerable.GetEnumerator" signature="()">
+              <lines>
+                <line number="73" hits="0" branch="False" />
+              </lines>
+            </method>
+            <method line-rate="1" branch-rate="1" complexity="1" name=".cctor" signature="()">
+              <lines>
+                <line number="15" hits="1" branch="False" />
+              </lines>
+            </method>
+          </methods>
+          <lines>
+            <line number="15" hits="1" branch="False" />
+            <line number="21" hits="0" branch="False" />
+            <line number="23" hits="0" branch="False" />
+            <line number="25" hits="0" branch="False" />
+            <line number="26" hits="0" branch="False" />
+            <line number="28" hits="1" branch="False" />
+            <line number="30" hits="1" branch="False" />
+            <line number="31" hits="1" branch="False" />
+            <line number="32" hits="1" branch="False" />
+            <line number="33" hits="1" branch="False" />
+            <line number="34" hits="1" branch="False" />
+            <line number="38" hits="1" branch="True" condition-coverage="50% (1/2)">
+              <conditions>
+                <condition number="0" type="jump" coverage="50%" />
+              </conditions>
+            </line>
+            <line number="40" hits="0" branch="False" />
+            <line number="41" hits="0" branch="False" />
+            <line number="44" hits="1" branch="False" />
+            <line number="45" hits="1" branch="True" condition-coverage="25% (1/4)">
+              <conditions>
+                <condition number="0" type="jump" coverage="50%" />
+                <condition number="1" type="jump" coverage="0%" />
+              </conditions>
+            </line>
+            <line number="47" hits="0" branch="False" />
+            <line number="48" hits="0" branch="False" />
+            <line number="50" hits="1" branch="True" condition-coverage="50% (1/2)">
+              <conditions>
+                <condition number="0" type="jump" coverage="50%" />
+              </conditions>
+            </line>
+            <line number="52" hits="1" branch="False" />
+            <line number="54" hits="1" branch="False" />
+            <line number="55" hits="1" branch="True" condition-coverage="50% (1/2)">
+              <conditions>
+                <condition number="0" type="jump" coverage="50%" />
+              </conditions>
+            </line>
+            <line number="56" hits="1" branch="False" />
+            <line number="58" hits="0" branch="False" />
+            <line number="59" hits="0" branch="False" />
+            <line number="61" hits="0" branch="True" condition-coverage="0% (0/4)">
+              <conditions>
+                <condition number="0" type="jump" coverage="0%" />
+                <condition number="1" type="jump" coverage="0%" />
+              </conditions>
+            </line>
+            <line number="63" hits="0" branch="False" />
+            <line number="64" hits="0" branch="False" />
+            <line number="67" hits="0" branch="False" />
+            <line number="68" hits="0" branch="False" />
+            <line number="71" hits="1" branch="False" />
+            <line number="73" hits="0" branch="False" />
+          </lines>
+        </class>
+        <class line-rate="1" branch-rate="1" complexity="1" name="Ns.B.Query.SomeClass.&lt;&gt;c" filename="src/Ns.B/Query/SomeClass.cs">
+          <methods>
+            <method line-rate="1" branch-rate="1" complexity="1" name="&lt;GetValue&gt;b__2_0" signature="(Ns.A.Query.ISomeOtherInterface)">
+              <lines>
+                <line number="81" hits="1" branch="False" />
+              </lines>
+            </method>
+          </methods>
+          <lines>
+            <line number="81" hits="1" branch="False" />
+          </lines>
+        </class>
+        <class line-rate="1" branch-rate="1" complexity="1" name="Ns.B.Query.SomeClass.&lt;&gt;c__DisplayClass2_0" filename="src/Ns.B/Query/SomeClass.cs">
+          <methods>
+            <method line-rate="1" branch-rate="1" complexity="1" name="&lt;GetValue&gt;b__1" signature="(string)">
+              <lines>
+                <line number="83" hits="1" branch="False" />
+              </lines>
+            </method>
+          </methods>
+          <lines>
+            <line number="83" hits="1" branch="False" />
+          </lines>
+        </class>
+        <class line-rate="1" branch-rate="1" complexity="1" name="Ns.B.Query.SomeClass.SomeNestedClass.&lt;&gt;c__DisplayClass13_0" filename="src/Ns.B/Query/SomeClass.cs">
+          <methods>
+            <method line-rate="1" branch-rate="1" complexity="1" name="&lt;.ctor&gt;b__0" signature="()">
+              <lines>
+                <line number="33" hits="1" branch="False" />
+              </lines>
+            </method>
+          </methods>
+          <lines>
+            <line number="33" hits="1" branch="False" />
+          </lines>
+        </class>
+        <class line-rate="1" branch-rate="1" complexity="1" name="Ns.B.Query.SomeClass.SomeNestedClass.&lt;&gt;c__DisplayClass14_0" filename="src/Ns.B/Query/SomeClass.cs">
+          <methods>
+            <method line-rate="1" branch-rate="1" complexity="1" name="&lt;GetValue&gt;b__0" signature="(string)">
+              <lines>
+                <line number="44" hits="1" branch="False" />
+              </lines>
+            </method>
+          </methods>
+          <lines>
+            <line number="44" hits="1" branch="False" />
+          </lines>
+        </class>
+      </classes>
+    </package>
+  </packages>
+</coverage>


### PR DESCRIPTION
Some tools do not always report exact coverage data for branches. Cobertura reports from Microsoft Coverage may contain lines with full branch coverage but without a specification of the exact number of covered branches. This might cause problems when a merge with another report is processed, that contains a partial coverage (with the number of branches given). 

See: 
- https://issues.jenkins.io/browse/JENKINS-72757
- https://github.com/microsoft/codecoverage/issues/104
