### PR TITLE
Add `fileName` as a parameter.

### DIFF
--- a/src/main/java/edu/hm/hafner/coverage/parser/AbstractTestParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/parser/AbstractTestParser.java
@@ -48,12 +48,12 @@ abstract class AbstractTestParser extends CoverageParser {
     }
 
     @Override
-    protected ModuleNode parseReport(final Reader reader, final FilteredLog log) {
+    protected ModuleNode parseReport(final Reader reader, final String fileName, final FilteredLog log) {
         try {
             var eventReader = new SecureXmlParserFactory().createXmlEventReader(reader);
-            var root = new ModuleNode(EMPTY);
-            var tests = readTestCases(eventReader, root);
-            handleEmptyResults(log, tests.isEmpty());
+            var root = new ModuleNode(fileName);
+            var tests = readTestCases(eventReader, root, fileName);
+            handleEmptyResults(fileName, tests.isEmpty(), log);
             return root;
         }
         catch (XMLStreamException exception) {
@@ -62,7 +62,7 @@ abstract class AbstractTestParser extends CoverageParser {
     }
 
     private List<TestCase> readTestCases(final XMLEventReader eventReader,
-            final ModuleNode root) throws XMLStreamException {
+            final ModuleNode root, final String fileName) throws XMLStreamException {
         String suiteName = EMPTY;
         var tests = new ArrayList<TestCase>();
         while (eventReader.hasNext()) {
@@ -72,14 +72,14 @@ abstract class AbstractTestParser extends CoverageParser {
                 suiteName = getOptionalValueOf(event.asStartElement(), NAME).orElse(EMPTY);
             }
             else if (event.isStartElement() && getTestCase().equals(event.asStartElement().getName())) {
-                tests.add(readTestCase(eventReader, event.asStartElement(), suiteName, root));
+                tests.add(readTestCase(eventReader, event.asStartElement(), suiteName, root, fileName));
             }
         }
         return tests;
     }
 
     abstract TestCase readTestCase(XMLEventReader reader, StartElement testCaseElement,
-            String suiteName, ModuleNode root) throws XMLStreamException;
+            String suiteName, ModuleNode root, String fileName) throws XMLStreamException;
 
     protected String createId() {
         return UUID.randomUUID().toString();

--- a/src/main/java/edu/hm/hafner/coverage/parser/JunitParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/parser/JunitParser.java
@@ -44,7 +44,7 @@ public class JunitParser extends AbstractTestParser {
 
     @Override
     TestCase readTestCase(final XMLEventReader reader, final StartElement testCaseElement,
-            final String suiteName, final ModuleNode root) throws XMLStreamException {
+            final String suiteName, final ModuleNode root, final String fileName) throws XMLStreamException {
         var builder = new TestCaseBuilder();
 
         builder.withTestName(getOptionalValueOf(testCaseElement, NAME).orElse(createId()));
@@ -68,7 +68,7 @@ public class JunitParser extends AbstractTestParser {
                 return builder.build();
             }
         }
-        throw createEofException();
+        throw createEofException(fileName);
     }
 
     private boolean isFailure(final XMLEvent event) {

--- a/src/main/java/edu/hm/hafner/coverage/parser/NunitParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/parser/NunitParser.java
@@ -47,7 +47,7 @@ public class NunitParser extends AbstractTestParser {
 
     @Override
     TestCase readTestCase(final XMLEventReader reader, final StartElement testCaseElement,
-            final String suiteName, final ModuleNode root) throws XMLStreamException {
+            final String suiteName, final ModuleNode root, final String fileName) throws XMLStreamException {
         var builder = new TestCaseBuilder();
 
         builder.withTestName(getOptionalValueOf(testCaseElement, NAME).orElse(createId()));
@@ -69,7 +69,7 @@ public class NunitParser extends AbstractTestParser {
                 return builder.build();
             }
         }
-        throw createEofException();
+        throw createEofException(fileName);
     }
 
     private void readStatus(final StartElement testCaseElement, final TestCaseBuilder builder) {

--- a/src/main/java/edu/hm/hafner/coverage/parser/OpenCoverParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/parser/OpenCoverParser.java
@@ -87,7 +87,7 @@ public class OpenCoverParser extends CoverageParser {
 
     @Override
     @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.AvoidDeeplyNestedIfStmts"})
-    protected ModuleNode parseReport(final Reader reader, final FilteredLog log) {
+    protected ModuleNode parseReport(final Reader reader, final String fileName, final FilteredLog log) {
         try {
             var eventReader = new SecureXmlParserFactory().createXmlEventReader(reader);
             var root = new ModuleNode(EMPTY);
@@ -103,7 +103,7 @@ public class OpenCoverParser extends CoverageParser {
                     }
                 }
             }
-            handleEmptyResults(log);
+            handleEmptyResults(fileName, log);
             return new ModuleNode("empty");
         }
         catch (XMLStreamException exception) {

--- a/src/main/java/edu/hm/hafner/coverage/parser/PitestParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/parser/PitestParser.java
@@ -64,7 +64,7 @@ public class PitestParser extends CoverageParser {
     }
 
     @Override
-    protected ModuleNode parseReport(final Reader reader, final FilteredLog log) {
+    protected ModuleNode parseReport(final Reader reader, final String fileName, final FilteredLog log) {
         try {
             var factory = new SecureXmlParserFactory();
             var eventReader = factory.createXmlEventReader(reader);
@@ -79,7 +79,7 @@ public class PitestParser extends CoverageParser {
                     isEmpty = false;
                 }
             }
-            handleEmptyResults(log, isEmpty);
+            handleEmptyResults(fileName, isEmpty, log);
             root.getAllFileNodes().forEach(this::collectLineCoverage);
             return root;
         }

--- a/src/main/java/edu/hm/hafner/coverage/parser/XunitParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/parser/XunitParser.java
@@ -48,7 +48,7 @@ public class XunitParser extends AbstractTestParser {
 
     @Override
     TestCase readTestCase(final XMLEventReader reader, final StartElement testCaseElement,
-            final String suiteName, final ModuleNode root) throws XMLStreamException {
+            final String suiteName, final ModuleNode root, final String fileName) throws XMLStreamException {
         var builder = new TestCaseBuilder();
 
         builder.withTestName(getOptionalValueOf(testCaseElement, NAME).orElse(createId()));
@@ -70,7 +70,7 @@ public class XunitParser extends AbstractTestParser {
                 return builder.build();
             }
         }
-        throw createEofException();
+        throw createEofException(fileName);
     }
 
     private void readStatus(final StartElement testCaseElement, final TestCaseBuilder builder) {

--- a/src/test/java/edu/hm/hafner/coverage/parser/AbstractParserTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/parser/AbstractParserTest.java
@@ -43,7 +43,7 @@ abstract class AbstractParserTest {
     ModuleNode readReport(final String fileName, final CoverageParser parser) {
         try (InputStream stream = createFile(fileName);
                 Reader reader = new InputStreamReader(Objects.requireNonNull(stream), StandardCharsets.UTF_8)) {
-            return parser.parse(reader, log);
+            return parser.parse(reader, fileName, log);
         }
         catch (IOException e) {
             throw new AssertionError(e);
@@ -85,8 +85,9 @@ abstract class AbstractParserTest {
         assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(() -> readReport("empty.xml"));
 
         var report = readReport("empty.xml", ProcessingMode.IGNORE_ERRORS);
-
         assertThat(report).hasNoChildren().hasNoValues();
-        assertThat(getLog().getErrorMessages()).contains(CoverageParser.EMPTY_MESSAGE);
+
+        var parserName = createParser(ProcessingMode.FAIL_FAST).getClass().getSimpleName();
+        assertThat(getLog().getErrorMessages()).contains(String.format("[%s] The processed file 'empty.xml' does not contain data.", parserName));
     }
 }

--- a/src/test/java/edu/hm/hafner/coverage/parser/JunitParserTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/parser/JunitParserTest.java
@@ -33,7 +33,7 @@ class JunitParserTest extends AbstractParserTest {
 
     @Test
     void shouldReadArchUnitTests() {
-        ModuleNode tree = readReport("archunit1.xml");
+        ModuleNode tree = readJunitReport("archunit1.xml");
 
         assertThat(tree.getAll(Metric.MODULE)).hasSize(1);
         assertThat(tree.getAll(Metric.PACKAGE)).hasSize(1);
@@ -41,7 +41,6 @@ class JunitParserTest extends AbstractParserTest {
 
         assertThat(tree.aggregateValues()).contains(new TestCount(1));
 
-        assertThat(tree).hasName(EMPTY);
         assertThat(getPackage(tree)).hasName(EMPTY);
 
         var testClass = getFirstClass(tree);
@@ -66,9 +65,7 @@ class JunitParserTest extends AbstractParserTest {
 
     @Test
     void shouldReadWithNameOnly() {
-        ModuleNode tree = readReport("cfn-lint.xml");
-
-        assertThat(tree).hasName(EMPTY);
+        var tree = readJunitReport("cfn-lint.xml");
         assertThat(getPackage(tree)).hasName(EMPTY);
         assertThat(getFirstClass(tree)).hasName("CloudFormation Lint");
 
@@ -79,9 +76,7 @@ class JunitParserTest extends AbstractParserTest {
 
     @Test
     void shouldReadFailure() {
-        ModuleNode tree = readReport("issue-113.xml");
-
-        assertThat(tree).hasName(EMPTY);
+        var tree = readJunitReport("issue-113.xml");
         assertThat(getPackage(tree)).hasName(EMPTY);
         assertThat(getFirstClass(tree)).hasName("Assignment1Test");
         assertThat(getFirstTest(tree).getDescription()).contains("Die Welten sind nicht korrekt");
@@ -91,9 +86,7 @@ class JunitParserTest extends AbstractParserTest {
 
     @Test
     void shouldReadError() {
-        ModuleNode tree = readReport("JENKINS-64117.xml");
-
-        assertThat(tree).hasName(EMPTY);
+        var tree = readJunitReport("JENKINS-64117.xml");
         assertThat(getPackage(tree)).hasName("eu.pinteam.kyoto.gunit.testenv.test");
         assertThat(getFirstClass(tree)).hasName("eu.pinteam.kyoto.gunit.testenv.test.CalculationUtilTest");
         assertThat(getFirstTest(tree).getMessage()).isEqualTo("The container NewcontTest0 does not allow a parameter of type f1");
@@ -104,9 +97,7 @@ class JunitParserTest extends AbstractParserTest {
 
     @Test
     void shouldReadBrokenClassNames() {
-        ModuleNode tree = readReport("jest-junit.xml");
-
-        assertThat(tree).hasName(EMPTY);
+        var tree = readJunitReport("jest-junit.xml");
         assertThat(getPackage(tree)).hasName(EMPTY);
         assertThat(getFirstClass(tree)).hasName("snapshots should display correct snapshot");
         assertThat(getFirstTest(tree).getDescription()).contains("Error: expect.assertions(3)");
@@ -116,9 +107,7 @@ class JunitParserTest extends AbstractParserTest {
 
     @Test
     void shouldReadJavaClassNames() {
-        ModuleNode tree = readReport("junit.xml");
-
-        assertThat(tree).hasName(EMPTY);
+        var tree = readJunitReport("junit.xml");
         assertThat(getPackage(tree)).hasName("com.example.jenkinstest");
         assertThat(getFirstClass(tree)).hasName("com.example.jenkinstest.ExampleUnitTest");
         assertThat(getFirstTest(tree).getDescription()).contains("com.example.jenkinstest.ExampleUnitTest.failTest4");
@@ -128,9 +117,7 @@ class JunitParserTest extends AbstractParserTest {
 
     @Test
     void shouldReadAndroidTestResults() {
-        ModuleNode tree = readReport("junit2.xml");
-
-        assertThat(tree).hasName(EMPTY);
+        var tree = readJunitReport("junit2.xml");
         assertThat(getPackage(tree)).hasName("my.company");
         assertThat(getFirstClass(tree)).hasName("my.company.MainActivityTest");
         assertThat(getFirstTest(tree).getDescription()).contains("Looped for 3838 iterations over 60 SECONDS");
@@ -140,9 +127,7 @@ class JunitParserTest extends AbstractParserTest {
 
     @Test
     void shouldReadNoMessageAndType() {
-        ModuleNode tree = readReport("junit-no-message-or-type.xml");
-
-        assertThat(tree).hasName(EMPTY);
+        var tree = readJunitReport("junit-no-message-or-type.xml");
         assertThat(getPackage(tree)).hasName("timrAPITests");
         assertThat(getFirstClass(tree)).hasName("timrAPITests.UtilTests");
         assertThat(getFirstTest(tree).getDescription()).contains("timrAPITests/Tests/Utils/UtilTests.swift:23");
@@ -152,9 +137,7 @@ class JunitParserTest extends AbstractParserTest {
 
     @Test
     void shouldReadErrorWithoutSuite() {
-        ModuleNode tree = readReport("plainerror.xml");
-
-        assertThat(tree).hasName(EMPTY);
+        var tree = readJunitReport("plainerror.xml");
         assertThat(getPackage(tree)).hasName("edu.hm.hafner.analysis.parser");
         assertThat(getFirstClass(tree)).hasName("edu.hm.hafner.analysis.parser.SonarQubeDiffParserTest");
         assertThat(getFirstTest(tree).getDescription()).contains("org.json.JSONException: Missing value at 0");
@@ -164,9 +147,7 @@ class JunitParserTest extends AbstractParserTest {
 
     @Test
     void shouldReadPerformanceTestResults() {
-        ModuleNode tree = readReport("TEST-org.jenkinsci.plugins.jvctb.perform.JvctbPerformerTest.xml");
-
-        assertThat(tree).hasName(EMPTY);
+        var tree = readJunitReport("TEST-org.jenkinsci.plugins.jvctb.perform.JvctbPerformerTest.xml");
         assertThat(getPackage(tree)).hasName("org.jenkinsci.plugins.jvctb.perform");
         assertThat(getFirstClass(tree)).hasName("org.jenkinsci.plugins.jvctb.perform.JvctbPerformerTest");
         assertThat(getFirstTest(tree).getDescription()).contains("org.junit.ComparisonFailure");
@@ -176,14 +157,18 @@ class JunitParserTest extends AbstractParserTest {
 
     @Test
     void shouldReadTestSuites() {
-        ModuleNode tree = readReport("TESTS-TestSuites.xml");
-
-        assertThat(tree).hasName(EMPTY);
+        var tree = readJunitReport("TESTS-TestSuites.xml");
         assertThat(getPackage(tree)).hasName("ch.bdna.tsm.service");
         assertThat(getFirstClass(tree)).hasName("ch.bdna.tsm.service.PollingServiceTest");
         assertThat(getFirstTest(tree).getDescription()).contains("Missing CPU value");
 
         assertThat(tree.aggregateValues()).contains(new TestCount(2));
+    }
+
+    private ModuleNode readJunitReport(final String fileName) {
+        ModuleNode tree = readReport(fileName);
+        assertThat(tree).hasName(fileName);
+        return tree;
     }
 
     private PackageNode getPackage(final Node node) {

--- a/src/test/java/edu/hm/hafner/coverage/parser/NunitParserTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/parser/NunitParserTest.java
@@ -33,9 +33,7 @@ class NunitParserTest extends AbstractParserTest {
 
     @Test
     void shouldReadReport() {
-        ModuleNode tree = readReport("nunit.xml");
-
-        assertThat(tree).hasName(EMPTY);
+        var tree = readNunitReport("nunit.xml");
         assertThat(getPackage(tree)).hasName("-");
         assertThat(getFirstClass(tree)).hasName("Tests");
         assertThat(getFirstTest(tree).getDescription()).contains("Expected string length 4 but was 5. Strings differ at index 4");
@@ -45,9 +43,7 @@ class NunitParserTest extends AbstractParserTest {
 
     @Test
     void shouldReadReportInV2Format() {
-        ModuleNode tree = readReport("nunit2-format.xml");
-
-        assertThat(tree).hasName(EMPTY);
+        var tree = readNunitReport("nunit2-format.xml");
         assertThat(getPackage(tree)).hasName("-");
         assertThat(getFirstClass(tree)).hasName("MockTestFixture");
         assertThat(getFirstTest(tree).getDescription()).contains("Intentional failure");
@@ -57,9 +53,7 @@ class NunitParserTest extends AbstractParserTest {
 
     @Test
     void shouldReadReportWithoutErrorMessage() {
-        ModuleNode tree = readReport("nunit-no-message.xml");
-
-        assertThat(tree).hasName(EMPTY);
+        var tree = readNunitReport("nunit-no-message.xml");
         assertThat(getPackage(tree)).hasName("-");
         assertThat(getFirstClass(tree)).hasName("Tests");
         assertThat(getFirstTest(tree).getDescription()).contains("");
@@ -68,20 +62,22 @@ class NunitParserTest extends AbstractParserTest {
 
     @Test
     void shouldReadReportWithoutFailure() {
-        ModuleNode tree = readReport("nunit-no-failure-block.xml");
-
-        assertThat(tree).hasName(EMPTY);
+        var tree = readNunitReport("nunit-no-failure-block.xml");
         assertThat(getPackage(tree)).hasName("-");
         assertThat(getFirstClass(tree)).hasName("Tests");
         assertThat(getFirstTest(tree).getDescription()).contains("");
         assertThat(tree.aggregateValues()).contains(new TestCount(4));
     }
 
+    private ModuleNode readNunitReport(final String fileName) {
+        ModuleNode tree = readReport(fileName);
+        assertThat(tree).hasName(fileName);
+        return tree;
+    }
+
     @Test
     void shouldReadReportWithInvalidStatus() {
-        ModuleNode tree = readReport("nunit-invalid-status.xml");
-
-        assertThat(tree).hasName(EMPTY);
+        var tree = readNunitReport("nunit-invalid-status.xml");
         assertThat(getPackage(tree)).hasName("-");
         assertThat(getFirstClass(tree)).hasName("Tests");
         assertThat(tree.aggregateValues()).contains(new TestCount(4));

--- a/src/test/java/edu/hm/hafner/coverage/parser/NunitParserTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/parser/NunitParserTest.java
@@ -19,8 +19,6 @@ import edu.hm.hafner.coverage.TestCount;
 import static edu.hm.hafner.coverage.assertions.Assertions.*;
 
 class NunitParserTest extends AbstractParserTest {
-    private static final String EMPTY = "-";
-
     @Override
     CoverageParser createParser(final ProcessingMode processingMode) {
         return new NunitParser(processingMode);

--- a/src/test/java/edu/hm/hafner/coverage/parser/TestCaseMappingTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/parser/TestCaseMappingTest.java
@@ -99,7 +99,7 @@ class TestCaseMappingTest {
             try (InputStream stream = Objects.requireNonNull(TestCaseMappingTest.class.getResourceAsStream(fileName),
                     "File not found: " + fileName);
                     Reader reader = new InputStreamReader(Objects.requireNonNull(stream), StandardCharsets.UTF_8)) {
-                return parser.parse(reader, new FilteredLog("Errors"));
+                return parser.parse(reader, fileName, new FilteredLog("Errors"));
             }
         }
         catch (IOException e) {

--- a/src/test/java/edu/hm/hafner/coverage/parser/XunitParserTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/parser/XunitParserTest.java
@@ -33,9 +33,7 @@ class XunitParserTest extends AbstractParserTest {
 
     @Test
     void shouldReadReport() {
-        ModuleNode tree = readReport("xunit.xml");
-
-        assertThat(tree).hasName(EMPTY);
+        var tree = readXunitReport("xunit.xml");
         assertThat(getPackage(tree)).hasName("-");
         assertThat(getFirstClass(tree)).hasName("test.Tests2");
         assertThat(getFirstTest(tree).getDescription()).contains("Assert.Equal() Failure");
@@ -45,9 +43,7 @@ class XunitParserTest extends AbstractParserTest {
 
     @Test
     void shouldReadReportWithoutFailure() {
-        ModuleNode tree = readReport("xunit-no-failure-block.xml");
-
-        assertThat(tree).hasName(EMPTY);
+        var tree = readXunitReport("xunit-no-failure-block.xml");
         assertThat(getPackage(tree)).hasName("-");
         assertThat(getFirstClass(tree)).hasName("test.Tests2");
         assertThat(getFirstTest(tree).getDescription()).contains("");
@@ -56,9 +52,7 @@ class XunitParserTest extends AbstractParserTest {
 
     @Test
     void shouldReadReportWithInvalidStatus() {
-        ModuleNode tree = readReport("xunit-invalid-status.xml");
-
-        assertThat(tree).hasName(EMPTY);
+        var tree = readXunitReport("xunit-invalid-status.xml");
         assertThat(getPackage(tree)).hasName("-");
         assertThat(getFirstClass(tree)).hasName("test.Tests2");
         assertThat(tree.aggregateValues()).contains(new TestCount(3));
@@ -66,13 +60,17 @@ class XunitParserTest extends AbstractParserTest {
 
     @Test
     void shouldReadReportWithoutErrorMessage() {
-        ModuleNode tree = readReport("xunit-no-message.xml");
-
-        assertThat(tree).hasName(EMPTY);
+        var tree = readXunitReport("xunit-no-message.xml");
         assertThat(getPackage(tree)).hasName("-");
         assertThat(getFirstClass(tree)).hasName("test.Tests2");
         assertThat(getFirstTest(tree).getDescription()).contains("");
         assertThat(tree.aggregateValues()).contains(new TestCount(3));
+    }
+
+    private ModuleNode readXunitReport(final String fileName) {
+        ModuleNode tree = readReport(fileName);
+        assertThat(tree).hasName(fileName);
+        return tree;
     }
 
     private PackageNode getPackage(final Node node) {

--- a/src/test/java/edu/hm/hafner/coverage/parser/XunitParserTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/parser/XunitParserTest.java
@@ -19,8 +19,6 @@ import edu.hm.hafner.coverage.TestCount;
 import static edu.hm.hafner.coverage.assertions.Assertions.*;
 
 class XunitParserTest extends AbstractParserTest {
-    private static final String EMPTY = "-";
-
     @Override
     CoverageParser createParser(final ProcessingMode processingMode) {
         return new XunitParser(processingMode);


### PR DESCRIPTION
This helps to improve error detection in the consumers.

Before:
```
Quality Monitor Errors:
No data found in the specified file.
```

After:
```
Quality Monitor Errors:
The processed file 'empty.xml' does not contain data.
```