### PR TITLE
Correctly merge test cases into the existing coverage tree

### DIFF
--- a/src/test/java/edu/hm/hafner/coverage/parser/TestCaseMappingTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/parser/TestCaseMappingTest.java
@@ -79,12 +79,12 @@ class TestCaseMappingTest {
         assertThat(tests.getTestCases()).hasSize(257);
         assertThat(tests.getAllClassNodes()).extracting(Node::getName).containsExactly(TEST_CLASSES);
 
-        var testCases = tests.getTestCases();
-        coverage.mapTests(tests.getAllClassNodes());
+        var unmappedTests = coverage.mergeTests(tests.getAllClassNodes());
+        assertThat(unmappedTests).flatMap(Node::getTestCases).hasSize(10);
+        assertThat(coverage.getTestCases()).hasSize(247);
 
-        testCases.removeAll(coverage.getTestCases());
-        assertThat(testCases).hasSize(10)
-                .extracting(TestCase::getClassName)
+        assertThat(unmappedTests)
+                .extracting(Node::getName)
                 .containsOnly("ArchitectureTest", "PackageArchitectureTest");
 
         assertThat(coverage.findFile("Metric.java")).hasValueSatisfying(


### PR DESCRIPTION
The mapping is done by evaluating the name of the test class. If the name of the test class cannot be mapped to a target class, then the tests of this test class are ignored. All unmapped test classes will be retained so that they can be visualized differently.
