### PR TITLE
Add parser for Clover coverage

### DIFF
--- a/src/main/java/edu/hm/hafner/coverage/CoverageParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/CoverageParser.java
@@ -207,4 +207,17 @@ public abstract class CoverageParser implements Serializable {
     protected static ParsingException createEofException(final String fileName) {
         return new ParsingException("Unexpected end of file '%s'", fileName);
     }
+
+
+    protected static Value createValue(final String currentType, final int covered, final int missed) {
+        if (currentType.equals("COMPLEXITY")) {
+            return new CyclomaticComplexity(covered + missed);
+        }
+        else {
+            var builder = new Coverage.CoverageBuilder();
+            return builder.withMetric(Metric.valueOf(currentType))
+                    .withCovered(covered)
+                    .withMissed(missed).build();
+        }
+    }
 }

--- a/src/main/java/edu/hm/hafner/coverage/CoverageParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/CoverageParser.java
@@ -209,7 +209,7 @@ public abstract class CoverageParser implements Serializable {
     }
 
 
-    protected static Value createValue(final String currentType, final int covered, final int missed) {
+    protected Value createValue(final String currentType, final int covered, final int missed) {
         if (currentType.equals("COMPLEXITY")) {
             return new CyclomaticComplexity(covered + missed);
         }

--- a/src/main/java/edu/hm/hafner/coverage/Metric.java
+++ b/src/main/java/edu/hm/hafner/coverage/Metric.java
@@ -31,7 +31,6 @@ public enum Metric {
     LINE(new ValuesAggregator()),
     BRANCH(new ValuesAggregator()),
     INSTRUCTION(new ValuesAggregator()),
-    CONDITIONAL(new ValuesAggregator()),
 
     /** Additional metrics without children. */
     MUTATION(new ValuesAggregator()),

--- a/src/main/java/edu/hm/hafner/coverage/Metric.java
+++ b/src/main/java/edu/hm/hafner/coverage/Metric.java
@@ -31,6 +31,7 @@ public enum Metric {
     LINE(new ValuesAggregator()),
     BRANCH(new ValuesAggregator()),
     INSTRUCTION(new ValuesAggregator()),
+    CONDITIONAL(new ValuesAggregator()),
 
     /** Additional metrics without children. */
     MUTATION(new ValuesAggregator()),

--- a/src/main/java/edu/hm/hafner/coverage/Node.java
+++ b/src/main/java/edu/hm/hafner/coverage/Node.java
@@ -388,6 +388,9 @@ public abstract class Node implements Serializable {
         return getAll(metric1).stream().map(cast).collect(Collectors.toList());
     }
 
+    public List<PackageNode> getAllPackageNodes() {
+        return getAll(Metric.PACKAGE, PackageNode.class::cast);
+    }
     public List<FileNode> getAllFileNodes() {
         return getAll(Metric.FILE, FileNode.class::cast);
     }

--- a/src/main/java/edu/hm/hafner/coverage/parser/CloverParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/parser/CloverParser.java
@@ -48,7 +48,7 @@ public class CloverParser extends CoverageParser {
                     var tagName = startElement.getName();
                     if (COVERAGE.equals(tagName)) {
                         ModuleNode root = new ModuleNode("");
-                        if (readCoverage(eventReader, root, fileName) == null) {
+                        if (!readCoverage(eventReader, root, fileName).hasChildren()) {
                             handleEmptyResults(fileName, log);
                         } else {
                             return root;
@@ -76,11 +76,7 @@ public class CloverParser extends CoverageParser {
             } else if (event.isEndElement()) {
                 var endElement = event.asEndElement();
                 if (COVERAGE.equals((endElement.getName()))) {
-                    if (root.hasChildren()) {
-                        return root;
-                    } else {
-                        return null;
-                    }
+                    return root;
                 }
             }
         }

--- a/src/main/java/edu/hm/hafner/coverage/parser/CloverParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/parser/CloverParser.java
@@ -1,0 +1,164 @@
+package edu.hm.hafner.coverage.parser;
+
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import edu.hm.hafner.coverage.*;
+import edu.hm.hafner.util.FilteredLog;
+import edu.hm.hafner.util.SecureXmlParserFactory;
+import edu.hm.hafner.util.TreeString;
+
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLEventReader;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.events.StartElement;
+import javax.xml.stream.events.XMLEvent;
+import java.io.Reader;
+
+public class CloverParser extends CoverageParser {
+    private static final java.util.logging.Logger LOGGER = java.util.logging.Logger.getLogger(CloverParser.class.getName());
+
+    private static final long serialVersionUID = -1903059983931698657L;
+
+    private static final QName COVERAGE = new QName("coverage");
+    private static final QName PACKAGE = new QName("package");
+    private static final QName METRICS = new QName("metrics");
+    private static final QName FILE = new QName("file");
+    private static final QName NAME = new QName("name");
+    private static final QName PATH = new QName("path");
+    private static final QName STATEMENTS = new QName("statements");
+    private static final QName COVERED_STATEMENTS = new QName("coveredstatements");
+    private static final QName CONDITIONALS = new QName("conditionals");
+    private static final QName COVERED_CONDITIONALS = new QName("coveredconditionals");
+    private static final QName LINE = new QName("line");
+    private static final QName NUM = new QName("num");
+    private static final QName COUNT = new QName("count");
+
+    public CloverParser(ProcessingMode processingMode) {
+        super(processingMode);
+    }
+
+    @Override
+    protected ModuleNode parseReport(Reader reader, String fileName, FilteredLog log) {
+        try {
+            var factory = new SecureXmlParserFactory();
+            var eventReader = factory.createXmlEventReader(reader);
+
+            while (eventReader.hasNext()) {
+                XMLEvent event = eventReader.nextEvent();
+                if (event.isStartElement()) {
+                    var startElement = event.asStartElement();
+                    var tagName = startElement.getName();
+                    if (COVERAGE.equals(tagName)) {
+                        ModuleNode root = new ModuleNode("");
+                        if (readCoverage(eventReader, root, fileName) == null) {
+                            handleEmptyResults(fileName, log);
+                        } else {
+                            return root;
+                        }
+                    }
+                }
+            }
+            handleEmptyResults(fileName, log);
+            return new ModuleNode("empty");
+        } catch (XMLStreamException exception) {
+            throw new SecureXmlParserFactory.ParsingException(exception);
+        }
+    }
+
+    @CanIgnoreReturnValue
+    private ModuleNode readCoverage(final XMLEventReader reader, final ModuleNode root, String fileName) throws XMLStreamException {
+        while (reader.hasNext()) {
+            XMLEvent event = reader.nextEvent();
+
+            if (event.isStartElement()) {
+                var startElement = event.asStartElement();
+                if (PACKAGE.equals(startElement.getName())) {
+                    readPackage(reader, root, startElement, fileName);
+                }
+            } else if (event.isEndElement()) {
+                var endElement = event.asEndElement();
+                if (COVERAGE.equals((endElement.getName()))) {
+                    if (root.hasChildren()) {
+                        return root;
+                    } else {
+                        return null;
+                    }
+                }
+            }
+        }
+        throw createEofException(fileName);
+    }
+
+    @CanIgnoreReturnValue
+    private PackageNode readPackage(final XMLEventReader reader, final ModuleNode root, final StartElement packageElement, String fileName)
+            throws XMLStreamException {
+        var packageName = getValueOf(packageElement, NAME);
+        var packageNode = root.findOrCreatePackageNode(packageName);
+
+        while (reader.hasNext()) {
+            XMLEvent event = reader.nextEvent();
+
+            if (event.isStartElement()) {
+                var startElement = event.asStartElement();
+                if (FILE.equals(startElement.getName())) {
+                    readFile(reader, packageNode, startElement);
+                }
+            } else if (event.isEndElement()) {
+                var endElement = event.asEndElement();
+                if (PACKAGE.equals((endElement.getName()))) {
+                    return packageNode;
+                }
+            }
+        }
+        throw createEofException(fileName);
+    }
+
+    @CanIgnoreReturnValue
+    private FileNode readFile(final XMLEventReader reader, final PackageNode packageNode, final StartElement fileElement) throws XMLStreamException {
+        String fileName = getValueOf(fileElement, NAME);
+        String className = fileName.substring(0, fileName.lastIndexOf("."));
+        String filePath = getValueOf(fileElement, PATH);
+        // TODO check if filePath is relative or absolute path (latter needs to remove everything except current workspace)
+        var fileNode = packageNode.findOrCreateFileNode(fileName, TreeString.valueOf(filePath));
+        var classNode = packageNode.findOrCreateClassNode(className);
+        while (reader.hasNext()) {
+            XMLEvent event = reader.nextEvent();
+            if (event.isStartElement()) {
+                var e = event.asStartElement();
+                if (METRICS.equals(e.getName())) {
+                    Integer condTotal = getIntegerValueOf(e, CONDITIONALS);
+                    Integer condCovered = getIntegerValueOf(e, COVERED_CONDITIONALS);
+                    Integer stmntsTotal = getIntegerValueOf(e, STATEMENTS);
+                    Integer stmntsCovered = getIntegerValueOf(e, COVERED_STATEMENTS);
+                    classNode.addValue(createValue("CONDITIONAL", condCovered, condTotal - condCovered));
+                    classNode.addValue(createValue("INSTRUCTION", stmntsCovered, stmntsTotal - stmntsCovered));
+
+                } else if (LINE.equals(e.getName())) {
+                    Integer line =  Integer.parseInt(getValueOf(e, NUM));
+                    Integer count = Integer.parseInt(getValueOf(e, COUNT));
+                    if (count > 0) {
+                        fileNode.addCounters(line, count, 0);
+                    } else {
+                        fileNode.addCounters(line, 0, 1);
+                    }
+                } else {
+                    LOGGER.warning("Unexpected element in <file> block: " + e.getName());
+                }
+            } else if (event.isEndElement()) {
+                var endElement = event.asEndElement();
+                if (FILE.equals(endElement.getName())) {
+                    resolveLines(fileNode);
+                    return fileNode;
+                }
+            }
+        }
+        throw createEofException(fileName);
+    }
+
+    private void resolveLines(final FileNode fileNode) {
+        var val = createValue("LINE", fileNode.getCoveredLines().size(), fileNode.getMissedLines().size());
+        fileNode.addValue(val);
+        for (ClassNode c: fileNode.getAllClassNodes()) {
+            c.addValue(val);
+        }
+    }
+}

--- a/src/main/java/edu/hm/hafner/coverage/parser/CloverParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/parser/CloverParser.java
@@ -161,4 +161,15 @@ public class CloverParser extends CoverageParser {
             c.addValue(val);
         }
     }
+
+    public static Value createValue(final String currentType, final int covered, final int missed) {
+        if (currentType.equals("CONDITIONAL")) {
+            var builder = new Coverage.CoverageBuilder();
+            return builder.withMetric(Metric.valueOf("BRANCH"))
+                    .withCovered(covered)
+                    .withMissed(missed).build();
+        } else {
+            return CoverageParser.createValue(currentType, covered, missed);
+        }
+    }
 }

--- a/src/main/java/edu/hm/hafner/coverage/parser/CloverParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/parser/CloverParser.java
@@ -4,6 +4,7 @@ import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import edu.hm.hafner.coverage.*;
 import edu.hm.hafner.util.FilteredLog;
 import edu.hm.hafner.util.SecureXmlParserFactory;
+import edu.hm.hafner.util.SecureXmlParserFactory.ParsingException;
 import edu.hm.hafner.util.TreeString;
 
 import javax.xml.namespace.QName;
@@ -14,8 +15,6 @@ import javax.xml.stream.events.XMLEvent;
 import java.io.Reader;
 
 public class CloverParser extends CoverageParser {
-    private static final java.util.logging.Logger LOGGER = java.util.logging.Logger.getLogger(CloverParser.class.getName());
-
     private static final long serialVersionUID = -1903059983931698657L;
 
     private static final QName COVERAGE = new QName("coverage");
@@ -125,23 +124,23 @@ public class CloverParser extends CoverageParser {
             if (event.isStartElement()) {
                 var e = event.asStartElement();
                 if (METRICS.equals(e.getName())) {
-                    Integer condTotal = getIntegerValueOf(e, CONDITIONALS);
-                    Integer condCovered = getIntegerValueOf(e, COVERED_CONDITIONALS);
-                    Integer stmntsTotal = getIntegerValueOf(e, STATEMENTS);
-                    Integer stmntsCovered = getIntegerValueOf(e, COVERED_STATEMENTS);
+                    int condTotal = getIntegerValueOf(e, CONDITIONALS);
+                    int condCovered = getIntegerValueOf(e, COVERED_CONDITIONALS);
+                    int stmntsTotal = getIntegerValueOf(e, STATEMENTS);
+                    int stmntsCovered = getIntegerValueOf(e, COVERED_STATEMENTS);
                     classNode.addValue(createValue("CONDITIONAL", condCovered, condTotal - condCovered));
                     classNode.addValue(createValue("INSTRUCTION", stmntsCovered, stmntsTotal - stmntsCovered));
 
                 } else if (LINE.equals(e.getName())) {
-                    Integer line =  Integer.parseInt(getValueOf(e, NUM));
-                    Integer count = Integer.parseInt(getValueOf(e, COUNT));
+                    int line =  Integer.parseInt(getValueOf(e, NUM));
+                    int count = Integer.parseInt(getValueOf(e, COUNT));
                     if (count > 0) {
                         fileNode.addCounters(line, count, 0);
                     } else {
                         fileNode.addCounters(line, 0, 1);
                     }
                 } else {
-                    LOGGER.warning("Unexpected element in <file> block: " + e.getName());
+                    new ParsingException(String.format("Unexpected element '%s' in <file> block in file '%s'", e.getName(), fileName));
                 }
             } else if (event.isEndElement()) {
                 var endElement = event.asEndElement();

--- a/src/main/java/edu/hm/hafner/coverage/parser/CloverParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/parser/CloverParser.java
@@ -124,8 +124,8 @@ public class CloverParser extends CoverageParser {
                     int condCovered = getIntegerValueOf(e, COVERED_CONDITIONALS);
                     int stmntsTotal = getIntegerValueOf(e, STATEMENTS);
                     int stmntsCovered = getIntegerValueOf(e, COVERED_STATEMENTS);
-                    classNode.addValue(createValue("CONDITIONAL", condCovered, condTotal - condCovered));
-                    classNode.addValue(createValue("INSTRUCTION", stmntsCovered, stmntsTotal - stmntsCovered));
+                    addBranchCoverage(classNode, condCovered, condTotal);
+                    addInstructionCoverage(classNode, stmntsCovered, stmntsTotal);
 
                 } else if (LINE.equals(e.getName())) {
                     int line =  Integer.parseInt(getValueOf(e, NUM));
@@ -157,14 +157,18 @@ public class CloverParser extends CoverageParser {
         }
     }
 
-    public static Value createValue(final String currentType, final int covered, final int missed) {
-        if (currentType.equals("CONDITIONAL")) {
-            var builder = new Coverage.CoverageBuilder();
-            return builder.withMetric(Metric.valueOf("BRANCH"))
-                    .withCovered(covered)
-                    .withMissed(missed).build();
-        } else {
-            return CoverageParser.createValue(currentType, covered, missed);
-        }
+    private void addBranchCoverage(final ClassNode classNode, final int covered, final int total) {
+        addCoverage(classNode, "BRANCH", covered, total);
+    }
+
+    private void addInstructionCoverage(final ClassNode classNode, final int covered, final int total) {
+        addCoverage(classNode, "INSTRUCTION", covered, total);
+    }
+
+    private void addCoverage(final ClassNode classNode, String metricName, final int covered, final int total) {
+        var builder = new Coverage.CoverageBuilder();
+        classNode.addValue(builder.withMetric(Metric.valueOf(metricName))
+                .withCovered(covered)
+                .withMissed(total - covered).build());
     }
 }

--- a/src/main/java/edu/hm/hafner/coverage/parser/CloverParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/parser/CloverParser.java
@@ -131,7 +131,7 @@ public class CloverParser extends CoverageParser {
                     int line =  Integer.parseInt(getValueOf(e, NUM));
                     int count = Integer.parseInt(getValueOf(e, COUNT));
                     if (count > 0) {
-                        fileNode.addCounters(line, count, 0);
+                        fileNode.addCounters(line, 1, 0);
                     } else {
                         fileNode.addCounters(line, 0, 1);
                     }

--- a/src/main/java/edu/hm/hafner/coverage/parser/CloverParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/parser/CloverParser.java
@@ -32,7 +32,7 @@ public class CloverParser extends CoverageParser {
     private static final QName NUM = new QName("num");
     private static final QName COUNT = new QName("count");
 
-    public CloverParser(ProcessingMode processingMode) {
+    public CloverParser(final ProcessingMode processingMode) {
         super(processingMode);
     }
 

--- a/src/main/java/edu/hm/hafner/coverage/parser/CloverParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/parser/CloverParser.java
@@ -128,8 +128,8 @@ public class CloverParser extends CoverageParser {
                     addInstructionCoverage(classNode, stmntsCovered, stmntsTotal);
 
                 } else if (LINE.equals(e.getName())) {
-                    int line =  Integer.parseInt(getValueOf(e, NUM));
-                    int count = Integer.parseInt(getValueOf(e, COUNT));
+                    int line =  getIntegerValueOf(e, NUM);
+                    int count = getIntegerValueOf(e, COUNT);
                     if (count > 0) {
                         fileNode.addCounters(line, 1, 0);
                     } else {

--- a/src/main/java/edu/hm/hafner/coverage/parser/CloverParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/parser/CloverParser.java
@@ -66,10 +66,7 @@ public class CloverParser extends CoverageParser {
                     var tagName = startElement.getName();
                     if (COVERAGE.equals(tagName)) {
                         ModuleNode root = new ModuleNode("");
-                        if (!readCoverage(eventReader, root, fileName).hasChildren()) {
-                            handleEmptyResults(fileName, log);
-                        }
-                        else {
+                        if (readCoverage(eventReader, root, fileName).hasChildren()) {
                             return root;
                         }
                     }

--- a/src/main/java/edu/hm/hafner/coverage/parser/JacocoParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/parser/JacocoParser.java
@@ -316,16 +316,4 @@ public class JacocoParser extends CoverageParser {
             }
         }
     }
-
-    private Value createValue(final String currentType, final int covered, final int missed) {
-        if (VALUE_COMPLEXITY.equals(currentType)) {
-            return new CyclomaticComplexity(covered + missed);
-        }
-        else {
-            var builder = new CoverageBuilder();
-            return builder.withMetric(Metric.valueOf(currentType))
-                        .withCovered(covered)
-                        .withMissed(missed).build();
-        }
-    }
 }

--- a/src/main/java/edu/hm/hafner/coverage/registry/ParserRegistry.java
+++ b/src/main/java/edu/hm/hafner/coverage/registry/ParserRegistry.java
@@ -1,16 +1,10 @@
 package edu.hm.hafner.coverage.registry;
 
+import edu.hm.hafner.coverage.parser.*;
 import org.apache.commons.lang3.StringUtils;
 
 import edu.hm.hafner.coverage.CoverageParser;
 import edu.hm.hafner.coverage.CoverageParser.ProcessingMode;
-import edu.hm.hafner.coverage.parser.CoberturaParser;
-import edu.hm.hafner.coverage.parser.JacocoParser;
-import edu.hm.hafner.coverage.parser.JunitParser;
-import edu.hm.hafner.coverage.parser.NunitParser;
-import edu.hm.hafner.coverage.parser.OpenCoverParser;
-import edu.hm.hafner.coverage.parser.PitestParser;
-import edu.hm.hafner.coverage.parser.XunitParser;
 
 /**
  * Provides a registry for all available {@link CoverageParserType parsers}.
@@ -26,7 +20,8 @@ public class ParserRegistry {
         JACOCO,
         PIT,
         JUNIT,
-        XUNIT
+        XUNIT,
+        CLOVER
     }
 
     /**
@@ -74,6 +69,8 @@ public class ParserRegistry {
                 return new JunitParser(processingMode);
             case XUNIT:
                 return new XunitParser(processingMode);
+            case CLOVER:
+                return new CloverParser(processingMode);
         }
         throw new IllegalArgumentException("Unknown parser type: " + parser);
     }

--- a/src/test/java/edu/hm/hafner/coverage/parser/CloverParserTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/parser/CloverParserTest.java
@@ -1,12 +1,12 @@
 package edu.hm.hafner.coverage.parser;
 
-import edu.hm.hafner.coverage.CoverageParser;
-import edu.hm.hafner.coverage.FileNode;
-import edu.hm.hafner.coverage.assertions.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.util.HashSet;
-import java.util.Set;
+import edu.hm.hafner.coverage.Coverage.CoverageBuilder;
+import edu.hm.hafner.coverage.CoverageParser;
+import edu.hm.hafner.coverage.Metric;
+
+import static edu.hm.hafner.coverage.assertions.Assertions.*;
 
 class CloverParserTest extends AbstractParserTest {
     @Override
@@ -15,50 +15,56 @@ class CloverParserTest extends AbstractParserTest {
     }
 
     @Override
-    CoverageParser createParser(CoverageParser.ProcessingMode processingMode) {
+    CoverageParser createParser(final CoverageParser.ProcessingMode processingMode) {
         return new CloverParser(processingMode);
     }
 
     @Test
-    void testBasic() throws Exception {
+    void shouldReadCloverReport() {
         var root = readReport("clover.xml");
-        for (FileNode f: root.getAllFileNodes()) {
-            switch(f.getFileName()) {
-                case "File1.js":
-                    Set<Integer> covered = new HashSet<>();
-                    addRange(covered, 4,7);
-                    addRange(covered, 12,22);
-                    addRange(covered, 24,43);
-                    addRange(covered, 45,77);
-                    addRange(covered, 79,77);
-                    Assertions.assertThat(f).hasMissedLines().hasCoveredLines(covered.toArray(new Integer[covered.size()]));
-
-                    break;
-                case "File2.js":
-                    Assertions.assertThat(f).hasMissedLines(92,127,204,369,492,503,515).hasCoveredLines(21,38,51,65,79,105,117,138,151,164,176,190,215,228,243,257,268,287,303,317,329,339,349,359,380,393,405,416,429,443,456,467,480);
-                    break;
-                case "File3.jsx":
-                    Assertions.assertThat(f).hasMissedLines(45,46,78,104,105,106).hasCoveredLines(13,21,26,29,32,60,61,62,89,93,103);
-                    break;
-                case "File4.jsx":
-                    Assertions.assertThat(f).hasMissedLines(8,50,51,58).hasCoveredLines(4,11,14,30,38,43,46,49,57,61,68,72,77,81,85,89,90);
-                    break;
-                case "File5.jsx":
-                    Assertions.assertThat(f).hasMissedLines(25).hasCoveredLines(18,19,20,24,31,50,59);
-                    break;
-                case "File6.jsx":
-                    Assertions.assertThat(f).hasMissedLines(32,33,35,92).hasCoveredLines(23,24,31,38,72,79,90);
-                    break;
-                default:
-                    throw new Exception("Unexpected file: " + f.getFileName());
-            }
-
-        }
-    }
-    private static void addRange(Set<Integer> collection, int start, int end) {
-        // generate a range of integers from start to end (inclusive)
-        for (int i = start; i <= end; i++) {
-            collection.add(i);
-        }
+        var line = new CoverageBuilder().withMetric(Metric.LINE);
+        var branch = new CoverageBuilder().withMetric(Metric.BRANCH);
+        assertThat(root.getAllFileNodes().get(2))
+                .hasFileName("File3.jsx")
+                .hasMissedLines(45, 46, 78, 104, 105, 106)
+                .hasCoveredLines(13, 21, 26, 29, 32, 60, 61, 62, 89, 93, 103)
+                .hasValues(line.withCovered(11).withTotal(17).build());
+        assertThat(root.getAllFileNodes()).satisfiesExactlyInAnyOrder(
+                file -> assertThat(file)
+                        .hasFileName("File1.js")
+                        .hasNoMissedLines()
+                        .hasCoveredLines(4, 5, 6, 7, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 24, 25, 26, 27, 28,
+                                29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 45, 46, 47, 48, 49, 50,
+                                51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72,
+                                73, 74, 75, 76, 77)
+                        .hasValues(line.withCovered(68).withTotal(68).build()),
+                file -> assertThat(file)
+                        .hasFileName("File2.js")
+                        .hasMissedLines(92, 127, 204, 369, 492, 503, 515)
+                        .hasCoveredLines(21, 38, 51, 65, 79, 105, 117, 138, 151, 164, 176, 190, 215, 228, 243, 257,
+                                268, 287, 303, 317, 329, 339, 349, 359, 380, 393, 405, 416, 429, 443, 456, 467, 480)
+                        .hasValues(line.withCovered(33).withTotal(40).build()),
+                file -> assertThat(file)
+                        .hasFileName("File3.jsx")
+                        .hasMissedLines(45, 46, 78, 104, 105, 106)
+                        .hasCoveredLines(13, 21, 26, 29, 32, 60, 61, 62, 89, 93, 103)
+                        .hasValues(line.withCovered(11).withTotal(17).build(),
+                                branch.withCovered(2).withTotal(2).build()),
+                file -> assertThat(file)
+                        .hasFileName("File4.jsx")
+                        .hasMissedLines(8, 50, 51, 58)
+                        .hasCoveredLines(4, 11, 14, 30, 38, 43, 46, 49, 57, 61, 68, 72, 77, 81, 85, 89, 90)
+                        .hasValues(line.withCovered(17).withTotal(21).build()),
+                file -> assertThat(file)
+                        .hasFileName("File5.jsx")
+                        .hasMissedLines(25)
+                        .hasCoveredLines(18, 19, 20, 24, 31, 50, 59)
+                        .hasValues(line.withCovered(7).withTotal(8).build()),
+                file -> assertThat(file)
+                        .hasFileName("File6.jsx")
+                        .hasMissedLines(32, 33, 35, 92)
+                        .hasCoveredLines(23, 24, 31, 38, 72, 79, 90)
+                        .hasValues(line.withCovered(7).withTotal(11).build())
+        );
     }
 }

--- a/src/test/java/edu/hm/hafner/coverage/parser/CloverParserTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/parser/CloverParserTest.java
@@ -1,0 +1,64 @@
+package edu.hm.hafner.coverage.parser;
+
+import edu.hm.hafner.coverage.CoverageParser;
+import edu.hm.hafner.coverage.FileNode;
+import edu.hm.hafner.coverage.assertions.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+class CloverParserTest extends AbstractParserTest {
+    @Override
+    protected String getFolder() {
+        return "clover";
+    }
+
+    @Override
+    CoverageParser createParser(CoverageParser.ProcessingMode processingMode) {
+        return new CloverParser(processingMode);
+    }
+
+    @Test
+    void testBasic() throws Exception {
+        var root = readReport("clover.xml");
+        for (FileNode f: root.getAllFileNodes()) {
+            switch(f.getFileName()) {
+                case "File1.js":
+                    Set<Integer> covered = new HashSet<>();
+                    addRange(covered, 4,7);
+                    addRange(covered, 12,22);
+                    addRange(covered, 24,43);
+                    addRange(covered, 45,77);
+                    addRange(covered, 79,77);
+                    Assertions.assertThat(f).hasMissedLines().hasCoveredLines(covered.toArray(new Integer[covered.size()]));
+
+                    break;
+                case "File2.js":
+                    Assertions.assertThat(f).hasMissedLines(92,127,204,369,492,503,515).hasCoveredLines(21,38,51,65,79,105,117,138,151,164,176,190,215,228,243,257,268,287,303,317,329,339,349,359,380,393,405,416,429,443,456,467,480);
+                    break;
+                case "File3.jsx":
+                    Assertions.assertThat(f).hasMissedLines(45,46,78,104,105,106).hasCoveredLines(13,21,26,29,32,60,61,62,89,93,103);
+                    break;
+                case "File4.jsx":
+                    Assertions.assertThat(f).hasMissedLines(8,50,51,58).hasCoveredLines(4,11,14,30,38,43,46,49,57,61,68,72,77,81,85,89,90);
+                    break;
+                case "File5.jsx":
+                    Assertions.assertThat(f).hasMissedLines(25).hasCoveredLines(18,19,20,24,31,50,59);
+                    break;
+                case "File6.jsx":
+                    Assertions.assertThat(f).hasMissedLines(32,33,35,92).hasCoveredLines(23,24,31,38,72,79,90);
+                    break;
+                default:
+                    throw new Exception("Unexpected file: " + f.getFileName());
+            }
+
+        }
+    }
+    private static void addRange(Set<Integer> collection, int start, int end) {
+        // generate a range of integers from start to end (inclusive)
+        for (int i = start; i <= end; i++) {
+            collection.add(i);
+        }
+    }
+}

--- a/src/test/java/edu/hm/hafner/coverage/parser/CloverParserTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/parser/CloverParserTest.java
@@ -24,11 +24,7 @@ class CloverParserTest extends AbstractParserTest {
         var root = readReport("clover.xml");
         var line = new CoverageBuilder().withMetric(Metric.LINE);
         var branch = new CoverageBuilder().withMetric(Metric.BRANCH);
-        assertThat(root.getAllFileNodes().get(2))
-                .hasFileName("File3.jsx")
-                .hasMissedLines(45, 46, 78, 104, 105, 106)
-                .hasCoveredLines(13, 21, 26, 29, 32, 60, 61, 62, 89, 93, 103)
-                .hasValues(line.withCovered(11).withTotal(17).build());
+        var instruction = new CoverageBuilder().withMetric(Metric.INSTRUCTION);
         assertThat(root.getAllFileNodes()).satisfiesExactlyInAnyOrder(
                 file -> assertThat(file)
                         .hasFileName("File1.js")
@@ -48,8 +44,7 @@ class CloverParserTest extends AbstractParserTest {
                         .hasFileName("File3.jsx")
                         .hasMissedLines(45, 46, 78, 104, 105, 106)
                         .hasCoveredLines(13, 21, 26, 29, 32, 60, 61, 62, 89, 93, 103)
-                        .hasValues(line.withCovered(11).withTotal(17).build(),
-                                branch.withCovered(2).withTotal(2).build()),
+                        .hasValues(line.withCovered(11).withTotal(17).build()),
                 file -> assertThat(file)
                         .hasFileName("File4.jsx")
                         .hasMissedLines(8, 50, 51, 58)
@@ -65,6 +60,31 @@ class CloverParserTest extends AbstractParserTest {
                         .hasMissedLines(32, 33, 35, 92)
                         .hasCoveredLines(23, 24, 31, 38, 72, 79, 90)
                         .hasValues(line.withCovered(7).withTotal(11).build())
+        );
+        assertThat(root.getAllClassNodes()).satisfiesExactlyInAnyOrder(
+                c -> assertThat(c)
+                        .hasName("File1")
+                        .hasValues(instruction.withCovered(68).withTotal(68).build()),
+                c -> assertThat(c)
+                        .hasName("File2")
+                        .hasValues(instruction.withCovered(33).withTotal(40).build(),
+                                branch.withCovered(12).withTotal(17).build()),
+                c -> assertThat(c)
+                        .hasName("File3")
+                        .hasValues(instruction.withCovered(11).withTotal(17).build(),
+                                branch.withCovered(2).withTotal(2).build()),
+                c -> assertThat(c)
+                        .hasName("File4")
+                        .hasValues(instruction.withCovered(17).withTotal(21).build(),
+                                branch.withCovered(2).withTotal(4).build()),
+                c -> assertThat(c)
+                        .hasName("File5")
+                        .hasValues(instruction.withCovered(7).withTotal(8).build(),
+                                branch.withCovered(4).withTotal(6).build()),
+                c -> assertThat(c)
+                        .hasName("File6")
+                        .hasValues(instruction.withCovered(7).withTotal(11).build(),
+                                branch.withCovered(1).withTotal(4).build())
         );
     }
 }

--- a/src/test/java/edu/hm/hafner/coverage/parser/CloverParserTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/parser/CloverParserTest.java
@@ -25,6 +25,25 @@ class CloverParserTest extends AbstractParserTest {
         var line = new CoverageBuilder().withMetric(Metric.LINE);
         var branch = new CoverageBuilder().withMetric(Metric.BRANCH);
         var instruction = new CoverageBuilder().withMetric(Metric.INSTRUCTION);
+        assertThat(root).satisfies(
+                node -> assertThat(node)
+                        .hasValues(instruction.withCovered(2578).withTotal(3057).build(),
+                                branch.withCovered(1068).withTotal(1444).build())
+        );
+        assertThat(root.getAllPackageNodes()).satisfiesExactlyInAnyOrder(
+                pkg -> assertThat(pkg)
+                        .hasName("actions")
+                        .hasValues(instruction.withCovered(212).withTotal(234).build(),
+                                branch.withCovered(12).withTotal(17).build()),
+                pkg -> assertThat(pkg)
+                        .hasName("components")
+                        .hasValues(instruction.withCovered(35).withTotal(46).build(),
+                                branch.withCovered(8).withTotal(12).build()),
+                pkg -> assertThat(pkg)
+                        .hasName("components.AddEditCategories")
+                        .hasValues(instruction.withCovered(33).withTotal(39).build(),
+                                branch.withCovered(1).withTotal(4).build())
+        );
         assertThat(root.getAllFileNodes()).satisfiesExactlyInAnyOrder(
                 file -> assertThat(file)
                         .hasFileName("File1.js")

--- a/src/test/resources/edu/hm/hafner/coverage/parser/clover/clover.xml
+++ b/src/test/resources/edu/hm/hafner/coverage/parser/clover/clover.xml
@@ -1,0 +1,198 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<coverage generated="1695944532781" clover="3.2.0">
+    <project timestamp="1695944532781" name="All files">
+        <metrics statements="3057" coveredstatements="2578" conditionals="1444" coveredconditionals="1068" methods="1003" coveredmethods="736" elements="5504" coveredelements="4382" complexity="0" loc="3057" ncloc="3057" packages="68" files="170" classes="170"/>
+        <package name="actions">
+            <metrics statements="234" coveredstatements="212" conditionals="17" coveredconditionals="12" methods="115" coveredmethods="93"/>
+            <file name="File1.js" path="/home/jenkins/agent/workspace/dir/src/js/actions/File1.js">
+                <metrics statements="68" coveredstatements="68" conditionals="0" coveredconditionals="0" methods="0" coveredmethods="0"/>
+                <line num="4" count="18" type="stmt"/>
+                <line num="5" count="18" type="stmt"/>
+                <line num="6" count="18" type="stmt"/>
+                <line num="7" count="18" type="stmt"/>
+                <line num="12" count="18" type="stmt"/>
+                <line num="13" count="18" type="stmt"/>
+                <line num="14" count="18" type="stmt"/>
+                <line num="15" count="18" type="stmt"/>
+                <line num="16" count="18" type="stmt"/>
+                <line num="17" count="18" type="stmt"/>
+                <line num="18" count="18" type="stmt"/>
+                <line num="19" count="18" type="stmt"/>
+                <line num="20" count="18" type="stmt"/>
+                <line num="21" count="18" type="stmt"/>
+                <line num="22" count="18" type="stmt"/>
+                <line num="24" count="18" type="stmt"/>
+                <line num="25" count="18" type="stmt"/>
+                <line num="26" count="18" type="stmt"/>
+                <line num="27" count="18" type="stmt"/>
+                <line num="28" count="18" type="stmt"/>
+                <line num="29" count="18" type="stmt"/>
+                <line num="30" count="18" type="stmt"/>
+                <line num="31" count="18" type="stmt"/>
+                <line num="32" count="18" type="stmt"/>
+                <line num="33" count="18" type="stmt"/>
+                <line num="34" count="18" type="stmt"/>
+                <line num="35" count="18" type="stmt"/>
+                <line num="36" count="18" type="stmt"/>
+                <line num="37" count="18" type="stmt"/>
+                <line num="38" count="18" type="stmt"/>
+                <line num="39" count="18" type="stmt"/>
+                <line num="40" count="18" type="stmt"/>
+                <line num="41" count="18" type="stmt"/>
+                <line num="42" count="18" type="stmt"/>
+                <line num="43" count="18" type="stmt"/>
+                <line num="45" count="18" type="stmt"/>
+                <line num="46" count="18" type="stmt"/>
+                <line num="47" count="18" type="stmt"/>
+                <line num="48" count="18" type="stmt"/>
+                <line num="49" count="18" type="stmt"/>
+                <line num="50" count="18" type="stmt"/>
+                <line num="51" count="18" type="stmt"/>
+                <line num="52" count="18" type="stmt"/>
+                <line num="53" count="18" type="stmt"/>
+                <line num="54" count="18" type="stmt"/>
+                <line num="55" count="18" type="stmt"/>
+                <line num="56" count="18" type="stmt"/>
+                <line num="57" count="18" type="stmt"/>
+                <line num="58" count="18" type="stmt"/>
+                <line num="59" count="18" type="stmt"/>
+                <line num="60" count="18" type="stmt"/>
+                <line num="61" count="18" type="stmt"/>
+                <line num="62" count="18" type="stmt"/>
+                <line num="63" count="18" type="stmt"/>
+                <line num="64" count="18" type="stmt"/>
+                <line num="65" count="18" type="stmt"/>
+                <line num="66" count="18" type="stmt"/>
+                <line num="67" count="18" type="stmt"/>
+                <line num="68" count="18" type="stmt"/>
+                <line num="69" count="18" type="stmt"/>
+                <line num="70" count="18" type="stmt"/>
+                <line num="71" count="18" type="stmt"/>
+                <line num="72" count="18" type="stmt"/>
+                <line num="73" count="18" type="stmt"/>
+                <line num="74" count="18" type="stmt"/>
+                <line num="75" count="18" type="stmt"/>
+                <line num="76" count="18" type="stmt"/>
+                <line num="77" count="18" type="stmt"/>
+            </file>
+            <file name="File2.js" path="/home/jenkins/agent/workspace/dir/src/js/actions/File2.js">
+                <metrics statements="40" coveredstatements="33" conditionals="17" coveredconditionals="12" methods="115" coveredmethods="93"/>
+                <line num="21" count="19" type="stmt"/>
+                <line num="38" count="1" type="stmt"/>
+                <line num="51" count="163" type="stmt"/>
+                <line num="65" count="149" type="stmt"/>
+                <line num="79" count="1" type="stmt"/>
+                <line num="92" count="0" type="stmt"/>
+                <line num="105" count="1" type="stmt"/>
+                <line num="117" count="15" type="stmt"/>
+                <line num="127" count="0" type="stmt"/>
+                <line num="138" count="11" type="stmt"/>
+                <line num="151" count="25" type="stmt"/>
+                <line num="164" count="26" type="stmt"/>
+                <line num="176" count="24" type="stmt"/>
+                <line num="190" count="72" type="stmt"/>
+                <line num="204" count="0" type="stmt"/>
+                <line num="215" count="32" type="stmt"/>
+                <line num="228" count="32" type="stmt"/>
+                <line num="243" count="4" type="stmt"/>
+                <line num="257" count="24" type="stmt"/>
+                <line num="268" count="1" type="stmt"/>
+                <line num="287" count="10" type="stmt"/>
+                <line num="303" count="1" type="stmt"/>
+                <line num="317" count="5" type="stmt"/>
+                <line num="329" count="11" type="stmt"/>
+                <line num="339" count="1" type="stmt"/>
+                <line num="349" count="2" type="stmt"/>
+                <line num="359" count="4" type="stmt"/>
+                <line num="369" count="0" type="stmt"/>
+                <line num="380" count="44" type="stmt"/>
+                <line num="393" count="32" type="stmt"/>
+                <line num="405" count="2" type="stmt"/>
+                <line num="416" count="4" type="stmt"/>
+                <line num="429" count="1" type="stmt"/>
+                <line num="443" count="1" type="stmt"/>
+                <line num="456" count="8" type="stmt"/>
+                <line num="467" count="2" type="stmt"/>
+                <line num="480" count="2" type="stmt"/>
+                <line num="492" count="0" type="stmt"/>
+                <line num="503" count="0" type="stmt"/>
+                <line num="515" count="0" type="stmt"/>
+            </file>
+        </package>
+        <package name="components">
+            <metrics statements="46" coveredstatements="35" conditionals="12" coveredconditionals="8" methods="17" coveredmethods="7"/>
+            <file name="File3.jsx" path="/home/jenkins/agent/workspace/dir/src/js/components/File3.jsx">
+                <metrics statements="17" coveredstatements="11" conditionals="2" coveredconditionals="2" methods="8" coveredmethods="3"/>
+                <line num="13" count="1" type="stmt"/>
+                <line num="21" count="1" type="stmt"/>
+                <line num="26" count="1" type="stmt"/>
+                <line num="29" count="1" type="stmt"/>
+                <line num="32" count="1" type="stmt"/>
+                <line num="45" count="0" type="stmt"/>
+                <line num="46" count="0" type="stmt"/>
+                <line num="60" count="145" type="stmt"/>
+                <line num="61" count="145" type="cond" truecount="2" falsecount="0"/>
+                <line num="62" count="1" type="stmt"/>
+                <line num="78" count="0" type="stmt"/>
+                <line num="89" count="144" type="stmt"/>
+                <line num="93" count="1" type="stmt"/>
+                <line num="103" count="1" type="stmt"/>
+                <line num="104" count="0" type="stmt"/>
+                <line num="105" count="0" type="stmt"/>
+                <line num="106" count="0" type="stmt"/>
+            </file>
+            <file name="File4.jsx" path="/home/jenkins/agent/workspace/dir/src/js/components/File4.jsx">
+                <metrics statements="21" coveredstatements="17" conditionals="4" coveredconditionals="2" methods="7" coveredmethods="3"/>
+                <line num="4" count="3" type="stmt"/>
+                <line num="8" count="0" type="stmt"/>
+                <line num="11" count="3" type="stmt"/>
+                <line num="14" count="28" type="stmt"/>
+                <line num="30" count="3" type="stmt"/>
+                <line num="38" count="3" type="stmt"/>
+                <line num="43" count="3" type="stmt"/>
+                <line num="46" count="1697" type="cond" truecount="2" falsecount="0"/>
+                <line num="49" count="3" type="stmt"/>
+                <line num="50" count="0" type="stmt"/>
+                <line num="51" count="0" type="cond" truecount="0" falsecount="2"/>
+                <line num="57" count="3" type="stmt"/>
+                <line num="58" count="0" type="stmt"/>
+                <line num="61" count="3" type="stmt"/>
+                <line num="68" count="3" type="stmt"/>
+                <line num="72" count="3" type="stmt"/>
+                <line num="77" count="3" type="stmt"/>
+                <line num="81" count="3" type="stmt"/>
+                <line num="85" count="3" type="stmt"/>
+                <line num="89" count="3" type="stmt"/>
+                <line num="90" count="4" type="stmt"/>
+            </file>
+            <file name="File5.jsx" path="/home/jenkins/agent/workspace/dir/src/js/components/File5.jsx">
+                <metrics statements="8" coveredstatements="7" conditionals="6" coveredconditionals="4" methods="2" coveredmethods="1"/>
+                <line num="18" count="1" type="stmt"/>
+                <line num="19" count="2" type="stmt"/>
+                <line num="20" count="2" type="stmt"/>
+                <line num="24" count="2" type="cond" truecount="3" falsecount="1"/>
+                <line num="25" count="0" type="stmt"/>
+                <line num="31" count="2" type="stmt"/>
+                <line num="50" count="1" type="stmt"/>
+                <line num="59" count="1" type="stmt"/>
+            </file>
+        </package>
+        <package name="components.AddEditCategories">
+            <metrics statements="39" coveredstatements="33" conditionals="4" coveredconditionals="1" methods="12" coveredmethods="7"/>
+            <file name="File6.jsx" path="/home/jenkins/agent/workspace/dir/src/js/components/AddEditCategories/File6.jsx">
+                <metrics statements="11" coveredstatements="7" conditionals="4" coveredconditionals="1" methods="5" coveredmethods="2"/>
+                <line num="23" count="1" type="stmt"/>
+                <line num="24" count="2" type="stmt"/>
+                <line num="31" count="2" type="stmt"/>
+                <line num="32" count="0" type="cond" truecount="0" falsecount="2"/>
+                <line num="33" count="0" type="stmt"/>
+                <line num="35" count="0" type="stmt"/>
+                <line num="38" count="2" type="stmt"/>
+                <line num="72" count="24" type="stmt"/>
+                <line num="79" count="1" type="stmt"/>
+                <line num="90" count="1" type="stmt"/>
+                <line num="92" count="0" type="stmt"/>
+            </file>
+        </package>
+    </project>
+</coverage>

--- a/src/test/resources/edu/hm/hafner/coverage/parser/clover/empty.xml
+++ b/src/test/resources/edu/hm/hafner/coverage/parser/clover/empty.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<coverage generated="1695944532781" clover="3.2.0">
+</coverage>


### PR DESCRIPTION
Adding a parser for Python coverage files.

### Testing done
Yesting was done in both with unit tests and a test coverage file (based on real coverage files). As well as on a local Jenkins, where a local version of the Jenkins coverage-plugin was installed to use this coverage model. Ran a simple Python pipeline and validated the coverage output was available in the UI.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
