### PR TITLE
Restore old API for `merge`

### DIFF
--- a/src/main/java/edu/hm/hafner/coverage/Node.java
+++ b/src/main/java/edu/hm/hafner/coverage/Node.java
@@ -694,7 +694,7 @@ public abstract class Node implements Serializable {
      *
      * @return a new tree with the merged {@link Node nodes}
      */
-    public static Node merge(final List<Node> nodes) {
+    public static Node merge(final List<? extends Node> nodes) {
         if (nodes.isEmpty()) {
             throw new IllegalArgumentException("Cannot merge an empty list of nodes");
         }
@@ -707,6 +707,7 @@ public abstract class Node implements Serializable {
 
         if (grouped.size() == 1) {
             return nodes.stream()
+                    .map(Node.class::cast)
                     .reduce(Node::merge)
                     .orElseThrow(() -> new NoSuchElementException("No node found"));
         }


### PR DESCRIPTION
The API is better usable with a type of `List<? extends Node>`.