### PR TITLE
JENKINS-73325: Use ID when merging nodes

### DIFF
--- a/src/main/java/edu/hm/hafner/coverage/Node.java
+++ b/src/main/java/edu/hm/hafner/coverage/Node.java
@@ -764,7 +764,7 @@ public abstract class Node implements Serializable {
 
         other.getChildren().forEach(otherChild -> {
             Optional<Node> existingChild = getChildren().stream()
-                    .filter(c -> c.getName().equals(otherChild.getName())).findFirst();
+                    .filter(c -> c.getId().equals(otherChild.getId())).findFirst();
             if (existingChild.isPresent()) {
                 existingChild.get().mergeNode(otherChild);
             }

--- a/src/test/java/edu/hm/hafner/coverage/parser/CoberturaParserTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/parser/CoberturaParserTest.java
@@ -43,7 +43,7 @@ class CoberturaParserTest extends AbstractParserTest {
 
     @Test
     @Issue("JENKINS-73325")
-    void shouldUseFullPath() {
+    void shouldUseFullPathWhenParsingFileNodes() {
         Node root = readReport("cobertura-same-filename.xml");
 
         assertThat(root.getAllFileNodes()).hasSize(2)
@@ -54,7 +54,7 @@ class CoberturaParserTest extends AbstractParserTest {
 
     @Test
     @Issue("JENKINS-73325")
-    void shouldMergeFiles() {
+    void shouldMergeFilesThatUseSameFileNameInDifferentFolder() {
         Node left = readReport("merge-duplicate-a.xml");
         Node right = readReport("merge-duplicate-b.xml");
 

--- a/src/test/java/edu/hm/hafner/coverage/parser/CoberturaParserTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/parser/CoberturaParserTest.java
@@ -19,6 +19,7 @@ import edu.hm.hafner.coverage.ModuleNode;
 import edu.hm.hafner.coverage.Node;
 import edu.hm.hafner.coverage.Percentage;
 import edu.hm.hafner.coverage.Value;
+import edu.hm.hafner.coverage.assertions.Assertions;
 
 import static edu.hm.hafner.coverage.Metric.CLASS;
 import static edu.hm.hafner.coverage.Metric.FILE;
@@ -46,12 +47,22 @@ class CoberturaParserTest extends AbstractParserTest {
         Node root = readReport("cobertura-same-filename.xml");
 
         assertThat(root.getAllFileNodes()).hasSize(2)
-                .first().isInstanceOfSatisfying(FileNode.class,
-                        first -> assertThat(first).hasName("MyClass.cs").hasRelativePath("/src/NamespaceA/MyClass.cs"));
-        assertThat(root.getAllFileNodes()).hasSize(2)
                 .satisfiesExactlyInAnyOrder(
                         file -> assertThat(file).hasName("MyClass.cs").hasRelativePath("/src/NamespaceA/MyClass.cs"),
                         file -> assertThat(file).hasName("MyClass.cs").hasRelativePath("/src/NamespaceB/MyClass.cs"));
+    }
+
+    @Test
+    @Issue("JENKINS-73325")
+    void shouldMergeFiles() {
+        Node left = readReport("merge-duplicate-a.xml");
+        Node right = readReport("merge-duplicate-b.xml");
+
+        var aggregation = left.merge(right);
+        assertThat(aggregation.getAllFileNodes()).hasSize(2)
+                .satisfiesExactlyInAnyOrder(
+                        file -> Assertions.assertThat(file).hasName("MyClass.cs").hasRelativePath("/src/Domain/NamespaceA/MyClass.cs"),
+                        file -> Assertions.assertThat(file).hasName("MyClass.cs").hasRelativePath("/src/Domain/NamespaceB/MyClass.cs"));
     }
 
     @Test

--- a/src/test/java/edu/hm/hafner/coverage/parser/CoberturaParserTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/parser/CoberturaParserTest.java
@@ -41,6 +41,20 @@ class CoberturaParserTest extends AbstractParserTest {
     }
 
     @Test
+    @Issue("JENKINS-73325")
+    void shouldUseFullPath() {
+        Node root = readReport("cobertura-same-filename.xml");
+
+        assertThat(root.getAllFileNodes()).hasSize(2)
+                .first().isInstanceOfSatisfying(FileNode.class,
+                        first -> assertThat(first).hasName("MyClass.cs").hasRelativePath("/src/NamespaceA/MyClass.cs"));
+        assertThat(root.getAllFileNodes()).hasSize(2)
+                .satisfiesExactlyInAnyOrder(
+                        file -> assertThat(file).hasName("MyClass.cs").hasRelativePath("/src/NamespaceA/MyClass.cs"),
+                        file -> assertThat(file).hasName("MyClass.cs").hasRelativePath("/src/NamespaceB/MyClass.cs"));
+    }
+
+    @Test
     @Issue("JENKINS-73175")
     void shouldAutoGenerateNamesForRuby() {
         Node root = readReport("cobertura-ruby.xml");

--- a/src/test/resources/edu/hm/hafner/coverage/parser/cobertura/cobertura-same-filename.xml
+++ b/src/test/resources/edu/hm/hafner/coverage/parser/cobertura/cobertura-same-filename.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">
+<coverage line-rate="1" branch-rate="1" lines-covered="12" lines-valid="12" branches-covered="6" branches-valid="6" complexity="6" version="0" timestamp="1675424586">
+  <sources>
+    <source>D:\</source>
+  </sources>
+  <packages>
+    <package name="Numbers" line-rate="1" branch-rate="1" complexity="6">
+      <classes>
+        <class name="NamespaceA.MyClass" filename="/src/NamespaceA/MyClass.cs" line-rate="1" branch-rate="0.6" complexity="3">
+          <methods>
+            <method name="Method" signature="System.Void ()" line-rate="1" branch-rate="0.5" complexity="3">
+              <lines>
+                <line number="17" hits="2" branch="true" condition-coverage="50% (2/4)">
+                  <conditions>
+                    <condition number="1779" type="jump" coverage="50%" />
+                  </conditions>
+                </line>
+              </lines>
+            </method>
+          </methods>
+        </class>
+        <class name="NamespaceB.MyClass" filename="/src/NamespaceB/MyClass.cs" line-rate="0" branch-rate="0" complexity="4">
+          <methods>
+            <method name="Method" signature="System.Void ()" line-rate="0" branch-rate="0" complexity="4">
+              <lines>
+                <line number="17" hits="0" branch="true" condition-coverage="0% (0/6)">
+                  <conditions>
+                    <condition number="3339" type="jump" coverage="0%" />
+                  </conditions>
+                </line>
+              </lines>
+            </method>
+          </methods>
+        </class>
+      </classes>
+    </package>
+  </packages>
+</coverage>

--- a/src/test/resources/edu/hm/hafner/coverage/parser/cobertura/merge-duplicate-a.xml
+++ b/src/test/resources/edu/hm/hafner/coverage/parser/cobertura/merge-duplicate-a.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">
+<coverage line-rate="0.02" branch-rate="0.02" lines-covered="417" lines-valid="18516" branches-covered="112" branches-valid="5820" complexity="19" version="8.8.0.0" timestamp="1715002690">
+  <sources>
+    <source>D:\</source>
+  </sources>
+  <packages>
+    <package name="Domain" line-rate="0.04" branch-rate="0.03" complexity="1.95">
+      <classes>
+        <class name="Domain.NamespaceA.MyClass" filename="/src/Domain/NamespaceA/MyClass.cs" line-rate="0" branch-rate="0" complexity="4">
+          <methods>
+            <method name="Method" signature="System.Void ()" line-rate="0" branch-rate="0" complexity="4">
+              <lines>
+                <line number="17" hits="0" branch="true" condition-coverage="0% (0/6)">
+                  <conditions>
+                    <condition number="3339" type="jump" coverage="0%" />
+                  </conditions>
+                </line>
+              </lines>
+            </method>
+          </methods>
+          <lines>
+            <line number="17" hits="0" branch="true" condition-coverage="0% (0/6)">
+              <conditions>
+                <condition number="3339" type="jump" coverage="0%" />
+              </conditions>
+            </line>
+          </lines>
+        </class>
+        <class name="Domain.NamespaceB.MyClass" filename="/src/Domain/NamespaceB/MyClass.cs" line-rate="1" branch-rate="0.6" complexity="3">
+          <methods>
+            <method name="Method" signature="System.Void ()" line-rate="1" branch-rate="0.5" complexity="3">
+              <lines>
+                <line number="17" hits="2" branch="true" condition-coverage="50% (2/4)">
+                  <conditions>
+                    <condition number="1779" type="jump" coverage="50%" />
+                  </conditions>
+                </line>
+              </lines>
+            </method>
+          </methods>
+          <lines>
+            <line number="17" hits="2" branch="true" condition-coverage="50% (2/4)">
+              <conditions>
+                <condition number="1779" type="jump" coverage="50%" />
+              </conditions>
+            </line>
+          </lines>
+        </class>
+      </classes>
+    </package>
+  </packages>
+</coverage>

--- a/src/test/resources/edu/hm/hafner/coverage/parser/cobertura/merge-duplicate-b.xml
+++ b/src/test/resources/edu/hm/hafner/coverage/parser/cobertura/merge-duplicate-b.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">
+<coverage line-rate="0" branch-rate="0" lines-covered="93" lines-valid="36985" branches-covered="18" branches-valid="11402" complexity="61" version="8.8.0.0" timestamp="1718963829">
+  <sources>
+    <source>D:\</source>
+  </sources>
+  <packages>
+    <package name="Domain" line-rate="0" branch-rate="0" complexity="1.95">
+      <classes>
+        <class name="Domain.NamespaceA.MyClass" filename="/src/Domain/NamespaceA/MyClass.cs" line-rate="0" branch-rate="0" complexity="4">
+          <methods>
+            <method name="Validate" signature="System.Void ()" line-rate="0" branch-rate="0" complexity="4">
+              <lines>
+                <line number="17" hits="0" branch="true" condition-coverage="0% (0/6)">
+                  <conditions>
+                    <condition number="3339" type="jump" coverage="0%" />
+                  </conditions>
+                </line>
+              </lines>
+            </method>
+          </methods>
+          <lines>
+            <line number="17" hits="0" branch="true" condition-coverage="0% (0/6)">
+              <conditions>
+                <condition number="3339" type="jump" coverage="0%" />
+              </conditions>
+            </line>
+          </lines>
+        </class>
+        <class name="Domain.NamespaceB.MyClass" filename="/src/Domain/NamespaceB/MyClass.cs" line-rate="0" branch-rate="0" complexity="3">
+          <methods>
+            <method name="Validate" signature="System.Void ()" line-rate="0" branch-rate="0" complexity="3">
+              <lines>
+                <line number="17" hits="0" branch="true" condition-coverage="0% (0/4)">
+                  <conditions>
+                    <condition number="1779" type="jump" coverage="0%" />
+                  </conditions>
+                </line>
+              </lines>
+            </method>
+          </methods>
+          <lines>
+            <line number="17" hits="0" branch="true" condition-coverage="0% (0/4)">
+              <conditions>
+                <condition number="1779" type="jump" coverage="0%" />
+              </conditions>
+            </line>
+          </lines>
+        </class>
+      </classes>
+    </package>
+  </packages>
+</coverage>


### PR DESCRIPTION
In #113 we replaced `name` with `id` when comparing nodes. It seems that we forgot to apply this behavioral change when merging nodes as well.

See https://issues.jenkins.io/browse/JENKINS-73352.