### PR TITLE
Move the parsing exception to the model

### DIFF
--- a/src/main/java/edu/hm/hafner/coverage/parser/AbstractTestParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/parser/AbstractTestParser.java
@@ -15,7 +15,6 @@ import edu.hm.hafner.coverage.ModuleNode;
 import edu.hm.hafner.coverage.TestCase;
 import edu.hm.hafner.util.FilteredLog;
 import edu.hm.hafner.util.SecureXmlParserFactory;
-import edu.hm.hafner.util.SecureXmlParserFactory.ParsingException;
 
 /**
  * Baseclass for test result parsers.

--- a/src/main/java/edu/hm/hafner/coverage/parser/CoberturaParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/parser/CoberturaParser.java
@@ -26,7 +26,6 @@ import edu.hm.hafner.coverage.PackageNode;
 import edu.hm.hafner.util.FilteredLog;
 import edu.hm.hafner.util.PathUtil;
 import edu.hm.hafner.util.SecureXmlParserFactory;
-import edu.hm.hafner.util.SecureXmlParserFactory.ParsingException;
 
 /**
  * Parses Cobertura reports into a hierarchical Java Object Model.
@@ -218,7 +217,7 @@ public class CoberturaParser extends CoverageParser {
         if (CLASS.equals(element.getName())) {
             return createClassNode(parentNode, log, name);
         }
-        
+
         return createMethodNode(parentNode, element, log, name);
     }
 

--- a/src/main/java/edu/hm/hafner/coverage/parser/JacocoParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/parser/JacocoParser.java
@@ -28,7 +28,6 @@ import edu.hm.hafner.coverage.Value;
 import edu.hm.hafner.util.FilteredLog;
 import edu.hm.hafner.util.PathUtil;
 import edu.hm.hafner.util.SecureXmlParserFactory;
-import edu.hm.hafner.util.SecureXmlParserFactory.ParsingException;
 import edu.hm.hafner.util.TreeString;
 
 /**

--- a/src/main/java/edu/hm/hafner/coverage/parser/OpenCoverParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/parser/OpenCoverParser.java
@@ -29,7 +29,6 @@ import edu.hm.hafner.coverage.PackageNode;
 import edu.hm.hafner.util.FilteredLog;
 import edu.hm.hafner.util.PathUtil;
 import edu.hm.hafner.util.SecureXmlParserFactory;
-import edu.hm.hafner.util.SecureXmlParserFactory.ParsingException;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**

--- a/src/main/java/edu/hm/hafner/coverage/parser/PitestParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/parser/PitestParser.java
@@ -22,7 +22,6 @@ import edu.hm.hafner.coverage.Mutation.MutationBuilder;
 import edu.hm.hafner.coverage.MutationStatus;
 import edu.hm.hafner.util.FilteredLog;
 import edu.hm.hafner.util.SecureXmlParserFactory;
-import edu.hm.hafner.util.SecureXmlParserFactory.ParsingException;
 
 /**
  * Parses reports created by PITest into a Java object model.

--- a/src/test/java/edu/hm/hafner/coverage/parser/AbstractParserTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/parser/AbstractParserTest.java
@@ -14,10 +14,10 @@ import org.junit.jupiter.api.Test;
 import com.google.errorprone.annotations.MustBeClosed;
 
 import edu.hm.hafner.coverage.CoverageParser;
+import edu.hm.hafner.coverage.CoverageParser.ParsingException;
 import edu.hm.hafner.coverage.CoverageParser.ProcessingMode;
 import edu.hm.hafner.coverage.ModuleNode;
 import edu.hm.hafner.util.FilteredLog;
-import edu.hm.hafner.util.SecureXmlParserFactory.ParsingException;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import static edu.hm.hafner.coverage.assertions.Assertions.*;


### PR DESCRIPTION
It makes no sense to reuse this exception, especially when there are non XML parsers used in the future.