### PR TITLE
[JENKINS-73663] Fix pom flattening so that parent deps are included now

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,8 @@
                   <goal>flatten</goal>
                 </goals>
                 <configuration>
-                  <flattenMode>oss</flattenMode>
+                  <flattenMode>ossrh</flattenMode>
+                  <flattenDependencyMode>all</flattenDependencyMode>
                   <outputDirectory>${project.build.directory}</outputDirectory>
                   <flattenedPomFilename>${project.artifactId}-${project.version}.pom</flattenedPomFilename>
                 </configuration>


### PR DESCRIPTION
Fix POM flattening configuration: now all artifacts are correctly added to the list of dependencies.

See [JENKINS-73663](https://issues.jenkins.io/browse/JENKINS-73663)