### PR TITLE
Retain the number of total tests after mapping the tests to classes

### DIFF
--- a/src/main/java/edu/hm/hafner/coverage/Metric.java
+++ b/src/main/java/edu/hm/hafner/coverage/Metric.java
@@ -259,11 +259,10 @@ public enum Metric {
             return LINE.getValueFor(node).map(this::getTotal);
         }
 
+        @SuppressFBWarnings(value = "BC", justification = "The value is a coverage value as it has the metric LINE")
         private Value getTotal(final Value leaf) {
-            if (leaf instanceof final Coverage coverage) {
-                return new Value(LOC, coverage.getTotal());
-            }
-            return Value.nullObject(LOC);
+            var coverage = (Coverage) leaf;
+            return new Value(LOC, coverage.getTotal());
         }
     }
 

--- a/src/main/java/edu/hm/hafner/coverage/Node.java
+++ b/src/main/java/edu/hm/hafner/coverage/Node.java
@@ -672,6 +672,13 @@ public abstract class Node implements Serializable {
      * @return the test classes that have not been merged into this coverage tree
      */
     public Set<ClassNode> mergeTests(final Collection<ClassNode> testClassNodes) {
+        var totalTests = testClassNodes.stream().map(testClass -> testClass.getValue(Metric.TESTS))
+                .flatMap(Optional::stream)
+                .reduce(Value::add)
+                .map(Value::asInteger)
+                .orElse(0);
+        addValue(new Value(Metric.TESTS, totalTests));
+
         return testClassNodes.stream()
                 .map(this::mapTestClass)
                 .flatMap(Optional::stream)

--- a/src/test/java/edu/hm/hafner/coverage/MetricTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/MetricTest.java
@@ -68,18 +68,27 @@ class MetricTest {
     @Test
     void shouldCorrectlyComputeDensityEvaluator() {
         var node = new PackageNode("package");
-        node.addValue(new Coverage.CoverageBuilder().withMetric(Metric.LINE).withCovered(5).withMissed(5).build());
-        node.addValue(new Value(Metric.CYCLOMATIC_COMPLEXITY, 10));
 
-        var loc = Metric.LOC.getValueFor(node).get();
-        assertThat(loc.asInteger()).isEqualTo(10);
-        assertThat(loc)
-                .hasMetric(Metric.LOC)
-                .hasFraction(Fraction.getFraction(10, 1));
-        var complexityDensity = Metric.CYCLOMATIC_COMPLEXITY_DENSITY.getValueFor(node).get();
-        assertThat(complexityDensity)
-                .hasMetric(Metric.CYCLOMATIC_COMPLEXITY_DENSITY)
-                .hasFraction(Fraction.getFraction(10, 10));
+        node.addValue(new Value(Metric.CYCLOMATIC_COMPLEXITY, 10));
+        assertThat(Metric.LOC.getValueFor(node)).isEmpty(); // no line coverage yet
+
+        node.addValue(new Coverage.CoverageBuilder().withMetric(Metric.LINE).withCovered(5).withMissed(5).build());
+
+        assertThat(Metric.LOC.getValueFor(node)).hasValueSatisfying(loc -> {
+            assertThat(loc.asInteger()).isEqualTo(10);
+            assertThat(loc.asText()).isEqualTo("10");
+            assertThat(loc)
+                    .hasMetric(Metric.LOC)
+                    .hasFraction(Fraction.getFraction(10, 1));
+        });
+
+        assertThat(Metric.CYCLOMATIC_COMPLEXITY_DENSITY.getValueFor(node)).hasValueSatisfying(complexity -> {
+            assertThat(complexity.asInteger()).isEqualTo(1);
+            assertThat(complexity.asText()).isEqualTo("1");
+            assertThat(complexity)
+                    .hasMetric(Metric.CYCLOMATIC_COMPLEXITY_DENSITY)
+                    .hasFraction(Fraction.getFraction(10, 10));
+        });
     }
 
     @Test

--- a/src/test/java/edu/hm/hafner/coverage/parser/TestCaseMappingTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/parser/TestCaseMappingTest.java
@@ -8,9 +8,11 @@ import java.util.Objects;
 import org.junit.jupiter.api.Test;
 
 import edu.hm.hafner.coverage.CoverageParser;
+import edu.hm.hafner.coverage.Metric;
 import edu.hm.hafner.coverage.ModuleNode;
 import edu.hm.hafner.coverage.Node;
 import edu.hm.hafner.coverage.TestCase;
+import edu.hm.hafner.coverage.Value;
 import edu.hm.hafner.util.FilteredLog;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -74,12 +76,15 @@ class TestCaseMappingTest {
         assertThat(coverage.getFiles()).hasSize(26);
 
         var tests = readReport("junit.xml", new JunitParser());
-        assertThat(tests.getTestCases()).hasSize(257);
+        var numberOfTests = 257;
+        assertThat(tests.getTestCases()).hasSize(numberOfTests);
         assertThat(tests.getAllClassNodes()).extracting(Node::getName).containsExactly(TEST_CLASSES);
+        assertThat(tests.getValue(Metric.TESTS)).contains(new Value(Metric.TESTS, numberOfTests));
 
         var unmappedTests = coverage.mergeTests(tests.getAllClassNodes());
         assertThat(unmappedTests).flatMap(Node::getTestCases).hasSize(10);
         assertThat(coverage.getTestCases()).hasSize(247);
+        assertThat(coverage.getValue(Metric.TESTS)).contains(new Value(Metric.TESTS, numberOfTests));
 
         assertThat(unmappedTests)
                 .extracting(Node::getName)


### PR DESCRIPTION
When the test cases are mapped to the coverage tree then we should not ignore those tests that could not be automatically be mapped. It makes more sense to attach the correct metric value to the tree, even though the tests within the tree are smaller.