### PR TITLE
Improve exception handling if metric is missing

### DIFF
--- a/src/main/java/edu/hm/hafner/coverage/Metric.java
+++ b/src/main/java/edu/hm/hafner/coverage/Metric.java
@@ -8,6 +8,8 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Stream;
 
+import org.apache.commons.lang3.StringUtils;
+
 import com.google.errorprone.annotations.Immutable;
 
 import edu.hm.hafner.coverage.Coverage.CoverageBuilder;
@@ -79,7 +81,10 @@ public enum Metric {
                 return metric;
             }
         }
-        throw new IllegalArgumentException("No metric found for name: " + name);
+        if (StringUtils.isBlank(name)) {
+            throw new IllegalArgumentException("No metric defined");
+        }
+        throw new IllegalArgumentException("No metric found for name '" + name + "'");
     }
 
     private static String normalize(final String name) {

--- a/src/test/java/edu/hm/hafner/coverage/MetricTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/MetricTest.java
@@ -23,6 +23,14 @@ class MetricTest {
         assertThat(Metric.fromName(name)).isSameAs(Metric.CYCLOMATIC_COMPLEXITY);
     }
 
+    @Test
+    void shouldProvideContextWhenMetricIsWrong() {
+        assertThatIllegalArgumentException().isThrownBy(() -> Metric.fromName("undefined"))
+                .withMessageContaining("No metric found for name 'undefined'");
+        assertThatIllegalArgumentException().isThrownBy(() -> Metric.fromName(""))
+                .withMessageContaining("No metric defined");
+    }
+
     @EnumSource(Metric.class)
     @ParameterizedTest(name = "{0} should be converted to a tag name and then back to a metric")
     void shouldConvertToTags(final Metric metric) {


### PR DESCRIPTION
If the metric is omitted then the correct message should be shown.