### PR TITLE
Add serialization of the null object

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>edu.hm.hafner</groupId>
     <artifactId>codingstyle-pom</artifactId>
-    <version>5.12.0</version>
+    <version>5.13.0</version>
     <relativePath />
   </parent>
 
@@ -56,7 +56,7 @@
 
   <properties>
     <scmTag>HEAD</scmTag>
-    <revision>0.54.0</revision>
+    <revision>0.53.1</revision>
     <changelist>-SNAPSHOT</changelist>
     <previousVersion>0.53.0</previousVersion>
 

--- a/src/main/java/edu/hm/hafner/coverage/Coverage.java
+++ b/src/main/java/edu/hm/hafner/coverage/Coverage.java
@@ -1,9 +1,5 @@
 package edu.hm.hafner.coverage;
 
-import java.io.Serial;
-import java.util.Locale;
-import java.util.Objects;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.Fraction;
 
@@ -13,6 +9,10 @@ import edu.hm.hafner.util.Ensure;
 import edu.hm.hafner.util.Generated;
 import edu.hm.hafner.util.VisibleForTesting;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
+
+import java.io.Serial;
+import java.util.Locale;
+import java.util.Objects;
 
 /**
  * Value of a code coverage metric. The code coverage is measured using the number of covered and missed items. The type
@@ -44,6 +44,9 @@ public final class Coverage extends Value {
         var errorMessage = "Cannot convert %s to a valid Coverage instance.".formatted(stringRepresentation);
         try {
             var cleanedFormat = StringUtils.deleteWhitespace(stringRepresentation);
+            if (N_A.equals(cleanedFormat)) {
+                return nullObject(metric);
+            }
             if (StringUtils.contains(cleanedFormat, FRACTION_SEPARATOR)) {
                 var extractedCovered = StringUtils.substringBefore(cleanedFormat, FRACTION_SEPARATOR);
                 var extractedTotal = StringUtils.substringAfter(cleanedFormat, FRACTION_SEPARATOR);
@@ -214,7 +217,10 @@ public final class Coverage extends Value {
 
     @Override
     protected String serializeValue() {
-        return String.format(Locale.ENGLISH, "%d/%d", getCovered(), getTotal());
+        if (isSet()) {
+            return String.format(Locale.ENGLISH, "%d/%d", getCovered(), getTotal());
+        }
+        return N_A;
     }
 
     @Override

--- a/src/test/java/edu/hm/hafner/coverage/CoverageTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/CoverageTest.java
@@ -1,7 +1,5 @@
 package edu.hm.hafner.coverage;
 
-import java.util.Locale;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -12,6 +10,7 @@ import org.junitpioneer.jupiter.DefaultLocale;
 import edu.hm.hafner.coverage.Coverage.CoverageBuilder;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+import java.util.Locale;
 import nl.jqno.equalsverifier.EqualsVerifier;
 
 import static edu.hm.hafner.coverage.assertions.Assertions.*;
@@ -143,6 +142,11 @@ class CoverageTest {
                 .hasTotal(0)
                 .hasCoveredPercentage(Percentage.ZERO)
                 .hasToString("LINE: n/a");
+
+        var nullSerialization = "LINE: n/a";
+        assertThat(NO_COVERAGE.serialize()).isEqualTo(nullSerialization);
+        assertThat(Value.valueOf(nullSerialization)).isEqualTo(NO_COVERAGE);
+
         assertThat(NO_COVERAGE.add(NO_COVERAGE)).isEqualTo(NO_COVERAGE);
     }
 


### PR DESCRIPTION
Even if the coverage is not set, the object needs to be serialized.