### PR TITLE
[JENKINS-75648] Make projectName optional in Clover Parser

### DIFF
--- a/src/main/java/edu/hm/hafner/coverage/parser/CloverParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/parser/CloverParser.java
@@ -108,7 +108,7 @@ public class CloverParser extends CoverageParser {
             if (event.isStartElement()) {
                 var startElement = event.asStartElement();
                 if (PROJECT.equals(startElement.getName())) {
-                    var projectName = getValueOf(startElement, NAME);
+                    var projectName = getOptionalValueOf(startElement, NAME).orElse(EMPTY);
                     var root = new ModuleNode(projectName);
 
                     readProject(fileName, reader, root);

--- a/src/test/java/edu/hm/hafner/coverage/parser/CloverParserTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/parser/CloverParserTest.java
@@ -36,7 +36,6 @@ class CloverParserTest extends AbstractParserTest {
     }
 
     @Test
-    @SuppressWarnings({"PMD.OptimizableToArrayCall", "PMD.AvoidThrowingRawExceptionTypes"})
     void testEmptyProjectName() {
         var root = readReport("clover-empty-project-name.xml");
         assertThat(root.getName()).isEqualTo(EMPTY);

--- a/src/test/java/edu/hm/hafner/coverage/parser/CloverParserTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/parser/CloverParserTest.java
@@ -22,6 +22,8 @@ class CloverParserTest extends AbstractParserTest {
     private static final String CLOVER_PUBLISHER = "CloverPublisher.java";
     private static final String PLUGIN_IMPL = "PluginImpl.java";
     private static final String CLOVER_COVERAGE_PARSER = "CloverCoverageParser.java";
+    private static final String PROJECT_NAME = "All files";
+    private static final String EMPTY = "-";
 
     @Override
     protected String getFolder() {
@@ -35,12 +37,20 @@ class CloverParserTest extends AbstractParserTest {
 
     @Test
     @SuppressWarnings({"PMD.OptimizableToArrayCall", "PMD.AvoidThrowingRawExceptionTypes"})
+    void testEmptyProjectName() {
+        var root = readReport("clover-empty-project-name.xml");
+        assertThat(root.getName()).isEqualTo(EMPTY);
+    }
+
+    @Test
+    @SuppressWarnings({"PMD.OptimizableToArrayCall", "PMD.AvoidThrowingRawExceptionTypes"})
     void testBasic() {
         var root = readReport("clover.xml");
         // Verifying package level coverage
         var builder = new Coverage.CoverageBuilder().withMetric(LINE);
         assertThat(root.getValue(LINE)).contains(
                 builder.withCovered(143).withTotal(165).build());
+        assertThat(root.getName()).isEqualTo(PROJECT_NAME);
 
         for (Node packageNode : root.getChildren()) {
             if (ACTIONS_PACKAGE.equals(packageNode.getName())) {

--- a/src/test/resources/edu/hm/hafner/coverage/parser/clover/clover-empty-project-name.xml
+++ b/src/test/resources/edu/hm/hafner/coverage/parser/clover/clover-empty-project-name.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<coverage generated="1695944532781" clover="3.2.0">
+    <project timestamp="1695944532781">
+		<metrics statements="12" coveredstatements="12" conditionals="0" coveredconditionals="0" methods="5" coveredmethods="5" elements="99" coveredelements="99" complexity="0" loc="12" ncloc="12" packages="1" files="1" classes="1"/>
+        <file name="HelloWidget.jsx" path="/home/jenkins/agent/workspace/_1_deleteme-test-coverage-1_PR-1/src/js/widgets/hello/HelloWidget.jsx">
+            <metrics statements="12" coveredstatements="12" conditionals="0" coveredconditionals="0" methods="5" coveredmethods="5"/>
+            <line num="15" count="1" type="stmt"/>
+            <line num="19" count="1" type="stmt"/>
+            <line num="36" count="7" type="stmt"/>
+            <line num="37" count="7" type="stmt"/>
+            <line num="38" count="7" type="stmt"/>
+            <line num="46" count="7" type="stmt"/>
+            <line num="47" count="7" type="stmt"/>
+            <line num="48" count="7" type="stmt"/>
+            <line num="59" count="2" type="stmt"/>
+            <line num="71" count="2" type="stmt"/>
+            <line num="80" count="7" type="stmt"/>
+            <line num="81" count="7" type="stmt"/>
+        </file>
+	</project>
+</coverage>


### PR DESCRIPTION
### Changes

In the Clover Parser the field projectName is now optional and will by default be set to "-".

### Testing done

An automated test where the previous name-setting functionality was tested could not be found.
Since the difference is minimal no additional automated test was written.

The logic of setting a default value when there is no name present has been tested in a separate environment.

Scenarios tested:

Optional name was missing (null) -> Default value was used.
Optional name was present -> Optional name was used.

### Relevant Issue

[JENKINS-75648](https://issues.jenkins.io/browse/JENKINS-75648)

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

