### PR TITLE
[JENKINS-75684] Rename broken file names

### DIFF
--- a/src/main/java/edu/hm/hafner/coverage/Node.java
+++ b/src/main/java/edu/hm/hafner/coverage/Node.java
@@ -1,5 +1,6 @@
 package edu.hm.hafner.coverage;
 
+import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.RegExUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 
@@ -471,7 +472,7 @@ public abstract class Node implements Serializable {
 
     private Optional<FileNode> findFile(final String fileName, final String relativePath) {
         return getAllFileNodes().stream().filter(fileNode ->
-                fileNode.getName().equals(fileName)
+                (fileNode.getName().equals(fileName) || fileNode.getFileName().equals(fileName))
                         && fileNode.getRelativePath().equals(relativePath)).findAny();
     }
 
@@ -945,7 +946,7 @@ public abstract class Node implements Serializable {
      * @return the created and linked node
      */
     public FileNode createFileNode(final String fileName, final TreeString relativePath) {
-        return addChildNode(new FileNode(fileName, relativePath));
+        return addChildNode(new FileNode(FilenameUtils.getName(fileName), relativePath));
     }
 
     /**

--- a/src/test/java/edu/hm/hafner/coverage/NodeTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/NodeTest.java
@@ -7,6 +7,7 @@ import org.junitpioneer.jupiter.Issue;
 
 import edu.hm.hafner.coverage.Coverage.CoverageBuilder;
 import edu.hm.hafner.coverage.Mutation.MutationBuilder;
+import edu.hm.hafner.util.TreeString;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -32,6 +33,37 @@ class NodeTest {
     private static final String CLASS_WITHOUT_MODIFICATION = "classWithoutModification";
     private static final String COVERED_CLASS = "CoveredClass.class";
     private static final String MISSED_CLASS = "MissedClass.class";
+
+    @Test
+    void shouldFixFileNameAndRelativePath() {
+        var root = new ModuleNode("Root");
+
+        var fileNode = root.findOrCreateFileNode("File.java", TreeString.valueOf("relative/path/to/File.java"));
+        assertThat(fileNode).hasFileName("File.java")
+                .hasRelativePath("relative/path/to/File.java")
+                .hasName("File.java");
+
+        var other = root.findOrCreateFileNode("path/to/Other.java", TreeString.valueOf("relative/path/to/Other.java"));
+        assertThat(other).hasFileName("Other.java")
+                .hasRelativePath("relative/path/to/Other.java")
+                .hasName("Other.java");
+
+        var another = root.findOrCreateFileNode("another/path/to/Other.java", TreeString.valueOf("another/path/to/Other.java"));
+        assertThat(another).hasFileName("Other.java")
+                .hasRelativePath("another/path/to/Other.java")
+                .hasName("Other.java");
+
+        var wrongName = new FileNode("path/to/WrongName.java", "path/to/WrongName.java");
+        assertThat(wrongName).hasFileName("WrongName.java")
+                .hasRelativePath("path/to/WrongName.java")
+                .hasName("path/to/WrongName.java"); // Note: This is the original name, not fixed
+        root.addChild(wrongName);
+
+        assertThat(root.findOrCreateFileNode("WrongName.java", TreeString.valueOf("path/to/WrongName.java")))
+                .isSameAs(wrongName);
+        assertThat(root.findOrCreateFileNode("path/to/WrongName.java", TreeString.valueOf("path/to/WrongName.java")))
+                .isSameAs(wrongName);
+    }
 
     @Test
     void shouldHandleNonExistingParent() {

--- a/src/test/java/edu/hm/hafner/coverage/parser/CloverParserTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/parser/CloverParserTest.java
@@ -167,12 +167,14 @@ class CloverParserTest extends AbstractParserTest {
 
         assertThat(root.getAllFileNodes()).hasSize(4)
                 .satisfiesExactlyInAnyOrder(
-                        file -> assertThat(file).hasName("C:\\local\\maven\\helpers\\hudson\\clover\\src\\main\\java\\hudson\\plugins\\clover\\CloverPublisher.java")
+                        file -> assertThat(file).hasName("CloverPublisher.java")
                                 .hasRelativePath("C:\\local\\maven\\helpers\\hudson\\clover\\src\\main\\java\\hudson\\plugins\\clover\\CloverPublisher.java"),
-                        file -> assertThat(file).hasName("C:\\local\\maven\\helpers\\hudson\\clover\\src\\main\\java\\hudson\\plugins\\clover\\PluginImpl.java").
+                        file -> assertThat(file).hasName("PluginImpl.java").
                                 hasRelativePath("C:\\local\\maven\\helpers\\hudson\\clover\\src\\main\\java\\hudson\\plugins\\clover\\PluginImpl.java"),
-                        file -> assertThat(file).hasName("C:\\local\\maven\\helpers\\hudson\\clover\\src\\main\\java\\hudson\\plugins\\clover\\CloverBuildAction.java").hasRelativePath("C:\\local\\maven\\helpers\\hudson\\clover\\src\\main\\java\\hudson\\plugins\\clover\\CloverBuildAction.java"),
-                        file -> assertThat(file).hasName("C:\\local\\maven\\helpers\\hudson\\clover\\src\\main\\java\\hudson\\plugins\\clover\\CloverCoverageParser.java").hasRelativePath("C:\\local\\maven\\helpers\\hudson\\clover\\src\\main\\java\\hudson\\plugins\\clover\\CloverCoverageParser.java"));
+                        file -> assertThat(file).hasName("CloverBuildAction.java")
+                                .hasRelativePath("C:\\local\\maven\\helpers\\hudson\\clover\\src\\main\\java\\hudson\\plugins\\clover\\CloverBuildAction.java"),
+                        file -> assertThat(file).hasName("CloverCoverageParser.java")
+                                .hasRelativePath("C:\\local\\maven\\helpers\\hudson\\clover\\src\\main\\java\\hudson\\plugins\\clover\\CloverCoverageParser.java"));
     }
 
     @Test


### PR DESCRIPTION
Some parsers create file nodes with names that contain path elements. While this technically works, it pollutes the UI that renders the file names in several places. So it is helpful to clean up the file names while creating the tree.

This change will also fix [JENKINS-75684](https://issues.jenkins.io/browse/JENKINS-75684)
