### PR TITLE
Create generic percentage and integer metrics

### DIFF
--- a/src/main/java/edu/hm/hafner/coverage/Metric.java
+++ b/src/main/java/edu/hm/hafner/coverage/Metric.java
@@ -28,10 +28,9 @@ import java.util.stream.Stream;
 @SuppressWarnings({"ImmutableEnumChecker", "PMD.ExcessivePublicCount"})
 public enum Metric {
     /**
-     * Nodes that can have children. These notes compute their coverage values on the fly based on their children's
-     * coverage.
+     * Coverage nodes that can have children. These nodes compute their coverage values on the fly based on
+     * their children's coverage.
      */
-    // TODO: why do we need these coverages?
     CONTAINER("Container Coverage", "Container", new CoverageOfChildrenEvaluator()),
     MODULE("Module Coverage", "Module", new CoverageOfChildrenEvaluator()),
     PACKAGE("Package Coverage", "Package", new CoverageOfChildrenEvaluator()),
@@ -48,7 +47,8 @@ public enum Metric {
 
     /** Additional coverage values obtained from mutation testing. */
     MUTATION("Mutation Coverage", "Mutation", new ValuesAggregator()),
-    TEST_STRENGTH("Test Strength", "Test Strength", new ValuesAggregator()),
+    TEST_STRENGTH("Test Strength", "Test Strength", new ValuesAggregator(),
+            MetricTendency.LARGER_IS_BETTER, MetricValueType.METRIC, new PercentageFormatter()),
 
     // TODO: metrics might be better placed into a class that can have new instances dynamically
     TESTS("Number of Tests", "Tests", new ValuesAggregator(),
@@ -87,6 +87,8 @@ public enum Metric {
             MetricTendency.SMALLER_IS_BETTER, MetricValueType.METRIC, new IntegerFormatter()),
     DUPLICATIONS("Number of Duplications", "Duplications", new ValuesAggregator(),
             MetricTendency.SMALLER_IS_BETTER, MetricValueType.METRIC, new IntegerFormatter()),
+    VULNERABILITIES("Number of Vulnerabilities", "Vulnerabilities", new ValuesAggregator(),
+            MetricTendency.SMALLER_IS_BETTER, MetricValueType.METRIC, new IntegerFormatter()),
 
     /** Metrics from git forensics. */
     // TODO: should we also expose dates like age of class or date of last commit?
@@ -95,7 +97,16 @@ public enum Metric {
     COMMITS("Number of Commits", "Commits", new ValuesAggregator(),
             MetricTendency.SMALLER_IS_BETTER, MetricValueType.METRIC, new IntegerFormatter()),
     CODE_CHURN("Code Churn", "Code Churn", new ValuesAggregator(),
-            MetricTendency.SMALLER_IS_BETTER, MetricValueType.METRIC, new IntegerFormatter());
+            MetricTendency.SMALLER_IS_BETTER, MetricValueType.METRIC, new IntegerFormatter()),
+
+    /** Generic metrics. */
+    UNBOUNDED("Unbounded Integer Metric", "Unbounded", new ValuesAggregator(),
+            MetricTendency.LARGER_IS_BETTER, MetricValueType.METRIC, new IntegerFormatter()),
+    COUNT("Metric Counter", "Count", new ValuesAggregator(),
+            MetricTendency.SMALLER_IS_BETTER, MetricValueType.METRIC, new IntegerFormatter()),
+    PERCENTAGE("Percentage Metric", "Percentage", new ValuesAggregator(),
+            MetricTendency.LARGER_IS_BETTER, MetricValueType.METRIC, new PercentageFormatter());
+
     /**
      * Returns the metric that belongs to the specified tag.
      *
@@ -155,14 +166,13 @@ public enum Metric {
         this(displayName, label, evaluator, tendency, MetricValueType.COVERAGE);
     }
 
-    Metric(final String displayName, final String label, final MetricEvaluator evaluator, final MetricTendency tendency,
-            final MetricValueType type) {
+    Metric(final String displayName, final String label, final MetricEvaluator evaluator,
+            final MetricTendency tendency, final MetricValueType type) {
         this(displayName, label, evaluator, tendency, type, new CoverageFormatter());
     }
 
-    Metric(final String displayName, final String label, final MetricEvaluator evaluator, final MetricTendency tendency,
-            final MetricValueType type,
-            final MetricFormatter formatter) {
+    Metric(final String displayName, final String label, final MetricEvaluator evaluator,
+            final MetricTendency tendency, final MetricValueType type, final MetricFormatter formatter) {
         this.displayName = displayName;
         this.label = label;
         this.evaluator = evaluator;

--- a/src/main/java/edu/hm/hafner/coverage/Value.java
+++ b/src/main/java/edu/hm/hafner/coverage/Value.java
@@ -350,7 +350,7 @@ public class Value implements Serializable, Comparable<Value> {
     }
 
     /**
-     * Returns this value as rounded double.
+     * Returns this value as a rounded double.
      *
      * @return this value as a double
      */

--- a/src/test/java/edu/hm/hafner/coverage/MetricTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/MetricTest.java
@@ -1,8 +1,5 @@
 package edu.hm.hafner.coverage;
 
-import java.util.Locale;
-import java.util.NavigableSet;
-
 import org.apache.commons.lang3.math.Fraction;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -11,6 +8,9 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import edu.hm.hafner.coverage.Metric.MetricTendency;
 import edu.hm.hafner.coverage.Metric.MetricValueType;
+
+import java.util.Locale;
+import java.util.NavigableSet;
 
 import static edu.hm.hafner.coverage.assertions.Assertions.*;
 
@@ -65,8 +65,7 @@ class MetricTest {
                 Metric.INSTRUCTION,
                 Metric.MCDC_PAIR,
                 Metric.FUNCTION_CALL,
-                Metric.MUTATION,
-                Metric.TEST_STRENGTH);
+                Metric.MUTATION);
     }
 
     /**


### PR DESCRIPTION
Some tools want to add metrics that are not given as constants in `Metric`. So it makes sense to provide some generic metrics that can be used for such a scenario.