### PR TITLE
Fix mapping of target nodes

### DIFF
--- a/src/main/java/edu/hm/hafner/coverage/Metric.java
+++ b/src/main/java/edu/hm/hafner/coverage/Metric.java
@@ -247,10 +247,10 @@ public enum Metric {
      * @return the target nodes
      */
     public List<? extends Node> getTargetNodes(final Node node) {
-        if (getType() == MetricValueType.CLASS_METRIC) {
-            return node.getAllClassNodes();
+        if (getType() == MetricValueType.METHOD_METRIC) {
+            return node.getAllMethodNodes();
         }
-        return node.getAllMethodNodes();
+        return node.getAllClassNodes(); // for all other metrics
     }
 
     /**

--- a/src/test/java/edu/hm/hafner/coverage/MetricTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/MetricTest.java
@@ -151,6 +151,6 @@ class MetricTest {
         assertThat(coverage.getAggregationType()).isEmpty();
         assertThat(coverage.getType()).isEqualTo(MetricValueType.COVERAGE);
         assertThat(coverage.getTargetNodes(root)).hasSize(1)
-                .first().extracting(Node::getName).isEqualTo("method()");
+                .first().extracting(Node::getName).isEqualTo("class");
     }
 }

--- a/src/test/java/edu/hm/hafner/coverage/parser/MetricsParserTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/parser/MetricsParserTest.java
@@ -175,6 +175,32 @@ class MetricsParserTest extends AbstractParserTest {
     }
 
     @Test
+    void shouldHandleEmptyMetrics() {
+        var tree = readReport("metrics-exception.xml");
+
+        assertThat(tree.getAll(MODULE)).hasSize(1);
+        assertThat(tree.getAll(PACKAGE)).hasSize(1);
+        assertThat(tree.getAll(FILE)).hasSize(2);
+        assertThat(tree.getAll(CLASS)).hasSize(2);
+        assertThat(tree.getAll(METHOD)).isEmpty();
+
+        assertThat(tree).hasOnlyMetrics(LOC,
+                NCSS,
+                ACCESS_TO_FOREIGN_DATA,
+                COHESION,
+                FAN_OUT,
+                NUMBER_OF_ACCESSORS,
+                WEIGHT_OF_CLASS,
+                WEIGHED_METHOD_COUNT);
+
+        assertThat(tree.aggregateValues()).contains(
+                new Value(LOC, 10),
+                new Value(NCSS, 2));
+
+        assertThat(LOC.getTargetNodes(tree).stream().map(n -> n.getValue(LOC))).hasSize(2);
+    }
+
+    @Test
     void shouldFailWhenParsingInvalidFiles() {
         assertThatExceptionOfType(ParsingException.class).isThrownBy(() -> readReport("/design.puml"));
     }

--- a/src/test/resources/edu/hm/hafner/coverage/parser/metrics/metrics-exception.xml
+++ b/src/test/resources/edu/hm/hafner/coverage/parser/metrics/metrics-exception.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metrics version="7.11.0-metrics" timestamp="2025-11-11T13:05:30.413" source="PMD">
+<package name="edu.hm.hafner.java2.assignment1">
+<file name="/builds/dev/gitlab-autograding-example/src/main/java/edu/hm/hafner/java2/assignment1/Assignment.java">
+<class name="Assignment">
+<metric name="ACCESS_TO_FOREIGN_DATA" value="0"/>
+<metric name="COHESION" value="0.0"/>
+<metric name="FAN_OUT" value="0"/>
+<metric name="LOC" value="5"/>
+<metric name="NCSS" value="1"/>
+<metric name="NUMBER_OF_ACCESSORS" value="0"/>
+<metric name="WEIGHED_METHOD_COUNT" value="0"/>
+<metric name="WEIGHT_OF_CLASS" value="0.0"/>
+</class>
+</file>
+<file name="/builds/dev/gitlab-autograding-example/src/main/java/edu/hm/hafner/java2/assignment1/Exam.java">
+<class name="Exam">
+<metric name="ACCESS_TO_FOREIGN_DATA" value="0"/>
+<metric name="COHESION" value="0.0"/>
+<metric name="FAN_OUT" value="0"/>
+<metric name="LOC" value="5"/>
+<metric name="NCSS" value="1"/>
+<metric name="NUMBER_OF_ACCESSORS" value="0"/>
+<metric name="WEIGHED_METHOD_COUNT" value="0"/>
+<metric name="WEIGHT_OF_CLASS" value="0.0"/>
+</class>
+</file>
+</package>
+</metrics>


### PR DESCRIPTION
Method metrics store the values within the method nodes. All other metrics use the class nodes.

See exception in autograding:

```
GitLab Autograding Errors:
An error occurred while grading
java.lang.NumberFormatException: Character N is neither a decimal digit number, decimal point, nor "e" notation exponential mark.
	at java.base/java.math.BigDecimal.<init>(BigDecimal.java:608)
	at java.base/java.math.BigDecimal.<init>(BigDecimal.java:497)
	at java.base/java.math.BigDecimal.<init>(BigDecimal.java:903)
	at java.base/java.math.BigDecimal.valueOf(BigDecimal.java:1371)
	at edu.hm.hafner.coverage.Metric$MetricFormatter.toRounded(Metric.java:481)
	at edu.hm.hafner.coverage.Metric$IntegerFormatter.format(Metric.java:535)
	at edu.hm.hafner.coverage.Metric.format(Metric.java:228)
	at edu.hm.hafner.grading.MetricMarkdown.createRow(MetricMarkdown.java:70)
	at edu.hm.hafner.grading.MetricMarkdown.createMetricRow(MetricMarkdown.java:58)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:1024)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:151)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:174)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:596)
	at edu.hm.hafner.grading.MetricMarkdown.createSpecificDetails(MetricMarkdown.java:47)
	at edu.hm.hafner.grading.ScoreMarkdown.createDetails(ScoreMarkdown.java:127)
	at edu.hm.hafner.grading.MetricMarkdown.createDetails(MetricMarkdown.java:18)
	at edu.hm.hafner.grading.GradingReport.getMarkdownDetails(GradingReport.java:198)
	at edu.hm.hafner.grading.GradingReport.getMarkdownDetails(GradingReport.java:176)
	at edu.hm.hafner.grading.gitlab.GitLabAutoGradingRunner.grade(GitLabAutoGradingRunner.java:103)
	at edu.hm.hafner.grading.gitlab.GitLabAutoGradingRunner.publishGradingResult(GitLabAutoGradingRunner.java:84)
	at edu.hm.hafner.grading.AutoGradingRunner.run(AutoGradingRunner.java:126)
	at edu.hm.hafner.grading.gitlab.GitLabAutoGradingRunner.main(GitLabAutoGradingRunner.java:39)
```