### PR TITLE
Fix adding of rates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 
   <properties>
     <scmTag>HEAD</scmTag>
-    <revision>0.65.0</revision>
+    <revision>0.64.1</revision>
     <changelist>-SNAPSHOT</changelist>
     <previousVersion>0.64.0</previousVersion>
 

--- a/src/main/java/edu/hm/hafner/coverage/Rate.java
+++ b/src/main/java/edu/hm/hafner/coverage/Rate.java
@@ -124,6 +124,15 @@ public class Rate extends Value {
     }
 
     @Override
+    public Value add(final Value other) {
+        ensureSameMetricAndType(other);
+
+        int numerator = getFraction().getNumerator() + other.getFraction().getNumerator();
+        int denominator = getFraction().getDenominator() + other.getFraction().getDenominator();
+        return createValue(Fraction.getFraction(numerator, denominator));
+    }
+
+    @Override
     public double asDouble() {
         return rawValue() * 100.0;
     }

--- a/src/test/java/edu/hm/hafner/coverage/RateTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/RateTest.java
@@ -16,6 +16,18 @@ class RateTest {
         assertThat(rate.asInformativeText(Locale.ENGLISH)).isEqualTo("75.00%");
         assertThat(rate.asRoundedText(Locale.ENGLISH)).isEqualTo("75.00");
         assertThat(rate.serialize()).isEqualTo("COHESION: %3:4");
+
+        assertThat(rate.add(rate).asDouble()).isCloseTo(75, withinPercentage(0.0001));
+    }
+
+    @Test
+    void shouldCorrectlyAdd() {
+        var zero = Rate.valueOf("COHESION: %0:6");
+        var hundred = Rate.valueOf("COHESION: %6:6");
+
+        var fifty = zero.add(hundred);
+        assertThat(fifty.asDouble()).isCloseTo(50, withinPercentage(0.0001));
+        assertThat(fifty.serialize()).isEqualTo("COHESION: %6:12");
     }
 
     @Test


### PR DESCRIPTION
When adding two rates, the numerators and denominators of both fractions must be added to create the new fraction.

