### PR TITLE
Change `toString` implementation of value to print the Metric name

### DIFF
--- a/src/main/java/edu/hm/hafner/coverage/Value.java
+++ b/src/main/java/edu/hm/hafner/coverage/Value.java
@@ -416,7 +416,7 @@ public class Value implements Serializable, Comparable<Value> {
 
     @Override
     public String toString() {
-        return asText(Locale.ENGLISH);
+        return getSummary(Locale.ENGLISH);
     }
 
     @Override

--- a/src/test/java/edu/hm/hafner/coverage/ValueTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/ValueTest.java
@@ -104,7 +104,7 @@ class ValueTest {
         var percentage = new Value(Metric.PERCENTAGE, value - 1, value);
 
         assertThat(percentage.asText(Locale.ENGLISH)).isEqualTo("100.00%");
-        assertThat(percentage).hasToString("100.00%");
+        assertThat(percentage).hasToString("Percentage Metric: 100.00%");
     }
 
     @ParameterizedTest(name = "digits={0}")
@@ -115,7 +115,7 @@ class ValueTest {
         var rate = new Value(Metric.RATE, value - 1, value);
 
         assertThat(rate.asText(Locale.ENGLISH)).isEqualTo("99.99%");
-        assertThat(rate).hasToString("99.99%");
+        assertThat(rate).hasToString("Rate Metric: 99.99%");
     }
 
     @Test


### PR DESCRIPTION
Some downstream tests rely on `toString`. And all values should have a similar output.