### PR TITLE
Improve parsing of cobertura files with duplicate methods

### DIFF
--- a/src/main/java/edu/hm/hafner/coverage/CoverageParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/CoverageParser.java
@@ -79,9 +79,23 @@ public abstract class CoverageParser implements Serializable {
      *         if the content cannot be read by the parser
      */
     public ModuleNode parse(final Reader reader, final String fileName, final FilteredLog log) {
-        var moduleNode = parseReport(reader, fileName, log);
-        getTreeStringBuilder().dedup();
-        return moduleNode;
+        try {
+            var moduleNode = parseReport(reader, fileName, log);
+            getTreeStringBuilder().dedup();
+            return moduleNode;
+        }
+        catch (IllegalArgumentException e) {
+            if (!ignoreErrors() && e.getMessage() != null && e.getMessage().contains("already the same child")) {
+                throw new ParsingException(e,
+                        "A duplicate element was detected in '%s' while parsing this coverage report. "
+                        + "This typically indicates a problem with the coverage producer tool. "
+                        + "As a temporary workaround, you can set ignoreErrors=true to skip such elements. "
+                        + "Please report this issue to the coverage producer (e.g., gcovr, Go coverage) "
+                        + "or create an issue at https://github.com/jenkinsci/coverage-model/issues.",
+                        fileName);
+            }
+            throw e;
+        }
     }
 
     /**

--- a/src/main/java/edu/hm/hafner/coverage/CoverageParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/CoverageParser.java
@@ -4,6 +4,7 @@ import javax.xml.namespace.QName;
 import javax.xml.stream.events.StartElement;
 import javax.xml.stream.events.XMLEvent;
 
+import org.apache.commons.lang3.Strings;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import com.google.errorprone.annotations.FormatMethod;
@@ -85,7 +86,7 @@ public abstract class CoverageParser implements Serializable {
             return moduleNode;
         }
         catch (IllegalArgumentException e) {
-            if (!ignoreErrors() && e.getMessage() != null && e.getMessage().contains("already the same child")) {
+            if (!ignoreErrors() && Strings.CS.contains(e.getMessage(), "same child")) {
                 throw new ParsingException(e,
                         "A duplicate element was detected in '%s' while parsing this coverage report. "
                         + "This typically indicates a problem with the coverage producer tool. "

--- a/src/main/java/edu/hm/hafner/coverage/parser/CoberturaParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/parser/CoberturaParser.java
@@ -288,11 +288,9 @@ public class CoberturaParser extends CoverageParser {
             final String name) {
         var methodName = name;
         var signature = getValueOf(element, SIGNATURE);
-        if (parentNode.findMethod(methodName, signature).isPresent()) {
-            if (ignoreErrors()) {
-                log.logError("Found a duplicate method '%s' with signature '%s' in '%s'",
-                        methodName, signature, parentNode.getName());
-            }
+        if (parentNode.findMethod(methodName, signature).isPresent() && ignoreErrors()) {
+            log.logError("Found a duplicate method '%s' with signature '%s' in '%s'",
+                    methodName, signature, parentNode.getName());
             methodName = createUniqueMethodName(parentNode, methodName, signature);
         }
         return parentNode.createMethodNode(methodName, signature);
@@ -313,9 +311,20 @@ public class CoberturaParser extends CoverageParser {
         var className = name;
         if (parentNode.hasChild(className) && ignoreErrors()) {
             log.logError("Found a duplicate class '%s' in '%s'", className, parentNode.getName());
-            className = name + "-" + createId();
+            className = createUniqueClassName(parentNode, className);
         }
         return parentNode.createClassNode(className);
+    }
+
+    private String createUniqueClassName(final Node parentNode, final String className) {
+        var number = 1;
+        var candidate = "%s-%d".formatted(className, number);
+
+        while (parentNode.hasChild(candidate)) {
+            number++;
+            candidate = "%s-%d".formatted(className, number);
+        }
+        return candidate;
     }
 
     private String readName(final StartElement element) {

--- a/src/main/java/edu/hm/hafner/coverage/parser/CoberturaParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/parser/CoberturaParser.java
@@ -288,12 +288,25 @@ public class CoberturaParser extends CoverageParser {
             final String name) {
         var methodName = name;
         var signature = getValueOf(element, SIGNATURE);
-        if (parentNode.findMethod(methodName, signature).isPresent() && ignoreErrors()) {
-            log.logError("Found a duplicate method '%s' with signature '%s' in '%s'",
-                    methodName, signature, parentNode.getName());
-            methodName = name + "-" + createId();
+        if (parentNode.findMethod(methodName, signature).isPresent()) {
+            if (ignoreErrors()) {
+                log.logError("Found a duplicate method '%s' with signature '%s' in '%s'",
+                        methodName, signature, parentNode.getName());
+            }
+            methodName = createUniqueMethodName(parentNode, methodName, signature);
         }
         return parentNode.createMethodNode(methodName, signature);
+    }
+
+    private String createUniqueMethodName(final Node parentNode, final String methodName, final String signature) {
+        var number = 1;
+        var candidate = "%s-%d".formatted(methodName, number);
+
+        while (parentNode.findMethod(candidate, signature).isPresent()) {
+            number++;
+            candidate = "%s-%d".formatted(methodName, number);
+        }
+        return candidate;
     }
 
     private ClassNode createClassNode(final Node parentNode, final FilteredLog log, final String name) {

--- a/src/test/java/edu/hm/hafner/coverage/parser/CoberturaParserTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/parser/CoberturaParserTest.java
@@ -213,16 +213,39 @@ class CoberturaParserTest extends AbstractParserTest {
                 .containsExactly("VisualOn.Data.DataSourceProvider");
         assertThat(duplicateMethods.getAll(METHOD)).extracting(Node::getName).hasSize(2)
                 .contains("Enumerate()")
-                .element(1).asString().startsWith("Enumerate-");
+                .contains("Enumerate-1()");
 
         assertThat(getLog().hasErrors()).isTrue();
         assertThat(getLog().getErrorMessages())
                 .contains("Found a duplicate method 'Enumerate' with signature '()' in 'VisualOn.Data.DataSourceProvider'");
 
         verifyBranchCoverageOfLine61(duplicateMethods);
+    }
 
-        assertThatIllegalArgumentException().isThrownBy(
-                () -> readReport("cobertura-duplicate-methods.xml", new CoberturaParser()));
+    @Test
+    void shouldHandleDuplicateMethodsInFailFastMode() {
+        var duplicateMethods = readReport("cobertura-duplicate-methods.xml", new CoberturaParser());
+
+        assertThat(duplicateMethods.getAll(METHOD)).extracting(Node::getName).hasSize(2)
+                .contains("Enumerate()")
+                .contains("Enumerate-1()");
+        assertThat(getLog().hasErrors()).isFalse();
+    }
+
+    @Test
+    @Issue("https://github.com/jenkinsci/coverage-model/issues/249")
+    void shouldHandleDuplicateInitMethodsInFailFastMode() {
+        var duplicateMethods = readReport("cobertura-duplicate-go-init-methods.xml", new CoberturaParser());
+
+        assertThat(duplicateMethods.getAll(METHOD)).extracting(Node::getName)
+                .containsExactly("init<0>", "init-1<0>");
+        assertThat(duplicateMethods.getValue(LINE)).hasValueSatisfying(
+                lineCoverage -> assertThat(lineCoverage).isEqualTo(new CoverageBuilder()
+                        .withMetric(LINE)
+                        .withCovered(2)
+                        .withMissed(0)
+                        .build()));
+        assertThat(getLog().hasErrors()).isFalse();
     }
 
     @Test @Issue("jenkinsci/code-coverage-api-plugin#729")

--- a/src/test/java/edu/hm/hafner/coverage/parser/CoberturaParserTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/parser/CoberturaParserTest.java
@@ -198,7 +198,7 @@ class CoberturaParserTest extends AbstractParserTest {
 
         verifyBranchCoverageOfLine61(duplicateClasses);
 
-        assertThatIllegalArgumentException().isThrownBy(
+        assertThatExceptionOfType(ParsingException.class).isThrownBy(
                 () -> readReport("cobertura-duplicate-classes.xml", new CoberturaParser()));
     }
 
@@ -224,28 +224,15 @@ class CoberturaParserTest extends AbstractParserTest {
 
     @Test
     void shouldHandleDuplicateMethodsInFailFastMode() {
-        var duplicateMethods = readReport("cobertura-duplicate-methods.xml", new CoberturaParser());
-
-        assertThat(duplicateMethods.getAll(METHOD)).extracting(Node::getName).hasSize(2)
-                .contains("Enumerate()")
-                .contains("Enumerate-1()");
-        assertThat(getLog().hasErrors()).isFalse();
+        assertThatExceptionOfType(ParsingException.class).isThrownBy(
+                () -> readReport("cobertura-duplicate-methods.xml", new CoberturaParser()));
     }
 
     @Test
     @Issue("https://github.com/jenkinsci/coverage-model/issues/249")
     void shouldHandleDuplicateInitMethodsInFailFastMode() {
-        var duplicateMethods = readReport("cobertura-duplicate-go-init-methods.xml", new CoberturaParser());
-
-        assertThat(duplicateMethods.getAll(METHOD)).extracting(Node::getName)
-                .containsExactly("init<0>", "init-1<0>", "init-2<0>");
-        assertThat(duplicateMethods.getValue(LINE)).hasValueSatisfying(
-                lineCoverage -> assertThat(lineCoverage).isEqualTo(new CoverageBuilder()
-                        .withMetric(LINE)
-                        .withCovered(3)
-                        .withMissed(0)
-                        .build()));
-        assertThat(getLog().hasErrors()).isFalse();
+        assertThatExceptionOfType(ParsingException.class).isThrownBy(
+                () -> readReport("cobertura-duplicate-go-init-methods.xml", new CoberturaParser()));
     }
 
     @Test @Issue("jenkinsci/code-coverage-api-plugin#729")

--- a/src/test/java/edu/hm/hafner/coverage/parser/CoberturaParserTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/parser/CoberturaParserTest.java
@@ -238,11 +238,11 @@ class CoberturaParserTest extends AbstractParserTest {
         var duplicateMethods = readReport("cobertura-duplicate-go-init-methods.xml", new CoberturaParser());
 
         assertThat(duplicateMethods.getAll(METHOD)).extracting(Node::getName)
-                .containsExactly("init<0>", "init-1<0>");
+                .containsExactly("init<0>", "init-1<0>", "init-2<0>");
         assertThat(duplicateMethods.getValue(LINE)).hasValueSatisfying(
                 lineCoverage -> assertThat(lineCoverage).isEqualTo(new CoverageBuilder()
                         .withMetric(LINE)
-                        .withCovered(2)
+                        .withCovered(3)
                         .withMissed(0)
                         .build()));
         assertThat(getLog().hasErrors()).isFalse();

--- a/src/test/resources/edu/hm/hafner/coverage/parser/cobertura/cobertura-duplicate-go-init-methods.xml
+++ b/src/test/resources/edu/hm/hafner/coverage/parser/cobertura/cobertura-duplicate-go-init-methods.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<coverage line-rate="1" branch-rate="1" version="1.9" timestamp="1663310122" lines-covered="2"
-          lines-valid="2" branches-covered="0" branches-valid="0">
+<coverage line-rate="1" branch-rate="1" version="1.9" timestamp="1663310122" lines-covered="3"
+          lines-valid="3" branches-covered="0" branches-valid="0">
   <sources>
     <source>/go/src/</source>
   </sources>
   <packages>
-    <package name="main" line-rate="1" branch-rate="1" complexity="2">
+    <package name="main" line-rate="1" branch-rate="1" complexity="3">
       <classes>
-        <class name="main" filename="main.go" line-rate="1" branch-rate="1" complexity="2">
+        <class name="main" filename="main.go" line-rate="1" branch-rate="1" complexity="3">
           <methods>
             <method name="init" signature="&lt;0&gt;" line-rate="1" branch-rate="1" complexity="1">
               <lines>
@@ -19,10 +19,16 @@
                 <line number="12" hits="1" branch="false"/>
               </lines>
             </method>
+            <method name="init" signature="&lt;0&gt;" line-rate="1" branch-rate="1" complexity="1">
+              <lines>
+                <line number="20" hits="1" branch="false"/>
+              </lines>
+            </method>
           </methods>
           <lines>
             <line number="5" hits="1" branch="false"/>
             <line number="12" hits="1" branch="false"/>
+            <line number="20" hits="1" branch="false"/>
           </lines>
         </class>
       </classes>

--- a/src/test/resources/edu/hm/hafner/coverage/parser/cobertura/cobertura-duplicate-go-init-methods.xml
+++ b/src/test/resources/edu/hm/hafner/coverage/parser/cobertura/cobertura-duplicate-go-init-methods.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<coverage line-rate="1" branch-rate="1" version="1.9" timestamp="1663310122" lines-covered="2"
+          lines-valid="2" branches-covered="0" branches-valid="0">
+  <sources>
+    <source>/go/src/</source>
+  </sources>
+  <packages>
+    <package name="main" line-rate="1" branch-rate="1" complexity="2">
+      <classes>
+        <class name="main" filename="main.go" line-rate="1" branch-rate="1" complexity="2">
+          <methods>
+            <method name="init" signature="&lt;0&gt;" line-rate="1" branch-rate="1" complexity="1">
+              <lines>
+                <line number="5" hits="1" branch="false"/>
+              </lines>
+            </method>
+            <method name="init" signature="&lt;0&gt;" line-rate="1" branch-rate="1" complexity="1">
+              <lines>
+                <line number="12" hits="1" branch="false"/>
+              </lines>
+            </method>
+          </methods>
+          <lines>
+            <line number="5" hits="1" branch="false"/>
+            <line number="12" hits="1" branch="false"/>
+          </lines>
+        </class>
+      </classes>
+    </package>
+  </packages>
+</coverage>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
There is already the same child [METHOD] `init <0>` with the name `init` in [CLASS]

Fixes #249 

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
