### PR TITLE
 Cyclomatic complexity is lost when reports are merged  

### DIFF
--- a/src/main/java/edu/hm/hafner/coverage/Node.java
+++ b/src/main/java/edu/hm/hafner/coverage/Node.java
@@ -797,23 +797,7 @@ public abstract class Node implements Serializable {
     }
 
     /**
-     * Merges the directly stored values of {@code other} into this node.
-     *
-     * <p>When both nodes carry a value for the same metric, the <em>maximum</em> (worse) value is kept.
-     * This is intentional for complexity-style metrics such as {@link Metric#CYCLOMATIC_COMPLEXITY}:
-     * when the same source file is compiled for multiple target frameworks via {@code #if} directives,
-     * each Cobertura report measures the same method independently. The merged report should reflect
-     * the worst-case maintainability across all targets, not an artificial double-count obtained by
-     * summing (as reported in JENKINS-75295 by the original bug reporter kon:
-     * "the entirety will be at least as difficult to maintain as the most difficult subset").</p>
-     *
-     * <p>If a metric exists only in {@code other} (e.g. a method compiled exclusively for one target
-     * framework), its value is carried over to this node unchanged so that nothing is silently lost.</p>
-     *
-     * <p>This fixes the bug reported in JENKINS-75295 / coverage-plugin#638 where cyclomatic complexity
-     * (and any other value stored directly on a node) was lost when two coverage reports were merged,
-     * because the old implementation called {@link #removeValues()} but never re-introduced the values
-     * from {@code other}.</p>
+     * Merges node metric values by keeping the maximum value for shared metrics (e.g.{@link Metric#CYCLOMATIC_COMPLEXITY}) * and preserving metrics present only in the other node, preventing metric loss during report merging (JENKINS-75295).
      *
      * @param other
      *         the node whose values should be merged into this node
@@ -825,14 +809,9 @@ public abstract class Node implements Serializable {
                     .filter(v -> v.getMetric() == metric)
                     .findAny();
             if (existingValue.isPresent()) {
-                // Both reports have a value for this metric: keep the larger (worse) one.
-                // For complexity metrics this reflects the hardest-to-maintain target framework;
-                // for other metrics (coverage fractions etc.) max is also a safe conservative choice.
                 replaceValue(existingValue.get().max(otherValue));
             }
             else {
-                // Only the other report has this value (e.g. platform-conditional code):
-                // carry it over so nothing is silently lost.
                 addValue(otherValue);
             }
         }

--- a/src/main/java/edu/hm/hafner/coverage/Node.java
+++ b/src/main/java/edu/hm/hafner/coverage/Node.java
@@ -814,7 +814,8 @@ public abstract class Node implements Serializable {
                     replaceValue(existingValue.get().max(otherValue));
                 }
                 else {
-                    replaceValue(existingValue.get().min(otherValue));
+                    replaceValue(existingValue.get().compareTo(otherValue) <= 0
+                            ? existingValue.get() : otherValue);
                 }
             }
             else {

--- a/src/main/java/edu/hm/hafner/coverage/Node.java
+++ b/src/main/java/edu/hm/hafner/coverage/Node.java
@@ -804,9 +804,8 @@ public abstract class Node implements Serializable {
      */
     private void mergeValues(final Node other) {
         for (Value otherValue : other.getValues()) {
-            var metric = otherValue.getMetric();
             var existingValue = values.stream()
-                    .filter(v -> v.getMetric() == metric)
+                    .filter(v -> v.getMetric() == otherValue.getMetric())
                     .findAny();
             if (existingValue.isPresent()) {
                 replaceValue(existingValue.get().max(otherValue));

--- a/src/main/java/edu/hm/hafner/coverage/Node.java
+++ b/src/main/java/edu/hm/hafner/coverage/Node.java
@@ -797,18 +797,25 @@ public abstract class Node implements Serializable {
     }
 
     /**
-     * Merges node metric values by keeping the maximum value for shared metrics (e.g.{@link Metric#CYCLOMATIC_COMPLEXITY}) * and preserving metrics present only in the other node, preventing metric loss during report merging (JENKINS-75295).
-     *
-     * @param other
-     *         the node whose values should be merged into this node
-     */
+    * Merges the directly stored values of {@code other} into this node. For metrics present in both
+    * nodes, the worse value according to {@link Metric#getTendency()} is retained; metrics present
+    * only in {@code other} are copied unchanged. This ensures that merged reports reflect the
+    * worst-case quality across multiple targets.
+    *
+    * @param other
+    *         the node whose values should be merged into this node
+    */
     private void mergeValues(final Node other) {
         for (Value otherValue : other.getValues()) {
-            var existingValue = values.stream()
-                    .filter(v -> v.getMetric() == otherValue.getMetric())
-                    .findAny();
+            var metric = otherValue.getMetric();
+            var existingValue = getValue(metric);
             if (existingValue.isPresent()) {
-                replaceValue(existingValue.get().max(otherValue));
+                if (metric.getTendency() == Metric.MetricTendency.SMALLER_IS_BETTER) {
+                    replaceValue(existingValue.get().max(otherValue));
+                }
+                else {
+                    replaceValue(existingValue.get().min(otherValue));
+                }
             }
             else {
                 addValue(otherValue);

--- a/src/main/java/edu/hm/hafner/coverage/Node.java
+++ b/src/main/java/edu/hm/hafner/coverage/Node.java
@@ -815,9 +815,7 @@ public abstract class Node implements Serializable {
                     replaceValue(existingValue.get().max(otherValue));
                 }
                 else {
-                    replaceValue(existingValue.get().compareTo(otherValue) <= 0
-                            ? existingValue.get() 
-                            : otherValue);
+                    replaceValue(existingValue.get().min(otherValue));
                 }
             }
             else {

--- a/src/main/java/edu/hm/hafner/coverage/Node.java
+++ b/src/main/java/edu/hm/hafner/coverage/Node.java
@@ -807,15 +807,17 @@ public abstract class Node implements Serializable {
     */
     private void mergeValues(final Node other) {
         for (Value otherValue : other.getValues()) {
-            var metric = otherValue.getMetric();
-            var existingValue = getValue(metric);
+            var currentMetric = otherValue.getMetric();
+
+            var existingValue = getValue(currentMetric);
             if (existingValue.isPresent()) {
-                if (metric.getTendency() == Metric.MetricTendency.SMALLER_IS_BETTER) {
+                if (currentMetric.getTendency() == Metric.MetricTendency.SMALLER_IS_BETTER) {
                     replaceValue(existingValue.get().max(otherValue));
                 }
                 else {
                     replaceValue(existingValue.get().compareTo(otherValue) <= 0
-                            ? existingValue.get() : otherValue);
+                            ? existingValue.get() 
+                            : otherValue);
                 }
             }
             else {

--- a/src/main/java/edu/hm/hafner/coverage/Node.java
+++ b/src/main/java/edu/hm/hafner/coverage/Node.java
@@ -782,7 +782,7 @@ public abstract class Node implements Serializable {
     protected void mergeNode(final Node other) {
         ensureSameMetric(other);
 
-        removeValues(); // clear all values
+        mergeValues(other);
 
         other.getChildren().forEach(otherChild -> {
             Optional<Node> existingChild = getChildren().stream()
@@ -794,6 +794,48 @@ public abstract class Node implements Serializable {
                 addChild(otherChild.copyTree());
             }
         });
+    }
+
+    /**
+     * Merges the directly stored values of {@code other} into this node.
+     *
+     * <p>When both nodes carry a value for the same metric, the <em>maximum</em> (worse) value is kept.
+     * This is intentional for complexity-style metrics such as {@link Metric#CYCLOMATIC_COMPLEXITY}:
+     * when the same source file is compiled for multiple target frameworks via {@code #if} directives,
+     * each Cobertura report measures the same method independently. The merged report should reflect
+     * the worst-case maintainability across all targets, not an artificial double-count obtained by
+     * summing (as reported in JENKINS-75295 by the original bug reporter kon:
+     * "the entirety will be at least as difficult to maintain as the most difficult subset").</p>
+     *
+     * <p>If a metric exists only in {@code other} (e.g. a method compiled exclusively for one target
+     * framework), its value is carried over to this node unchanged so that nothing is silently lost.</p>
+     *
+     * <p>This fixes the bug reported in JENKINS-75295 / coverage-plugin#638 where cyclomatic complexity
+     * (and any other value stored directly on a node) was lost when two coverage reports were merged,
+     * because the old implementation called {@link #removeValues()} but never re-introduced the values
+     * from {@code other}.</p>
+     *
+     * @param other
+     *         the node whose values should be merged into this node
+     */
+    private void mergeValues(final Node other) {
+        for (Value otherValue : other.getValues()) {
+            var metric = otherValue.getMetric();
+            var existingValue = values.stream()
+                    .filter(v -> v.getMetric() == metric)
+                    .findAny();
+            if (existingValue.isPresent()) {
+                // Both reports have a value for this metric: keep the larger (worse) one.
+                // For complexity metrics this reflects the hardest-to-maintain target framework;
+                // for other metrics (coverage fractions etc.) max is also a safe conservative choice.
+                replaceValue(existingValue.get().max(otherValue));
+            }
+            else {
+                // Only the other report has this value (e.g. platform-conditional code):
+                // carry it over so nothing is silently lost.
+                addValue(otherValue);
+            }
+        }
     }
 
     void removeValues() {

--- a/src/main/java/edu/hm/hafner/coverage/Value.java
+++ b/src/main/java/edu/hm/hafner/coverage/Value.java
@@ -267,6 +267,21 @@ public class Value implements Serializable, Comparable<Value> {
     }
 
     /**
+     * Computes the minimum of this value and the specified value.
+     * 
+     * @param other
+     *         the other coverage
+     * @return the minimum value
+     */
+    @CheckReturnValue
+    public Value min(final Value other) {
+        if (max(other).equals(this)) {
+            return other;
+        }
+        return this;
+    }
+
+    /**
      * Returns whether this value if within the specified threshold (given as double value). For metrics of type
      * {@link MetricTendency#LARGER_IS_BETTER} (like coverage percentage) this value will be checked with greater or
      * equal than the threshold. For metrics of type {@link MetricTendency#SMALLER_IS_BETTER} (like complexity) this

--- a/src/test/java/edu/hm/hafner/coverage/NodeTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/NodeTest.java
@@ -937,19 +937,10 @@ class NodeTest {
     @Test
     @Issue("https://github.com/jenkinsci/coverage-plugin/issues/638")
     void shouldTakeMaxComplexityAcrossThreeReports() {
-        var makeModule = (java.util.function.Function<Integer, ModuleNode>) complexity -> {
-            var m = new ModuleNode("Proj");
-            var p = new PackageNode("pkg");
-            var c = new ClassNode("Foo");
-            var meth = new MethodNode("run", "()V", 1);
-            meth.addValue(new Value(CYCLOMATIC_COMPLEXITY, complexity));
-            c.addChild(meth);
-            p.addChild(c);
-            m.addChild(p);
-            return m;
-        };
-
-        var merged = Node.merge(List.of(makeModule.apply(4), makeModule.apply(7), makeModule.apply(2)));
+        var merged = Node.merge(List.of(
+                createModuleWithComplexity(4),
+                createModuleWithComplexity(7),
+                createModuleWithComplexity(2)));
 
         var mergedMethod = merged.findMethod("run", "()V").orElseThrow();
         assertThat(mergedMethod.getValue(CYCLOMATIC_COMPLEXITY))
@@ -957,9 +948,21 @@ class NodeTest {
                 .hasValueSatisfying(v -> assertThat(v.asInteger()).isEqualTo(7)); // max(4,7,2)
     }
 
+    private static ModuleNode createModuleWithComplexity(final int complexity) {
+        var module = new ModuleNode("Proj");
+        var pkg = new PackageNode("pkg");
+        var cls = new ClassNode("Foo");
+        var method = new MethodNode("run", "()V", 1);
+        method.addValue(new Value(CYCLOMATIC_COMPLEXITY, complexity));
+        cls.addChild(method);
+        pkg.addChild(cls);
+        module.addChild(pkg);
+        return module;
+    }
+
     @Test
     @Issue("https://github.com/jenkinsci/coverage-plugin/issues/638")
-    void shouldNotLoseOtherValuesWhenMergingNodes() {     
+    void shouldNotLoseOtherValuesWhenMergingNodes() {
         var moduleA = new ModuleNode("Proj");
         var pkgA = new PackageNode("pkg");
         var classA = new ClassNode("Bar");

--- a/src/test/java/edu/hm/hafner/coverage/NodeTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/NodeTest.java
@@ -8,7 +8,6 @@ import org.junitpioneer.jupiter.Issue;
 import edu.hm.hafner.coverage.Coverage.CoverageBuilder;
 import edu.hm.hafner.coverage.Mutation.MutationBuilder;
 import edu.hm.hafner.util.TreeString;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -867,5 +866,188 @@ class NodeTest {
 
         fileNode.addModifiedLines(1);
         assertThat(packageNode).hasModifiedLines();
+    }
+
+    // ----------------------------------------------------------------
+    // Tests for JENKINS-75295: cyclomatic complexity is lost when reports are merged
+    // ----------------------------------------------------------------
+
+    /**
+     * Verifies the fix for JENKINS-75295: when two Cobertura reports (or any two reports) are merged,
+     * directly stored values like {@link Metric#CYCLOMATIC_COMPLEXITY} on method nodes must be
+     * preserved using the <em>maximum</em> (worse) value rather than being silently dropped.
+     *
+     * <p>The bug was in {@link Node#mergeNode(Node)}: it called {@code removeValues()} which erased
+     * all values, then only recursively merged children — never re-introducing values from {@code other}.
+     * The result was zero complexity for every method/class appearing in more than one input report.</p>
+     *
+     * <p>The fix uses {@code max} (not {@code add}) per the original reporter kon's guidance:
+     * "the entirety will be at least as difficult to maintain as the most difficult subset."</p>
+     */
+    @Test
+    @Issue("https://github.com/jenkinsci/coverage-plugin/issues/638")
+    void shouldPreserveCyclomaticComplexityWhenMergingReports() {
+        // Two Cobertura reports for different target frameworks (net472 and net8.0).
+        // The same method appears in both — complexity should be the MAX, not the sum.
+
+        var moduleA = new ModuleNode("ProjectA");
+        var pkgA = new PackageNode("com.example");
+        var classA = new ClassNode("Calculator");
+        var methodA = new MethodNode("add", "(II)I", 10);
+        methodA.addValue(new Value(CYCLOMATIC_COMPLEXITY, 3));
+        classA.addChild(methodA);
+        pkgA.addChild(classA);
+        moduleA.addChild(pkgA);
+
+        var moduleB = new ModuleNode("ProjectA");
+        var pkgB = new PackageNode("com.example");
+        var classB = new ClassNode("Calculator");
+        var methodB = new MethodNode("add", "(II)I", 10);
+        methodB.addValue(new Value(CYCLOMATIC_COMPLEXITY, 5));
+        classB.addChild(methodB);
+        pkgB.addChild(classB);
+        moduleB.addChild(pkgB);
+
+        var merged = moduleA.merge(moduleB);
+
+        // max(3, 5) = 5 — not 3+5=8, because the same method was just measured twice
+        var mergedMethod = merged.findMethod("add", "(II)I").orElseThrow(
+                () -> new AssertionError("Method 'add' not found in merged tree"));
+        assertThat(mergedMethod.getValue(CYCLOMATIC_COMPLEXITY))
+                .isPresent()
+                .hasValueSatisfying(v -> assertThat(v.asInteger()).isEqualTo(5));
+    }
+
+    @Test
+    @Issue("https://github.com/jenkinsci/coverage-plugin/issues/638")
+    void shouldPreserveCyclomaticComplexityWhenOnlyOneReportHasComplexity() {
+        // Exact scenario from JENKINS-75295: a source file guarded by #if !NET6_0_OR_GREATER
+        // only exists in report A. Report B has a different class entirely.
+        // Both complexities must appear in the merged output.
+
+        var moduleA = new ModuleNode("ProjectA");
+        var pkgA = new PackageNode("com.example");
+        var classA = new ClassNode("LegacyHelper");
+        var methodA = new MethodNode("doLegacyThing", "()V", 5);
+        methodA.addValue(new Value(CYCLOMATIC_COMPLEXITY, 7));
+        classA.addChild(methodA);
+        pkgA.addChild(classA);
+        moduleA.addChild(pkgA);
+
+        var moduleB = new ModuleNode("ProjectA");
+        var pkgB = new PackageNode("com.example");
+        var classB = new ClassNode("ModernHelper");
+        var methodB = new MethodNode("doModernThing", "()V", 10);
+        methodB.addValue(new Value(CYCLOMATIC_COMPLEXITY, 2));
+        classB.addChild(methodB);
+        pkgB.addChild(classB);
+        moduleB.addChild(pkgB);
+
+        var merged = moduleA.merge(moduleB);
+
+        // LegacyHelper only in report A — complexity must survive unchanged
+        var legacyMethod = merged.findMethod("doLegacyThing", "()V").orElseThrow(
+                () -> new AssertionError("Method 'doLegacyThing' not found in merged tree"));
+        assertThat(legacyMethod.getValue(CYCLOMATIC_COMPLEXITY))
+                .isPresent()
+                .hasValueSatisfying(v -> assertThat(v.asInteger()).isEqualTo(7));
+
+        // ModernHelper only in report B — complexity must also survive unchanged
+        var modernMethod = merged.findMethod("doModernThing", "()V").orElseThrow(
+                () -> new AssertionError("Method 'doModernThing' not found in merged tree"));
+        assertThat(modernMethod.getValue(CYCLOMATIC_COMPLEXITY))
+                .isPresent()
+                .hasValueSatisfying(v -> assertThat(v.asInteger()).isEqualTo(2));
+    }
+
+    @Test
+    @Issue("https://github.com/jenkinsci/coverage-plugin/issues/638")
+    void shouldTakeMaxComplexityAcrossThreeReports() {
+        // When Node.merge(List) chains multiple pairwise merges, max must still win.
+        // Reports have complexity 4, 7, 2 — result must be max = 7, not sum = 13.
+        var makeModule = (java.util.function.Function<Integer, ModuleNode>) complexity -> {
+            var m = new ModuleNode("Proj");
+            var p = new PackageNode("pkg");
+            var c = new ClassNode("Foo");
+            var meth = new MethodNode("run", "()V", 1);
+            meth.addValue(new Value(CYCLOMATIC_COMPLEXITY, complexity));
+            c.addChild(meth);
+            p.addChild(c);
+            m.addChild(p);
+            return m;
+        };
+
+        var merged = Node.merge(List.of(makeModule.apply(4), makeModule.apply(7), makeModule.apply(2)));
+
+        var mergedMethod = merged.findMethod("run", "()V").orElseThrow();
+        assertThat(mergedMethod.getValue(CYCLOMATIC_COMPLEXITY))
+                .isPresent()
+                .hasValueSatisfying(v -> assertThat(v.asInteger()).isEqualTo(7)); // max(4,7,2)
+    }
+
+    @Test
+    @Issue("https://github.com/jenkinsci/coverage-plugin/issues/638")
+    void shouldNotLoseOtherValuesWhenMergingNodes() {
+        // LOC values are also preserved; max applies to them too when both sides have them.
+        var moduleA = new ModuleNode("Proj");
+        var pkgA = new PackageNode("pkg");
+        var classA = new ClassNode("Bar");
+        var methodA = new MethodNode("compute", "()I", 20);
+        methodA.addValue(new Value(CYCLOMATIC_COMPLEXITY, 2));
+        methodA.addValue(new Value(LOC, 5));
+        classA.addChild(methodA);
+        pkgA.addChild(classA);
+        moduleA.addChild(pkgA);
+
+        var moduleB = new ModuleNode("Proj");
+        var pkgB = new PackageNode("pkg");
+        var classB = new ClassNode("Bar");
+        var methodB = new MethodNode("compute", "()I", 20);
+        methodB.addValue(new Value(CYCLOMATIC_COMPLEXITY, 3));
+        methodB.addValue(new Value(LOC, 8));
+        classB.addChild(methodB);
+        pkgB.addChild(classB);
+        moduleB.addChild(pkgB);
+
+        var merged = moduleA.merge(moduleB);
+
+        var mergedMethod = merged.findMethod("compute", "()I").orElseThrow();
+        assertThat(mergedMethod.getValue(CYCLOMATIC_COMPLEXITY))
+                .isPresent()
+                .hasValueSatisfying(v -> assertThat(v.asInteger()).isEqualTo(3));  // max(2,3)
+        assertThat(mergedMethod.getValue(LOC))
+                .isPresent()
+                .hasValueSatisfying(v -> assertThat(v.asInteger()).isEqualTo(8));  // max(5,8)
+    }
+
+    @Test
+    @Issue("https://github.com/jenkinsci/coverage-plugin/issues/638")
+    void shouldKeepComplexityFromFirstReportWhenSecondHasNone() {
+        // If only the first (left-hand) report has complexity for a node and the second
+        // doesn't have it at all, the value must survive the merge unchanged.
+        var moduleA = new ModuleNode("Proj");
+        var pkgA = new PackageNode("pkg");
+        var classA = new ClassNode("OnlyInA");
+        var methodA = new MethodNode("run", "()V", 1);
+        methodA.addValue(new Value(CYCLOMATIC_COMPLEXITY, 9));
+        classA.addChild(methodA);
+        pkgA.addChild(classA);
+        moduleA.addChild(pkgA);
+
+        var moduleB = new ModuleNode("Proj");
+        var pkgB = new PackageNode("pkg");
+        var classB = new ClassNode("OnlyInA");
+        var methodB = new MethodNode("run", "()V", 1);
+        // intentionally no complexity value on the second report's method
+        classB.addChild(methodB);
+        pkgB.addChild(classB);
+        moduleB.addChild(pkgB);
+
+        var merged = moduleA.merge(moduleB);
+
+        var mergedMethod = merged.findMethod("run", "()V").orElseThrow();
+        assertThat(mergedMethod.getValue(CYCLOMATIC_COMPLEXITY))
+                .isPresent()
+                .hasValueSatisfying(v -> assertThat(v.asInteger()).isEqualTo(9));
     }
 }

--- a/src/test/java/edu/hm/hafner/coverage/NodeTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/NodeTest.java
@@ -895,7 +895,42 @@ class NodeTest {
                 () -> new AssertionError("Method 'add' not found in merged tree"));
         assertThat(mergedMethod.getValue(CYCLOMATIC_COMPLEXITY))
                 .isPresent()
+                .hasValueSatisfying(v -> assertThat(v.asInteger()).isEqualTo(5)); // max(3,5)
+    }
+
+    @Test
+    @Issue("https://github.com/jenkinsci/coverage-plugin/issues/638")
+    void shouldUsePessimisticValueBasedOnMetricTendencyWhenMerging() {
+        var moduleA = new ModuleNode("Proj");
+        var pkgA = new PackageNode("pkg");
+        var classA = new ClassNode("Cls");
+        classA.addValue(new Value(CYCLOMATIC_COMPLEXITY, 3));
+        classA.addValue(new Value(WARNINGS, 2));              
+        classA.addValue(new Value(UNBOUNDED, 10));            
+        pkgA.addChild(classA);
+        moduleA.addChild(pkgA);
+
+        var moduleB = new ModuleNode("Proj");
+        var pkgB = new PackageNode("pkg");
+        var classB = new ClassNode("Cls");
+        classB.addValue(new Value(CYCLOMATIC_COMPLEXITY, 7));
+        classB.addValue(new Value(WARNINGS, 5));              
+        classB.addValue(new Value(UNBOUNDED, 4));             
+        pkgB.addChild(classB);
+        moduleB.addChild(pkgB);
+
+        var merged = moduleA.merge(moduleB);
+        var mergedClass = merged.findClass("Cls").orElseThrow();
+
+        assertThat(mergedClass.getValue(CYCLOMATIC_COMPLEXITY))
+                .isPresent()
+                .hasValueSatisfying(v -> assertThat(v.asInteger()).isEqualTo(7));
+        assertThat(mergedClass.getValue(WARNINGS))
+                .isPresent()
                 .hasValueSatisfying(v -> assertThat(v.asInteger()).isEqualTo(5));
+        assertThat(mergedClass.getValue(UNBOUNDED))
+                .isPresent()
+                .hasValueSatisfying(v -> assertThat(v.asInteger()).isEqualTo(4));
     }
 
     @Test

--- a/src/test/java/edu/hm/hafner/coverage/NodeTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/NodeTest.java
@@ -868,28 +868,10 @@ class NodeTest {
         assertThat(packageNode).hasModifiedLines();
     }
 
-    // ----------------------------------------------------------------
-    // Tests for JENKINS-75295: cyclomatic complexity is lost when reports are merged
-    // ----------------------------------------------------------------
-
-    /**
-     * Verifies the fix for JENKINS-75295: when two Cobertura reports (or any two reports) are merged,
-     * directly stored values like {@link Metric#CYCLOMATIC_COMPLEXITY} on method nodes must be
-     * preserved using the <em>maximum</em> (worse) value rather than being silently dropped.
-     *
-     * <p>The bug was in {@link Node#mergeNode(Node)}: it called {@code removeValues()} which erased
-     * all values, then only recursively merged children — never re-introducing values from {@code other}.
-     * The result was zero complexity for every method/class appearing in more than one input report.</p>
-     *
-     * <p>The fix uses {@code max} (not {@code add}) per the original reporter kon's guidance:
-     * "the entirety will be at least as difficult to maintain as the most difficult subset."</p>
-     */
     @Test
     @Issue("https://github.com/jenkinsci/coverage-plugin/issues/638")
     void shouldPreserveCyclomaticComplexityWhenMergingReports() {
-        // Two Cobertura reports for different target frameworks (net472 and net8.0).
-        // The same method appears in both — complexity should be the MAX, not the sum.
-
+    
         var moduleA = new ModuleNode("ProjectA");
         var pkgA = new PackageNode("com.example");
         var classA = new ClassNode("Calculator");
@@ -910,7 +892,6 @@ class NodeTest {
 
         var merged = moduleA.merge(moduleB);
 
-        // max(3, 5) = 5 — not 3+5=8, because the same method was just measured twice
         var mergedMethod = merged.findMethod("add", "(II)I").orElseThrow(
                 () -> new AssertionError("Method 'add' not found in merged tree"));
         assertThat(mergedMethod.getValue(CYCLOMATIC_COMPLEXITY))
@@ -921,9 +902,6 @@ class NodeTest {
     @Test
     @Issue("https://github.com/jenkinsci/coverage-plugin/issues/638")
     void shouldPreserveCyclomaticComplexityWhenOnlyOneReportHasComplexity() {
-        // Exact scenario from JENKINS-75295: a source file guarded by #if !NET6_0_OR_GREATER
-        // only exists in report A. Report B has a different class entirely.
-        // Both complexities must appear in the merged output.
 
         var moduleA = new ModuleNode("ProjectA");
         var pkgA = new PackageNode("com.example");
@@ -945,14 +923,12 @@ class NodeTest {
 
         var merged = moduleA.merge(moduleB);
 
-        // LegacyHelper only in report A — complexity must survive unchanged
         var legacyMethod = merged.findMethod("doLegacyThing", "()V").orElseThrow(
                 () -> new AssertionError("Method 'doLegacyThing' not found in merged tree"));
         assertThat(legacyMethod.getValue(CYCLOMATIC_COMPLEXITY))
                 .isPresent()
                 .hasValueSatisfying(v -> assertThat(v.asInteger()).isEqualTo(7));
 
-        // ModernHelper only in report B — complexity must also survive unchanged
         var modernMethod = merged.findMethod("doModernThing", "()V").orElseThrow(
                 () -> new AssertionError("Method 'doModernThing' not found in merged tree"));
         assertThat(modernMethod.getValue(CYCLOMATIC_COMPLEXITY))
@@ -963,8 +939,6 @@ class NodeTest {
     @Test
     @Issue("https://github.com/jenkinsci/coverage-plugin/issues/638")
     void shouldTakeMaxComplexityAcrossThreeReports() {
-        // When Node.merge(List) chains multiple pairwise merges, max must still win.
-        // Reports have complexity 4, 7, 2 — result must be max = 7, not sum = 13.
         var makeModule = (java.util.function.Function<Integer, ModuleNode>) complexity -> {
             var m = new ModuleNode("Proj");
             var p = new PackageNode("pkg");
@@ -988,7 +962,7 @@ class NodeTest {
     @Test
     @Issue("https://github.com/jenkinsci/coverage-plugin/issues/638")
     void shouldNotLoseOtherValuesWhenMergingNodes() {
-        // LOC values are also preserved; max applies to them too when both sides have them.
+        
         var moduleA = new ModuleNode("Proj");
         var pkgA = new PackageNode("pkg");
         var classA = new ClassNode("Bar");
@@ -1023,8 +997,7 @@ class NodeTest {
     @Test
     @Issue("https://github.com/jenkinsci/coverage-plugin/issues/638")
     void shouldKeepComplexityFromFirstReportWhenSecondHasNone() {
-        // If only the first (left-hand) report has complexity for a node and the second
-        // doesn't have it at all, the value must survive the merge unchanged.
+
         var moduleA = new ModuleNode("Proj");
         var pkgA = new PackageNode("pkg");
         var classA = new ClassNode("OnlyInA");
@@ -1038,7 +1011,6 @@ class NodeTest {
         var pkgB = new PackageNode("pkg");
         var classB = new ClassNode("OnlyInA");
         var methodB = new MethodNode("run", "()V", 1);
-        // intentionally no complexity value on the second report's method
         classB.addChild(methodB);
         pkgB.addChild(classB);
         moduleB.addChild(pkgB);

--- a/src/test/java/edu/hm/hafner/coverage/NodeTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/NodeTest.java
@@ -871,7 +871,6 @@ class NodeTest {
     @Test
     @Issue("https://github.com/jenkinsci/coverage-plugin/issues/638")
     void shouldPreserveCyclomaticComplexityWhenMergingReports() {
-    
         var moduleA = new ModuleNode("ProjectA");
         var pkgA = new PackageNode("com.example");
         var classA = new ClassNode("Calculator");
@@ -902,7 +901,6 @@ class NodeTest {
     @Test
     @Issue("https://github.com/jenkinsci/coverage-plugin/issues/638")
     void shouldPreserveCyclomaticComplexityWhenOnlyOneReportHasComplexity() {
-
         var moduleA = new ModuleNode("ProjectA");
         var pkgA = new PackageNode("com.example");
         var classA = new ClassNode("LegacyHelper");
@@ -961,8 +959,7 @@ class NodeTest {
 
     @Test
     @Issue("https://github.com/jenkinsci/coverage-plugin/issues/638")
-    void shouldNotLoseOtherValuesWhenMergingNodes() {
-        
+    void shouldNotLoseOtherValuesWhenMergingNodes() {     
         var moduleA = new ModuleNode("Proj");
         var pkgA = new PackageNode("pkg");
         var classA = new ClassNode("Bar");
@@ -997,7 +994,6 @@ class NodeTest {
     @Test
     @Issue("https://github.com/jenkinsci/coverage-plugin/issues/638")
     void shouldKeepComplexityFromFirstReportWhenSecondHasNone() {
-
         var moduleA = new ModuleNode("Proj");
         var pkgA = new PackageNode("pkg");
         var classA = new ClassNode("OnlyInA");


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
 Cyclomatic complexity is lost when reports are merged
 
See : https://github.com/jenkinsci/coverage-plugin/issues/638

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
