### PR TITLE
Always use a `ParsingException` when the file cannot be parsed

### DIFF
--- a/src/main/java/edu/hm/hafner/coverage/CoverageParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/CoverageParser.java
@@ -126,7 +126,7 @@ public abstract class CoverageParser implements Serializable {
      * @param isEmpty
      *         set this flag to {@code true} to indicate that the results are empty
      *
-     * @throws NoSuchElementException
+     * @throws ParsingException
      *         if the results are empty and errors should not be ignored
      */
     protected void handleEmptyResults(final String fileName, final FilteredLog log, final boolean isEmpty) {
@@ -136,7 +136,7 @@ public abstract class CoverageParser implements Serializable {
                 log.logError(emptyMessage);
             }
             else {
-                throw new NoSuchElementException(emptyMessage);
+                throw new ParsingException(emptyMessage);
             }
         }
     }

--- a/src/test/java/edu/hm/hafner/coverage/parser/AbstractParserTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/parser/AbstractParserTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import com.google.errorprone.annotations.MustBeClosed;
 
 import edu.hm.hafner.coverage.CoverageParser;
+import edu.hm.hafner.coverage.CoverageParser.ParsingException;
 import edu.hm.hafner.coverage.CoverageParser.ProcessingMode;
 import edu.hm.hafner.coverage.ModuleNode;
 import edu.hm.hafner.util.FilteredLog;
@@ -15,7 +16,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
-import java.util.NoSuchElementException;
 import java.util.Objects;
 
 import static edu.hm.hafner.coverage.assertions.Assertions.*;
@@ -74,7 +74,7 @@ abstract class AbstractParserTest {
 
     @Test
     void shouldFailWhenEmptyFilesAreNotIgnored() {
-        assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(() -> readReport("empty.xml"));
+        assertThatExceptionOfType(ParsingException.class).isThrownBy(() -> readReport("empty.xml"));
 
         var report = readReport("empty.xml", ProcessingMode.IGNORE_ERRORS);
         assertThat(report).hasNoChildren().hasNoValues();

--- a/src/test/java/edu/hm/hafner/coverage/parser/StrykerParserTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/parser/StrykerParserTest.java
@@ -1,18 +1,17 @@
 package edu.hm.hafner.coverage.parser;
 
-import java.util.NoSuchElementException;
-
 import org.junit.jupiter.api.Test;
 
 import edu.hm.hafner.coverage.Coverage;
 import edu.hm.hafner.coverage.CoverageParser;
+import edu.hm.hafner.coverage.CoverageParser.ParsingException;
 import edu.hm.hafner.coverage.CoverageParser.ProcessingMode;
 import edu.hm.hafner.coverage.FileNode;
 import edu.hm.hafner.coverage.Mutation;
 import edu.hm.hafner.coverage.MutationStatus;
 import edu.hm.hafner.coverage.Node;
 
-import static edu.hm.hafner.coverage.Metric.MUTATION;
+import static edu.hm.hafner.coverage.Metric.*;
 import static edu.hm.hafner.coverage.assertions.Assertions.*;
 
 /**
@@ -38,7 +37,7 @@ class StrykerParserTest extends AbstractParserTest {
 
     @Test
     void shouldEnterIfBlockButSkipLoopWhenFilesObjectIsEmpty() {
-        assertThatExceptionOfType(NoSuchElementException.class)
+        assertThatExceptionOfType(ParsingException.class)
                 .isThrownBy(() -> readReport("mutation-report-no-files.json"));
     }
 
@@ -53,7 +52,7 @@ class StrykerParserTest extends AbstractParserTest {
 
     @Test
     void shouldSkipIfBlockWhenFilesKeyIsMissing() {
-        assertThatExceptionOfType(NoSuchElementException.class)
+        assertThatExceptionOfType(ParsingException.class)
                 .isThrownBy(() -> readReport("mutation-report-missing-files.json"));
     }
 

--- a/src/test/java/edu/hm/hafner/coverage/parser/Trace32ParserTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/parser/Trace32ParserTest.java
@@ -1,17 +1,17 @@
 package edu.hm.hafner.coverage.parser;
 
-import java.util.NoSuchElementException;
-import java.util.stream.Collectors;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import org.junit.jupiter.api.Test;
 
 import edu.hm.hafner.coverage.Coverage;
 import edu.hm.hafner.coverage.CoverageParser;
+import edu.hm.hafner.coverage.CoverageParser.ParsingException;
 import edu.hm.hafner.coverage.CoverageParser.ProcessingMode;
 import edu.hm.hafner.coverage.Metric;
 import edu.hm.hafner.coverage.Node;
+
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * Tests for {@link Trace32Parser} - focuses on single file reports.
@@ -29,12 +29,12 @@ class Trace32ParserTest extends AbstractParserTest {
 
     @Test
     void testEmptyReport() {
-        assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(() -> readReport("empty.xml"));
+        assertThatExceptionOfType(ParsingException.class).isThrownBy(() -> readReport("empty.xml"));
     }
 
     @Test
     void testInvalidReport() {
-        assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(() -> readReport("trace32-invalid.xml"));
+        assertThatExceptionOfType(ParsingException.class).isThrownBy(() -> readReport("trace32-invalid.xml"));
     }
 
     @Test

--- a/src/test/java/edu/hm/hafner/coverage/registry/ParserRegistryTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/registry/ParserRegistryTest.java
@@ -1,10 +1,15 @@
 package edu.hm.hafner.coverage.registry;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.junit.jupiter.api.Test;
 
+import edu.hm.hafner.coverage.CoverageParser.ParsingException;
 import edu.hm.hafner.coverage.CoverageParser.ProcessingMode;
 import edu.hm.hafner.coverage.registry.ParserRegistry.CoverageParserType;
+import edu.hm.hafner.util.FilteredLog;
+
+import java.io.StringReader;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -18,6 +23,11 @@ class ParserRegistryTest {
             assertThat(parser).isNotNull();
             assertThat(parser.getClass().toString()).containsIgnoringCase(
                     Strings.CS.remove(parserType.name(), "_"));
+
+            var log = new FilteredLog();
+
+            assertThatExceptionOfType(ParsingException.class).isThrownBy(() ->
+                    parser.parse(new StringReader(StringUtils.EMPTY), "empty.file", log));
         }
     }
 


### PR DESCRIPTION
It makes sense to use a specific exception that indicates that something went wrong.