### PR TITLE
Handle large hit counts in `LcovParser`

### DIFF
--- a/src/main/java/edu/hm/hafner/coverage/parser/LcovParser.java
+++ b/src/main/java/edu/hm/hafner/coverage/parser/LcovParser.java
@@ -75,9 +75,9 @@ public class LcovParser extends CoverageParser {
                 else if (line.startsWith("DA:")) {
                     var parts = line.substring(3).split(",", 3);
                     var ln = Integer.parseInt(parts[0]);
-                    var exec = parts.length > 1 ? Integer.parseInt(parts[1]) : 0;
+                    var isCovered = parts.length > 1 && Long.parseLong(parts[1]) > 0;
                     var pair = files.getOrDefault(currentFile, new TreeMap<>()).getOrDefault(ln, MutablePair.of(0, 0));
-                    pair.setLeft(exec > 0 ? 1 : 0);
+                    pair.setLeft(isCovered ? 1 : 0);
                     files.get(currentFile).put(ln, pair);
                 }
                 // Branch coverage (BRDA:<line>,<block>,<branch>,<taken>)
@@ -86,7 +86,7 @@ public class LcovParser extends CoverageParser {
                     var ln = Integer.parseInt(parts[0]);
                     var taken = parts.length > 3 ? parts[3] : "-";
                     var pair = files.getOrDefault(currentFile, new TreeMap<>()).getOrDefault(ln, MutablePair.of(0, 0));
-                    if (!"-".equals(taken) && !"0".equals(taken)) {
+                    if (!"-".equals(taken) && Long.parseLong(taken) > 0) {
                         pair.setRight(pair.getRight() + 1);
                     }
                     files.get(currentFile).put(ln, pair);

--- a/src/test/java/edu/hm/hafner/coverage/parser/LcovParserTest.java
+++ b/src/test/java/edu/hm/hafner/coverage/parser/LcovParserTest.java
@@ -72,4 +72,18 @@ class LcovParserTest extends AbstractParserTest {
         assertThat(report.getAllFileNodes()).map(FileNode::getFileName).containsExactlyInAnyOrder(
                 "main.ts", "helper.ts", "module.c");
     }
+
+    @Test
+    void shouldParseLargeHitCounts() {
+        var report = readReport("large-hit-counts.lcov", ProcessingMode.IGNORE_ERRORS);
+
+        var builder = new Coverage.CoverageBuilder();
+
+        assertThat(report.aggregateValues()).contains(
+                builder.withMetric(FILE).withCovered(1).withTotal(1).build(),
+                builder.withMetric(LINE).withCovered(1).withTotal(2).build(),
+                builder.withMetric(INSTRUCTION).withCovered(1).withTotal(2).build(),
+                new Value(LOC, 2)
+        );
+    }
 }

--- a/src/test/resources/edu/hm/hafner/coverage/parser/lcov/large-hit-counts.lcov
+++ b/src/test/resources/edu/hm/hafner/coverage/parser/lcov/large-hit-counts.lcov
@@ -1,0 +1,8 @@
+TN:large-hit-counts
+SF:/tmp/large-hit-counts.c
+DA:1,2874063630
+DA:2,0
+BRDA:1,0,0,2874063630
+BRDA:2,0,0,0
+end_of_record
+EOF


### PR DESCRIPTION
Lcov coverage reports may contain counters greater than `MAX_INT`, so all calculations should be long based.

Will fix #313.

<!-- Fix for issue 313
[issue 313](https://github.com/jenkinsci/coverage-model/issues/313)
Change to support LongParse from IntParse in specific Lcov parser cases where the failure was observed
and logged in issue 313.
 -->


